### PR TITLE
feat(augment): Phase 2 acoustic augmentation modules (PR A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           uv pip install \
             pydantic pyyaml jinja2 soundfile numpy scipy \
             click rich jsonlines \
+            pyroomacoustics \
             pytest pytest-asyncio pytest-cov
 
       - name: Install package

--- a/synthbanshee/augment/__init__.py
+++ b/synthbanshee/augment/__init__.py
@@ -1,5 +1,18 @@
 """Audio augmentation pipeline: room simulation, device profiles, noise mixing, preprocessing."""
 
+from synthbanshee.augment.device_profiles import DeviceProfiler
+from synthbanshee.augment.noise_mixer import NoiseMixer
 from synthbanshee.augment.preprocessing import PreprocessingResult, preprocess, validate_audio
+from synthbanshee.augment.room_sim import RoomSimulator
+from synthbanshee.augment.types import AugmentationResult, AugmentedEvent
 
-__all__ = ["PreprocessingResult", "preprocess", "validate_audio"]
+__all__ = [
+    "AugmentationResult",
+    "AugmentedEvent",
+    "DeviceProfiler",
+    "NoiseMixer",
+    "PreprocessingResult",
+    "RoomSimulator",
+    "preprocess",
+    "validate_audio",
+]

--- a/synthbanshee/augment/device_profiles.py
+++ b/synthbanshee/augment/device_profiles.py
@@ -1,0 +1,109 @@
+"""Device-specific audio coloration profiles for AVDP Tier B clips.
+
+Each profile models the frequency response and level characteristics of the
+device used to capture a scene.  Profiles are applied as a chain of
+scipy Butterworth filters plus optional hum injection and level adjustment.
+
+Spec reference: docs/spec.md §3.1 (device placement, Stage 3 augmentation)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import butter, sosfilt
+
+_FILTER_ORDER = 4
+
+# Per-device parameters:
+#   highpass_hz  — roll-off below this frequency (models mic sensitivity floor)
+#   lowpass_hz   — roll-off above this frequency (models bandwidth limit / muffling)
+#   hum_hz       — mains hum frequency to inject; None = no hum
+#   hum_dbfs     — amplitude of injected hum in dBFS (ignored when hum_hz is None)
+#   level_db     — broadband gain applied after filtering (models pickup / insertion loss)
+_PROFILES: dict[str, dict] = {
+    "phone_in_hand": {
+        "highpass_hz": 200,
+        "lowpass_hz": 8_000,
+        "hum_hz": None,
+        "hum_dbfs": None,
+        "level_db": 0.0,
+    },
+    "phone_in_pocket": {
+        # Cloth occlusion: strong high-frequency muffling + insertion loss
+        "highpass_hz": 300,
+        "lowpass_hz": 2_500,
+        "hum_hz": None,
+        "hum_dbfs": None,
+        "level_db": -6.0,
+    },
+    "phone_on_table": {
+        # Surface coupling: slight low-end coupling loss, mild high-frequency rolloff
+        "highpass_hz": 100,
+        "lowpass_hz": 7_000,
+        "hum_hz": None,
+        "hum_dbfs": None,
+        "level_db": -3.0,
+    },
+    "pi_budget_mic": {
+        # Budget electret mic: limited bandwidth, 50 Hz mains hum (EU/IL grid)
+        "highpass_hz": 80,
+        "lowpass_hz": 7_000,
+        "hum_hz": 50.0,
+        "hum_dbfs": -50.0,
+        "level_db": 0.0,
+    },
+}
+
+
+class DeviceProfiler:
+    """Apply device-specific frequency coloring to a float32 mono signal."""
+
+    def apply(
+        self,
+        samples: np.ndarray,
+        sr: int,
+        device: str,
+        rng_seed: int = 0,
+    ) -> np.ndarray:
+        """Return a colored float32 mono array of the same length as input.
+
+        Args:
+            samples: Float32 mono audio at ``sr`` Hz.
+            sr: Sample rate in Hz.
+            device: One of the known device profile keys (e.g. "phone_in_pocket").
+            rng_seed: Reserved for future per-device randomisation (unused).
+
+        Returns:
+            Float32 mono array — filtered, hum-injected, and level-adjusted.
+
+        Raises:
+            KeyError: if ``device`` is not a recognised profile.
+        """
+        profile = _PROFILES[device]
+        out = samples.astype(np.float32).copy()
+        nyq = sr / 2.0
+
+        # High-pass filter
+        hp_hz = profile["highpass_hz"]
+        if hp_hz > 0:
+            sos = butter(_FILTER_ORDER, hp_hz / nyq, btype="high", output="sos")
+            out = sosfilt(sos, out).astype(np.float32)
+
+        # Low-pass filter
+        lp_hz = profile["lowpass_hz"]
+        if lp_hz < nyq:
+            sos = butter(_FILTER_ORDER, lp_hz / nyq, btype="low", output="sos")
+            out = sosfilt(sos, out).astype(np.float32)
+
+        # Mains hum injection (pi_budget_mic)
+        if profile["hum_hz"] is not None:
+            hum_amp = float(10.0 ** (profile["hum_dbfs"] / 20.0))
+            t = np.arange(len(out), dtype=np.float64) / sr
+            out = (out + hum_amp * np.sin(2.0 * np.pi * profile["hum_hz"] * t)).astype(np.float32)
+
+        # Broadband level adjustment
+        level_db = profile["level_db"]
+        if level_db != 0.0:
+            out = (out * float(10.0 ** (level_db / 20.0))).astype(np.float32)
+
+        return out

--- a/synthbanshee/augment/noise_mixer.py
+++ b/synthbanshee/augment/noise_mixer.py
@@ -374,17 +374,18 @@ class NoiseMixer:
 
     def _has_asset(self, ev: BackgroundEvent) -> bool:
         """Return True if a loadable asset exists for this event."""
-        if ev.asset_path is not None:
-            return Path(ev.asset_path).exists()
+        if ev.asset_path is not None and Path(ev.asset_path).exists():
+            return True
         search_dir = self._sfx_dir if ev.type in _ACOU_TYPES else self._ambient_dir
         return search_dir.exists() and any(search_dir.glob(f"{ev.type}*.wav"))
 
     def _resolve_asset_path(self, ev: BackgroundEvent) -> Path:
         """Return the first matching asset path for an event."""
-        if ev.asset_path is not None:
+        if ev.asset_path is not None and Path(ev.asset_path).exists():
             return Path(ev.asset_path)
         search_dir = self._sfx_dir if ev.type in _ACOU_TYPES else self._ambient_dir
-        return next(search_dir.glob(f"{ev.type}*.wav"))
+        candidates = sorted(search_dir.glob(f"{ev.type}*.wav"))
+        return next(iter(candidates))
 
     def _load_or_synthesise_sfx(
         self, ev: BackgroundEvent, sr: int, rng: np.random.Generator

--- a/synthbanshee/augment/noise_mixer.py
+++ b/synthbanshee/augment/noise_mixer.py
@@ -1,0 +1,404 @@
+"""Background noise and SFX event mixer for AVDP Tier B clips.
+
+Responsibilities
+----------------
+* Load or synthesise audio for each BackgroundEvent in AcousticSceneConfig.
+* Scale all looping ambient tracks to collectively achieve config.snr_target_db
+  relative to the speech signal.
+* Insert foreground SFX events (ACOU_* taxonomy codes) at their script-specified
+  onsets and log their actual onset/offset times for label generation.
+* Return the augmented signal, a structured event log, and the measured SNR.
+
+Asset loading order (per event)
+--------------------------------
+1. BackgroundEvent.asset_path — explicit path if given and file exists.
+2. assets_dir/sfx/<type>*.wav — for ACOU_* types.
+3. assets_dir/ambient/<type>*.wav — for ambient types.
+4. Synthetic fallback — always available; logs a quality note.
+
+Spec reference: docs/spec.md §3.1 (Stage 3 acoustic augmentation)
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+from scipy.signal import butter, resample_poly, sosfilt
+
+from synthbanshee.augment.types import AugmentedEvent
+from synthbanshee.config.acoustic_config import AcousticSceneConfig, BackgroundEvent
+
+_TARGET_SR = 16_000
+
+# Taxonomy codes that represent foreground sound events (not part of SNR floor).
+_ACOU_TYPES = frozenset(
+    [
+        "ACOU_BREAK",
+        "ACOU_SLAM",
+        "ACOU_THROW",
+        "ACOU_FOOT",
+        "ACOU_FALL",
+    ]
+)
+
+# Default fractional positions for phase-relative onset resolution when
+# no phase_boundaries map is provided.
+_PHASE_FRACTIONS: dict[str, float] = {
+    "baseline": 0.05,
+    "tension": 0.25,
+    "escalation": 0.45,
+    "peak": 0.65,
+    "aftermath": 0.80,
+    "de-escalation": 0.90,
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal audio helpers
+# ---------------------------------------------------------------------------
+
+
+def _rms(samples: np.ndarray) -> float:
+    """Return RMS of float32 array."""
+    return float(np.sqrt(np.mean(samples.astype(np.float64) ** 2)))
+
+
+def _to_dbfs(samples: np.ndarray) -> float:
+    """Return peak dBFS (−inf if silent)."""
+    peak = float(np.max(np.abs(samples)))
+    if peak == 0.0:
+        return -math.inf
+    return 20.0 * math.log10(peak)
+
+
+def _speech_rms(samples: np.ndarray, frame_ms: int = 20, sr: int = _TARGET_SR) -> float:
+    """Estimate RMS over the loudest 50% of frames (excludes silence padding)."""
+    frame_n = int(sr * frame_ms / 1000)
+    if frame_n == 0 or len(samples) < frame_n:
+        return _rms(samples)
+    n_frames = len(samples) // frame_n
+    frames = samples[: n_frames * frame_n].reshape(n_frames, frame_n)
+    frame_rms = np.sqrt(np.mean(frames.astype(np.float64) ** 2, axis=1))
+    threshold = np.median(frame_rms)
+    active = frame_rms[frame_rms >= threshold]
+    return (
+        float(np.sqrt(np.mean(active**2)))
+        if len(active) > 0
+        else float(np.sqrt(np.mean(frame_rms**2)))
+    )
+
+
+def _snr_db(speech: np.ndarray, noise: np.ndarray) -> float:
+    """Return SNR in dB (signal = speech, noise = added background)."""
+    s_rms = _speech_rms(speech)
+    n_rms = _rms(noise)
+    if s_rms == 0.0:
+        return -math.inf
+    if n_rms == 0.0:
+        return math.inf
+    return 20.0 * math.log10(s_rms / n_rms)
+
+
+def _pad_or_trim(audio: np.ndarray, target_n: int) -> np.ndarray:
+    """Return float32 array of exactly target_n samples (tiled or truncated)."""
+    if len(audio) == 0:
+        return np.zeros(target_n, dtype=np.float32)
+    if len(audio) >= target_n:
+        return audio[:target_n].astype(np.float32)
+    # Tile to fill
+    reps = math.ceil(target_n / len(audio))
+    return np.tile(audio, reps)[:target_n].astype(np.float32)
+
+
+def _load_audio(path: Path, sr: int = _TARGET_SR) -> np.ndarray:
+    """Load a WAV file as float32 mono at *sr* Hz."""
+    data, src_sr = sf.read(str(path), dtype="float32", always_2d=True)
+    mono = data.mean(axis=1) if data.shape[1] > 1 else data[:, 0]
+    if src_sr != sr:
+        from math import gcd
+
+        g = gcd(sr, src_sr)
+        mono = resample_poly(mono, sr // g, src_sr // g).astype(np.float32)
+    return mono.astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic audio generators (fallbacks when no asset files are present)
+# ---------------------------------------------------------------------------
+
+
+def _pink_noise(n: int, rng: np.random.Generator) -> np.ndarray:
+    """Generate pink (1/f) noise via FFT shaping."""
+    white = rng.standard_normal(n).astype(np.float64)
+    fft = np.fft.rfft(white)
+    freqs = np.fft.rfftfreq(n)
+    freqs[0] = 1.0  # avoid divide-by-zero at DC
+    fft /= np.sqrt(freqs)
+    pink = np.fft.irfft(fft, n=n).astype(np.float32)
+    return pink
+
+
+def _synthesise_ambient(
+    event_type: str,
+    duration_s: float,
+    sr: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Generate synthetic ambient audio for common looping event types."""
+    n = int(duration_s * sr)
+    if n == 0:
+        return np.zeros(0, dtype=np.float32)
+
+    if event_type == "hvac_hum":
+        # Narrowband noise centred on 120 Hz (2nd harmonic of 60 Hz) + 100 Hz
+        t = np.arange(n, dtype=np.float64) / sr
+        hum = (
+            0.5 * np.sin(2 * np.pi * 100 * t)
+            + 0.3 * np.sin(2 * np.pi * 120 * t)
+            + 0.2 * np.sin(2 * np.pi * 200 * t)
+        )
+        hum += 0.05 * rng.standard_normal(n)
+        return hum.astype(np.float32)
+
+    if event_type == "distant_phone_ring":
+        # NANP dual-tone ring: 480 Hz + 620 Hz, 2 s on / 4 s off pattern
+        t = np.arange(n, dtype=np.float64) / sr
+        tone = np.sin(2 * np.pi * 480 * t) + np.sin(2 * np.pi * 620 * t)
+        cycle = int(6 * sr)  # 6-second ring cycle
+        pattern = np.zeros(n, dtype=np.float32)
+        for start in range(0, n, cycle):
+            end = min(start + int(2 * sr), n)
+            pattern[start:end] = tone[start:end]
+        return (0.3 * pattern).astype(np.float32)
+
+    # Default (tv_ambient and unknown types): bandpassed pink noise
+    pink = _pink_noise(n, rng)
+    nyq = sr / 2.0
+    sos = butter(4, [300 / nyq, 4000 / nyq], btype="band", output="sos")
+    filtered = sosfilt(sos, pink).astype(np.float32)
+    return filtered
+
+
+def _synthesise_sfx(event_type: str, sr: int, rng: np.random.Generator) -> np.ndarray:
+    """Generate a synthetic placeholder SFX burst.
+
+    For ACOU_FOOT, returns a sequence of short clicks.
+    For all other ACOU_* types, returns white noise with an exponential decay.
+    """
+    if event_type == "ACOU_FOOT":
+        # 3-5 footstep clicks, each ~30 ms
+        n_steps = int(rng.integers(3, 6))
+        step_n = int(0.03 * sr)
+        gap_n = int(rng.uniform(0.08, 0.15) * sr)
+        total_n = n_steps * (step_n + gap_n)
+        out = np.zeros(total_n, dtype=np.float32)
+        for i in range(n_steps):
+            start = i * (step_n + gap_n)
+            noise = rng.standard_normal(step_n).astype(np.float32)
+            env = np.exp(-np.linspace(0, 8, step_n)).astype(np.float32)
+            out[start : start + step_n] = noise * env
+        return out
+
+    # Default burst: white noise with exponential decay
+    durations = {
+        "ACOU_BREAK": (0.4, 0.8),
+        "ACOU_SLAM": (0.15, 0.35),
+        "ACOU_THROW": (0.2, 0.5),
+        "ACOU_FALL": (0.5, 1.2),
+    }
+    dur_min, dur_max = durations.get(event_type, (0.3, 0.6))
+    dur_s = float(rng.uniform(dur_min, dur_max))
+    n = int(dur_s * sr)
+    noise = rng.standard_normal(n).astype(np.float32)
+    decay_rate = float(rng.uniform(5.0, 12.0))
+    env = np.exp(-decay_rate * np.linspace(0, 1, n)).astype(np.float32)
+    # Sharp transient onset
+    onset_n = min(int(0.005 * sr), n)
+    burst = noise * env
+    burst[:onset_n] *= np.linspace(0, 1, onset_n)
+    return burst
+
+
+# ---------------------------------------------------------------------------
+# Onset resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_onset_s(
+    ev: BackgroundEvent,
+    duration_s: float,
+    phase_boundaries: dict[str, float] | None,
+    rng: np.random.Generator,
+) -> float:
+    """Return the resolved onset in seconds for a non-looping BackgroundEvent."""
+    if ev.onset_seconds is not None:
+        base = float(ev.onset_seconds)
+    elif ev.onset_at_phase is not None:
+        if phase_boundaries is not None and ev.onset_at_phase in phase_boundaries:
+            base = float(phase_boundaries[ev.onset_at_phase])
+        else:
+            frac = _PHASE_FRACTIONS.get(ev.onset_at_phase, 0.5)
+            base = frac * duration_s
+    else:
+        base = 0.0
+
+    offset = float(ev.onset_offset_seconds) if ev.onset_offset_seconds is not None else 0.0
+    return max(0.0, min(base + offset, duration_s - 0.1))
+
+
+# ---------------------------------------------------------------------------
+# NoiseMixer
+# ---------------------------------------------------------------------------
+
+
+class NoiseMixer:
+    """Mix looping ambient audio and SFX events into a speech signal.
+
+    Parameters
+    ----------
+    assets_dir:
+        Root of the assets tree.  The mixer looks for SFX in
+        ``assets_dir/sfx/`` and ambient loops in ``assets_dir/ambient/``.
+    """
+
+    def __init__(self, assets_dir: Path = Path("assets")) -> None:
+        self._sfx_dir = assets_dir / "sfx"
+        self._ambient_dir = assets_dir / "ambient"
+
+    def mix(
+        self,
+        samples: np.ndarray,
+        sr: int,
+        config: AcousticSceneConfig,
+        rng_seed: int = 0,
+        phase_boundaries: dict[str, float] | None = None,
+    ) -> tuple[np.ndarray, list[AugmentedEvent], float]:
+        """Mix background events from config into speech samples.
+
+        Args:
+            samples: Float32 mono speech signal.
+            sr: Sample rate in Hz (should be 16 000).
+            config: AcousticSceneConfig with background_events and snr_target_db.
+            rng_seed: Reproducibility seed.
+            phase_boundaries: Optional mapping of phase name → onset_s used to
+                resolve BackgroundEvent.onset_at_phase fields.  When absent,
+                default fractional positions (_PHASE_FRACTIONS) are used.
+
+        Returns:
+            Tuple of:
+            * augmented float32 mono samples (same length as input)
+            * list of AugmentedEvent records (raw clip-relative times,
+              before silence-pad offset)
+            * snr_db_actual — measured SNR between speech and added noise
+        """
+        rng = np.random.default_rng(rng_seed)
+        duration_s = len(samples) / sr
+        mixed = samples.astype(np.float32).copy()
+        events: list[AugmentedEvent] = []
+
+        ambient_events = [e for e in config.background_events if e.loop]
+        sfx_events = [e for e in config.background_events if not e.loop]
+
+        # --- Looping ambient tracks → scale to snr_target_db ---
+        ambient_sum: np.ndarray | None = None
+        if ambient_events:
+            parts = [
+                _synthesise_ambient(ev.type, duration_s, sr, rng)
+                if not self._has_asset(ev)
+                else _load_audio(self._resolve_asset_path(ev), sr)
+                for ev in ambient_events
+            ]
+            # Mix all ambient tracks at equal weight before SNR scaling
+            combined = np.zeros(len(mixed), dtype=np.float32)
+            for part in parts:
+                combined += _pad_or_trim(part, len(mixed))
+            ambient_sum = combined
+
+            speech_rms = _speech_rms(samples, sr=sr)
+            ambient_rms = _rms(ambient_sum)
+            if speech_rms > 0.0 and ambient_rms > 0.0:
+                target_noise_rms = speech_rms / (10.0 ** (config.snr_target_db / 20.0))
+                gain = target_noise_rms / ambient_rms
+                ambient_sum = (ambient_sum * gain).astype(np.float32)
+
+            mixed = (mixed + ambient_sum).astype(np.float32)
+            actual_level = _to_dbfs(ambient_sum)
+            for ev in ambient_events:
+                events.append(
+                    AugmentedEvent(
+                        type=ev.type,
+                        onset_s=0.0,
+                        offset_s=duration_s,
+                        level_db=actual_level,
+                    )
+                )
+
+        # --- Non-looping SFX events ---
+        for ev in sfx_events:
+            onset_s = _resolve_onset_s(ev, duration_s, phase_boundaries, rng)
+            sfx_audio = self._load_or_synthesise_sfx(ev, sr, rng)
+            onset_n = int(onset_s * sr)
+            copy_n = min(len(sfx_audio), len(mixed) - onset_n)
+            if copy_n <= 0 or onset_n >= len(mixed):
+                continue
+
+            chunk = sfx_audio[:copy_n].astype(np.float32)
+            if ev.level_db is not None:
+                target_amp = float(10.0 ** (ev.level_db / 20.0))
+                peak = float(np.max(np.abs(chunk))) + 1e-9
+                chunk = (chunk * (target_amp / peak)).astype(np.float32)
+
+            mixed[onset_n : onset_n + copy_n] += chunk
+            offset_s = onset_s + copy_n / sr
+            events.append(
+                AugmentedEvent(
+                    type=ev.type,
+                    onset_s=onset_s,
+                    offset_s=offset_s,
+                    level_db=ev.level_db if ev.level_db is not None else _to_dbfs(chunk),
+                )
+            )
+
+        # --- Measure actual SNR ---
+        added_noise = mixed - samples.astype(np.float32)
+        snr_actual = _snr_db(samples.astype(np.float32), added_noise)
+
+        return mixed, events, snr_actual
+
+    # ------------------------------------------------------------------
+    # Asset resolution helpers
+    # ------------------------------------------------------------------
+
+    def _has_asset(self, ev: BackgroundEvent) -> bool:
+        """Return True if a loadable asset exists for this event."""
+        if ev.asset_path is not None:
+            return Path(ev.asset_path).exists()
+        search_dir = self._sfx_dir if ev.type in _ACOU_TYPES else self._ambient_dir
+        return search_dir.exists() and any(search_dir.glob(f"{ev.type}*.wav"))
+
+    def _resolve_asset_path(self, ev: BackgroundEvent) -> Path:
+        """Return the first matching asset path for an event."""
+        if ev.asset_path is not None:
+            return Path(ev.asset_path)
+        search_dir = self._sfx_dir if ev.type in _ACOU_TYPES else self._ambient_dir
+        return next(search_dir.glob(f"{ev.type}*.wav"))
+
+    def _load_or_synthesise_sfx(
+        self, ev: BackgroundEvent, sr: int, rng: np.random.Generator
+    ) -> np.ndarray:
+        """Return float32 mono audio for a non-looping SFX event."""
+        if ev.asset_path is not None:
+            p = Path(ev.asset_path)
+            if p.exists():
+                return _load_audio(p, sr)
+
+        if self._sfx_dir.exists():
+            candidates = sorted(self._sfx_dir.glob(f"{ev.type}*.wav"))
+            if candidates:
+                idx = int(rng.integers(len(candidates)))
+                return _load_audio(candidates[idx], sr)
+
+        return _synthesise_sfx(ev.type, sr, rng)

--- a/synthbanshee/augment/noise_mixer.py
+++ b/synthbanshee/augment/noise_mixer.py
@@ -14,7 +14,7 @@ Asset loading order (per event)
 1. BackgroundEvent.asset_path — explicit path if given and file exists.
 2. assets_dir/sfx/<type>*.wav — for ACOU_* types.
 3. assets_dir/ambient/<type>*.wav — for ambient types.
-4. Synthetic fallback — always available; logs a quality note.
+4. Synthetic fallback — always available.
 
 Spec reference: docs/spec.md §3.1 (Stage 3 acoustic augmentation)
 """

--- a/synthbanshee/augment/room_sim.py
+++ b/synthbanshee/augment/room_sim.py
@@ -111,21 +111,23 @@ class RoomSimulator:
             air_absorption=True,
         )
 
-        # Microphone at room centre, ear height (1.2 m)
-        mic = np.array([dims[0] / 2.0, dims[1] / 2.0, 1.2])
+        # Microphone at room centre, ear height (1.2 m), clamped to room z
+        mic_z = float(np.clip(1.2, 0.1, dims[2] - 0.1))
+        mic = np.array([dims[0] / 2.0, dims[1] / 2.0, mic_z])
 
         # Source at speaker_distance_meters from mic (random azimuth, mouth height)
-        # Clamp so source stays inside the room (10 cm margin from walls)
+        # Clamp so source stays inside the room (10 cm margin from all walls)
         max_dist = min(
             config.speaker_distance_meters,
             min(dims[0], dims[1]) * 0.85,
         )
         angle = float(rng.uniform(0.0, 2.0 * np.pi))
+        src_z = float(np.clip(1.6, 0.1, dims[2] - 0.1))
         src = np.array(
             [
                 float(np.clip(mic[0] + max_dist * np.cos(angle), 0.1, dims[0] - 0.1)),
                 float(np.clip(mic[1] + max_dist * np.sin(angle), 0.1, dims[1] - 0.1)),
-                1.6,  # mouth height
+                src_z,
             ]
         )
 

--- a/synthbanshee/augment/room_sim.py
+++ b/synthbanshee/augment/room_sim.py
@@ -14,7 +14,6 @@ import numpy as np
 
 from synthbanshee.config.acoustic_config import AcousticSceneConfig
 
-_TARGET_SR = 16_000
 _ISM_ORDER_MAX = 12  # cap to keep simulation tractable
 
 # Preset fallback bounds: (dims_min, dims_max, rt60_range)

--- a/synthbanshee/augment/room_sim.py
+++ b/synthbanshee/augment/room_sim.py
@@ -1,0 +1,143 @@
+"""Room impulse response simulation using pyroomacoustics (ShoeBox / ISM).
+
+For each clip, a random room geometry is drawn within the bounds specified in
+AcousticSceneConfig.  If no bounds are given, per-room-type preset defaults are
+used.  The speech signal is convolved with the resulting RIR and the output is
+truncated to the original clip length.
+
+Spec reference: docs/spec.md §3.1 (Stage 3 acoustic augmentation)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from synthbanshee.config.acoustic_config import AcousticSceneConfig
+
+_TARGET_SR = 16_000
+_ISM_ORDER_MAX = 12  # cap to keep simulation tractable
+
+# Preset fallback bounds: (dims_min, dims_max, rt60_range)
+# dims = [width_m, length_m, height_m]
+_ROOM_PRESETS: dict[str, tuple[list[float], list[float], tuple[float, float]]] = {
+    "small_bedroom": (
+        [2.5, 2.5, 2.3],
+        [3.5, 3.5, 2.7],
+        (0.20, 0.40),
+    ),
+    "apartment_kitchen": (
+        [2.5, 2.0, 2.3],
+        [4.0, 3.5, 2.7],
+        (0.15, 0.35),
+    ),
+    "living_room": (
+        [4.0, 3.5, 2.4],
+        [6.5, 5.5, 3.0],
+        (0.30, 0.60),
+    ),
+    "clinic_office": (
+        [3.0, 2.5, 2.4],
+        [5.0, 4.0, 3.0],
+        (0.20, 0.40),
+    ),
+    "welfare_office": (
+        [3.5, 3.0, 2.4],
+        [6.0, 5.0, 3.0],
+        (0.25, 0.50),
+    ),
+    "open_office_corridor": (
+        [6.0, 2.5, 2.4],
+        [12.0, 4.0, 3.5],
+        (0.30, 0.70),
+    ),
+}
+
+
+class RoomSimulator:
+    """Apply room acoustics to a mono float32 signal via pyroomacoustics ShoeBox."""
+
+    def apply(
+        self,
+        samples: np.ndarray,
+        sr: int,
+        config: AcousticSceneConfig,
+        rng_seed: int = 0,
+    ) -> np.ndarray:
+        """Convolve speech with a room impulse response derived from config.
+
+        Args:
+            samples: Float32 mono audio at ``sr`` Hz.
+            sr: Sample rate in Hz (should be 16 000).
+            config: AcousticSceneConfig controlling room geometry, RT60, and
+                    source distance.  Unknown room_type raises KeyError.
+            rng_seed: Seed for reproducible room geometry / placement sampling.
+
+        Returns:
+            Float32 mono array of the same length as ``samples``.
+
+        Raises:
+            ImportError: if pyroomacoustics is not installed.
+            KeyError: if config.room_type is not in _ROOM_PRESETS.
+        """
+        import pyroomacoustics as pra  # Phase 2 dependency — deferred import
+
+        rng = np.random.default_rng(rng_seed)
+        dims_min, dims_max, preset_rt60 = _ROOM_PRESETS[config.room_type]
+
+        # Resolve room dimensions
+        if config.room_dimensions_range is not None:
+            lo = config.room_dimensions_range.min
+            hi = config.room_dimensions_range.max
+        else:
+            lo, hi = dims_min, dims_max
+        dims = [float(rng.uniform(lo[i], hi[i])) for i in range(3)]
+
+        # Resolve RT60
+        if config.rt60_range is not None:
+            rt60_lo, rt60_hi = config.rt60_range
+        else:
+            rt60_lo, rt60_hi = preset_rt60
+        rt60 = float(rng.uniform(rt60_lo, rt60_hi))
+
+        # Absorption coefficient from Sabine's formula via pyroomacoustics helper
+        e_absorption, order = pra.inverse_sabine(rt60, dims)
+        order = min(int(order), _ISM_ORDER_MAX)
+
+        room = pra.ShoeBox(
+            dims,
+            fs=sr,
+            materials=pra.Material(e_absorption),
+            max_order=order,
+            ray_tracing=False,
+            air_absorption=True,
+        )
+
+        # Microphone at room centre, ear height (1.2 m)
+        mic = np.array([dims[0] / 2.0, dims[1] / 2.0, 1.2])
+
+        # Source at speaker_distance_meters from mic (random azimuth, mouth height)
+        # Clamp so source stays inside the room (10 cm margin from walls)
+        max_dist = min(
+            config.speaker_distance_meters,
+            min(dims[0], dims[1]) * 0.85,
+        )
+        angle = float(rng.uniform(0.0, 2.0 * np.pi))
+        src = np.array(
+            [
+                float(np.clip(mic[0] + max_dist * np.cos(angle), 0.1, dims[0] - 0.1)),
+                float(np.clip(mic[1] + max_dist * np.sin(angle), 0.1, dims[1] - 0.1)),
+                1.6,  # mouth height
+            ]
+        )
+
+        room.add_source(src.tolist(), signal=samples.astype(np.float32))
+        room.add_microphone(mic.reshape(3, 1))
+        room.simulate()
+
+        reverbed = room.mic_array.signals[0].astype(np.float32)
+
+        # Truncate or zero-pad to match input length
+        n = len(samples)
+        if len(reverbed) >= n:
+            return reverbed[:n]
+        return np.pad(reverbed, (0, n - len(reverbed))).astype(np.float32)

--- a/synthbanshee/augment/types.py
+++ b/synthbanshee/augment/types.py
@@ -11,10 +11,11 @@ import numpy as np
 class AugmentedEvent:
     """Record of one background or SFX event applied during augmentation.
 
-    onset_s and offset_s are times in the *final preprocessed* clip
-    (i.e. already offset by PreprocessingResult.silence_pad_applied_s).
-    The NoiseMixer returns raw times relative to the un-padded MixedScene;
-    cli.py is responsible for adding the padding offset before writing labels.
+    onset_s and offset_s are raw times relative to the un-padded MixedScene.
+    They do not include any preprocessing silence padding offset such as
+    PreprocessingResult.silence_pad_applied_s.  Downstream code (for example,
+    cli.py when writing labels) is responsible for adding that padding offset
+    if final preprocessed-clip coordinates are required.
     """
 
     type: str  # taxonomy ACOU_* code or ambient label (e.g. "tv_ambient")

--- a/synthbanshee/augment/types.py
+++ b/synthbanshee/augment/types.py
@@ -1,0 +1,61 @@
+"""Shared types for the acoustic augmentation pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+@dataclass
+class AugmentedEvent:
+    """Record of one background or SFX event applied during augmentation.
+
+    onset_s and offset_s are times in the *final preprocessed* clip
+    (i.e. already offset by PreprocessingResult.silence_pad_applied_s).
+    The NoiseMixer returns raw times relative to the un-padded MixedScene;
+    cli.py is responsible for adding the padding offset before writing labels.
+    """
+
+    type: str  # taxonomy ACOU_* code or ambient label (e.g. "tv_ambient")
+    onset_s: float  # seconds from start of clip
+    offset_s: float  # seconds from start of clip
+    level_db: float  # level relative to 0 dBFS (negative = quieter)
+
+
+@dataclass
+class AugmentationResult:
+    """Result of applying the full acoustic augmentation stack to a MixedScene.
+
+    Returned by NoiseMixer.mix(); consumed by Stage 3 → Stage 4 of the pipeline.
+    The acoustic_scene dict is suitable for direct inclusion in ClipMetadata.
+    """
+
+    samples: np.ndarray  # float32, mono, 16 kHz — post-room, post-device, post-mix
+    sample_rate: int  # always 16_000
+    room_type: str
+    device: str
+    ir_source: str
+    speaker_distance_meters: float
+    snr_db_actual: float  # measured after mixing; logged in ClipMetadata
+    events: list[AugmentedEvent] = field(default_factory=list)
+
+    @property
+    def acoustic_scene_dict(self) -> dict:
+        """Return the acoustic_scene block for ClipMetadata (spec §5)."""
+        return {
+            "room_type": self.room_type,
+            "device": self.device,
+            "ir_source": self.ir_source,
+            "speaker_distance_meters": self.speaker_distance_meters,
+            "snr_db_actual": round(self.snr_db_actual, 2),
+            "background_events": [
+                {
+                    "type": ev.type,
+                    "onset_s": round(ev.onset_s, 3),
+                    "offset_s": round(ev.offset_s, 3),
+                    "level_db": round(ev.level_db, 1),
+                }
+                for ev in self.events
+            ],
+        }

--- a/synthbanshee/augment/types.py
+++ b/synthbanshee/augment/types.py
@@ -53,8 +53,8 @@ class AugmentationResult:
             "background_events": [
                 {
                     "type": ev.type,
-                    "onset_s": round(ev.onset_s, 3),
-                    "offset_s": round(ev.offset_s, 3),
+                    "onset": round(ev.onset_s, 3),
+                    "offset": round(ev.offset_s, 3),
                     "level_db": round(ev.level_db, 1),
                 }
                 for ev in self.events

--- a/synthbanshee/labels/schema.py
+++ b/synthbanshee/labels/schema.py
@@ -71,6 +71,8 @@ class ClipAcousticScene(BaseModel):
     room_type: str | None = None
     device: str | None = None
     ir_source: str | None = None
+    speaker_distance_meters: float | None = None
+    snr_db_actual: float | None = None
     background_events: list[dict] = Field(default_factory=list)
 
 

--- a/tests/unit/test_device_profiles.py
+++ b/tests/unit/test_device_profiles.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -157,3 +159,19 @@ def test_pi_budget_mic_adds_hum_to_silence():
     silence = np.zeros(_N, dtype=np.float32)
     out = profiler.apply(silence, _SR, "pi_budget_mic")
     assert np.max(np.abs(out)) > 0.0
+
+
+def test_highpass_skipped_when_hz_is_zero():
+    """Cover the False branch of 'if hp_hz > 0' using a patched profile."""
+    profiler = DeviceProfiler()
+    fake_profile = {
+        "highpass_hz": 0,
+        "lowpass_hz": 8_000,
+        "hum_hz": None,
+        "hum_dbfs": None,
+        "level_db": 0.0,
+    }
+    with patch.dict("synthbanshee.augment.device_profiles._PROFILES", {"zero_hp": fake_profile}):
+        out = profiler.apply(_make_samples(), _SR, "zero_hp")
+    assert out.shape == (_N,)
+    assert out.dtype == np.float32

--- a/tests/unit/test_device_profiles.py
+++ b/tests/unit/test_device_profiles.py
@@ -1,0 +1,159 @@
+"""Unit tests for synthbanshee.augment.device_profiles."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from synthbanshee.augment.device_profiles import _PROFILES, DeviceProfiler
+
+_SR = 16_000
+_N = _SR  # 1 s
+
+
+def _make_samples(n: int = _N) -> np.ndarray:
+    """Broadband white-ish signal that exercises all frequency bands."""
+    rng = np.random.default_rng(0)
+    return rng.standard_normal(n).astype(np.float32) * 0.3
+
+
+# ---------------------------------------------------------------------------
+# _PROFILES sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_all_expected_devices_present():
+    expected = {"phone_in_hand", "phone_in_pocket", "phone_on_table", "pi_budget_mic"}
+    assert set(_PROFILES.keys()) == expected
+
+
+def test_profile_keys_complete():
+    required = {"highpass_hz", "lowpass_hz", "hum_hz", "hum_dbfs", "level_db"}
+    for device, profile in _PROFILES.items():
+        assert required.issubset(profile.keys()), f"{device} missing keys"
+
+
+def test_phone_in_pocket_has_lower_lowpass_than_in_hand():
+    assert _PROFILES["phone_in_pocket"]["lowpass_hz"] < _PROFILES["phone_in_hand"]["lowpass_hz"]
+
+
+def test_phone_in_pocket_has_negative_level():
+    assert _PROFILES["phone_in_pocket"]["level_db"] < 0.0
+
+
+def test_pi_budget_mic_has_hum():
+    assert _PROFILES["pi_budget_mic"]["hum_hz"] is not None
+    assert _PROFILES["pi_budget_mic"]["hum_hz"] == 50.0
+    assert _PROFILES["pi_budget_mic"]["hum_dbfs"] is not None
+
+
+def test_phone_devices_no_hum():
+    for device in ("phone_in_hand", "phone_in_pocket", "phone_on_table"):
+        assert _PROFILES[device]["hum_hz"] is None
+
+
+# ---------------------------------------------------------------------------
+# DeviceProfiler.apply — output shape and dtype
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", list(_PROFILES.keys()))
+def test_output_length_matches_input(device):
+    profiler = DeviceProfiler()
+    samples = _make_samples()
+    out = profiler.apply(samples, _SR, device, rng_seed=0)
+    assert out.shape == samples.shape
+
+
+@pytest.mark.parametrize("device", list(_PROFILES.keys()))
+def test_output_dtype_is_float32(device):
+    profiler = DeviceProfiler()
+    out = profiler.apply(_make_samples(), _SR, device, rng_seed=0)
+    assert out.dtype == np.float32
+
+
+def test_unknown_device_raises():
+    profiler = DeviceProfiler()
+    with pytest.raises(KeyError):
+        profiler.apply(_make_samples(), _SR, "does_not_exist")
+
+
+# ---------------------------------------------------------------------------
+# Filtering behaviour
+# ---------------------------------------------------------------------------
+
+
+def _power_in_band(signal: np.ndarray, sr: int, lo_hz: float, hi_hz: float) -> float:
+    """Return fraction of signal power in [lo_hz, hi_hz]."""
+    freqs = np.fft.rfftfreq(len(signal), d=1.0 / sr)
+    spectrum = np.abs(np.fft.rfft(signal)) ** 2
+    mask = (freqs >= lo_hz) & (freqs <= hi_hz)
+    total = float(spectrum.sum())
+    if total == 0:
+        return 0.0
+    return float(spectrum[mask].sum()) / total
+
+
+def test_phone_in_pocket_attenuates_high_frequencies():
+    """phone_in_pocket LPF at 2500 Hz should reduce energy above 4 kHz."""
+    profiler = DeviceProfiler()
+    samples = _make_samples()
+    out = profiler.apply(samples, _SR, "phone_in_pocket")
+    # High-frequency power should be much lower after filtering
+    hi_power_before = _power_in_band(samples, _SR, 4000, 8000)
+    hi_power_after = _power_in_band(out, _SR, 4000, 8000)
+    assert hi_power_after < hi_power_before * 0.5, (
+        f"High-freq attenuation insufficient: before={hi_power_before:.3f}, after={hi_power_after:.3f}"
+    )
+
+
+def test_phone_in_pocket_reduces_overall_level():
+    """phone_in_pocket has −6 dB gain → RMS should drop."""
+    profiler = DeviceProfiler()
+    samples = _make_samples()
+    out_pocket = profiler.apply(samples, _SR, "phone_in_pocket")
+    out_hand = profiler.apply(samples, _SR, "phone_in_hand")
+    rms_pocket = float(np.sqrt(np.mean(out_pocket.astype(np.float64) ** 2)))
+    rms_hand = float(np.sqrt(np.mean(out_hand.astype(np.float64) ** 2)))
+    assert rms_pocket < rms_hand
+
+
+def test_pi_budget_mic_injects_50hz_hum():
+    """pi_budget_mic should add detectable 50 Hz energy."""
+    profiler = DeviceProfiler()
+    # Use a signal with no energy at 50 Hz (pure 440 Hz tone)
+    t = np.arange(_N, dtype=np.float32) / _SR
+    clean = (0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+
+    out = profiler.apply(clean, _SR, "pi_budget_mic")
+
+    # 50 Hz power should be detectable in output but not in input
+    power_before = _power_in_band(clean, _SR, 45, 55)
+    power_after = _power_in_band(out, _SR, 45, 55)
+    assert power_after > power_before * 2
+
+
+def test_phone_in_hand_zero_level_db_preserves_rms():
+    """phone_in_hand has level_db=0 → RMS should be roughly preserved after filtering."""
+    profiler = DeviceProfiler()
+    samples = _make_samples()
+    out = profiler.apply(samples, _SR, "phone_in_hand")
+    rms_in = float(np.sqrt(np.mean(samples.astype(np.float64) ** 2)))
+    rms_out = float(np.sqrt(np.mean(out.astype(np.float64) ** 2)))
+    # Within a factor of 2 (filtering redistributes energy but shouldn't be huge)
+    assert 0.2 < rms_out / rms_in < 5.0
+
+
+def test_silent_input_stays_silent_for_non_hum_device():
+    profiler = DeviceProfiler()
+    silence = np.zeros(_N, dtype=np.float32)
+    out = profiler.apply(silence, _SR, "phone_in_hand")
+    assert np.max(np.abs(out)) < 1e-9
+
+
+def test_pi_budget_mic_adds_hum_to_silence():
+    """Hum is injected even when speech is silent."""
+    profiler = DeviceProfiler()
+    silence = np.zeros(_N, dtype=np.float32)
+    out = profiler.apply(silence, _SR, "pi_budget_mic")
+    assert np.max(np.abs(out)) > 0.0

--- a/tests/unit/test_noise_mixer.py
+++ b/tests/unit/test_noise_mixer.py
@@ -1,0 +1,402 @@
+"""Unit tests for synthbanshee.augment.noise_mixer."""
+
+from __future__ import annotations
+
+import math
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from synthbanshee.augment.noise_mixer import (
+    _PHASE_FRACTIONS,
+    NoiseMixer,
+    _resolve_onset_s,
+    _rms,
+    _snr_db,
+    _speech_rms,
+    _synthesise_ambient,
+    _synthesise_sfx,
+    _to_dbfs,
+)
+from synthbanshee.config.acoustic_config import AcousticSceneConfig, BackgroundEvent
+
+_SR = 16_000
+_N = _SR * 2  # 2 s — long enough for SNR estimation
+
+
+def _sine(freq: float = 440.0, n: int = _N, sr: int = _SR, amp: float = 0.5) -> np.ndarray:
+    t = np.arange(n, dtype=np.float32) / sr
+    return (amp * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+
+def _make_config(
+    background_events: list[BackgroundEvent] | None = None,
+    snr_target_db: float = 20.0,
+) -> AcousticSceneConfig:
+    return AcousticSceneConfig(
+        room_type="small_bedroom",
+        device="phone_in_hand",
+        speaker_distance_meters=1.0,
+        victim_distance_meters=1.0,
+        background_events=background_events or [],
+        snr_target_db=snr_target_db,
+    )
+
+
+def _ambient_event(event_type: str = "tv_ambient") -> BackgroundEvent:
+    return BackgroundEvent(type=event_type, loop=True, onset_seconds=0.0)
+
+
+def _sfx_event(
+    event_type: str = "ACOU_SLAM",
+    onset_seconds: float = 0.5,
+    level_db: float | None = None,
+) -> BackgroundEvent:
+    return BackgroundEvent(
+        type=event_type,
+        loop=False,
+        onset_seconds=onset_seconds,
+        level_db=level_db,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audio helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestAudioHelpers:
+    def test_rms_sine(self):
+        samples = _sine()
+        rms = _rms(samples)
+        # RMS of sin(x)*amp = amp/sqrt(2)
+        expected = 0.5 / math.sqrt(2)
+        assert abs(rms - expected) < 0.01
+
+    def test_rms_zeros(self):
+        assert _rms(np.zeros(100, dtype=np.float32)) == 0.0
+
+    def test_to_dbfs_full_scale(self):
+        samples = np.ones(100, dtype=np.float32)
+        assert _to_dbfs(samples) == pytest.approx(0.0, abs=1e-6)
+
+    def test_to_dbfs_half_scale(self):
+        samples = np.full(100, 0.5, dtype=np.float32)
+        assert _to_dbfs(samples) == pytest.approx(-6.02, abs=0.1)
+
+    def test_to_dbfs_silence(self):
+        assert _to_dbfs(np.zeros(100, dtype=np.float32)) == -math.inf
+
+    def test_speech_rms_excludes_silence_frames(self):
+        # Mix loud active frames with silent frames
+        n_frames = 100
+        frame_n = 320
+        loud = np.ones(frame_n * n_frames // 2, dtype=np.float32) * 0.8
+        silent = np.zeros(frame_n * n_frames // 2, dtype=np.float32)
+        mixed = np.concatenate([loud, silent])
+        srms = _speech_rms(mixed, frame_ms=20, sr=_SR)
+        full_rms = _rms(mixed)
+        # speech_rms should be higher than full RMS since silence is excluded
+        assert srms > full_rms
+
+    def test_snr_db_equal_levels_is_zero(self):
+        signal = _sine(440, amp=0.5)
+        noise = _sine(880, amp=0.5)
+        snr = _snr_db(signal, noise)
+        # Not exact (speech_rms excludes silence) but should be near 0
+        assert -5 < snr < 5
+
+    def test_snr_db_silent_signal(self):
+        assert _snr_db(np.zeros(_N, dtype=np.float32), _sine()) == -math.inf
+
+    def test_snr_db_silent_noise(self):
+        assert _snr_db(_sine(), np.zeros(_N, dtype=np.float32)) == math.inf
+
+
+# ---------------------------------------------------------------------------
+# Synthetic generator tests
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesiseAmbient:
+    @pytest.mark.parametrize(
+        "event_type", ["hvac_hum", "distant_phone_ring", "tv_ambient", "unknown_type"]
+    )
+    def test_length_matches_duration(self, event_type):
+        rng = np.random.default_rng(0)
+        out = _synthesise_ambient(event_type, 1.0, _SR, rng)
+        assert len(out) == _SR
+
+    @pytest.mark.parametrize("event_type", ["hvac_hum", "distant_phone_ring", "tv_ambient"])
+    def test_dtype_float32(self, event_type):
+        rng = np.random.default_rng(0)
+        out = _synthesise_ambient(event_type, 1.0, _SR, rng)
+        assert out.dtype == np.float32
+
+    def test_zero_duration_returns_empty(self):
+        rng = np.random.default_rng(0)
+        out = _synthesise_ambient("tv_ambient", 0.0, _SR, rng)
+        assert len(out) == 0
+
+    def test_hvac_hum_not_silent(self):
+        rng = np.random.default_rng(0)
+        out = _synthesise_ambient("hvac_hum", 1.0, _SR, rng)
+        assert _rms(out) > 0.0
+
+
+class TestSynthesiseSfx:
+    @pytest.mark.parametrize(
+        "event_type",
+        ["ACOU_BREAK", "ACOU_SLAM", "ACOU_THROW", "ACOU_FALL", "ACOU_FOOT"],
+    )
+    def test_dtype_float32(self, event_type):
+        rng = np.random.default_rng(0)
+        out = _synthesise_sfx(event_type, _SR, rng)
+        assert out.dtype == np.float32
+
+    @pytest.mark.parametrize(
+        "event_type",
+        ["ACOU_BREAK", "ACOU_SLAM", "ACOU_THROW", "ACOU_FALL", "ACOU_FOOT"],
+    )
+    def test_not_silent(self, event_type):
+        rng = np.random.default_rng(0)
+        out = _synthesise_sfx(event_type, _SR, rng)
+        assert _rms(out) > 0.0
+
+    def test_slam_shorter_than_fall(self):
+        rng = np.random.default_rng(0)
+        slam = _synthesise_sfx("ACOU_SLAM", _SR, rng)
+        rng2 = np.random.default_rng(0)
+        fall = _synthesise_sfx("ACOU_FALL", _SR, rng2)
+        # SLAM duration range (0.15-0.35) max < FALL range (0.5-1.2) min
+        assert len(slam) <= len(fall)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_onset_s tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOnsetS:
+    def _make_ev(self, **kwargs) -> BackgroundEvent:
+        # Provide a default onset to satisfy the validator
+        defaults = {"type": "ACOU_SLAM", "loop": False, "onset_seconds": 0.0}
+        defaults.update(kwargs)
+        return BackgroundEvent(**defaults)
+
+    def test_explicit_onset_seconds(self):
+        ev = self._make_ev(onset_seconds=1.5)
+        rng = np.random.default_rng(0)
+        onset = _resolve_onset_s(ev, 5.0, None, rng)
+        assert onset == pytest.approx(1.5)
+
+    def test_onset_with_offset(self):
+        ev = self._make_ev(onset_seconds=1.0, onset_offset_seconds=0.3)
+        rng = np.random.default_rng(0)
+        onset = _resolve_onset_s(ev, 5.0, None, rng)
+        assert onset == pytest.approx(1.3)
+
+    def test_phase_boundaries_resolution(self):
+        ev = BackgroundEvent(type="ACOU_SLAM", loop=False, onset_at_phase="peak")
+        phase_boundaries = {"peak": 2.5}
+        rng = np.random.default_rng(0)
+        onset = _resolve_onset_s(ev, 5.0, phase_boundaries, rng)
+        assert onset == pytest.approx(2.5)
+
+    def test_phase_fractions_fallback(self):
+        ev = BackgroundEvent(type="ACOU_SLAM", loop=False, onset_at_phase="peak")
+        rng = np.random.default_rng(0)
+        onset = _resolve_onset_s(ev, 10.0, None, rng)
+        expected = _PHASE_FRACTIONS["peak"] * 10.0
+        assert onset == pytest.approx(expected)
+
+    def test_clamped_to_duration(self):
+        ev = self._make_ev(onset_seconds=100.0)
+        rng = np.random.default_rng(0)
+        onset = _resolve_onset_s(ev, 5.0, None, rng)
+        assert onset <= 5.0 - 0.1
+
+    def test_negative_clamped_to_zero(self):
+        ev = self._make_ev(onset_seconds=0.5, onset_offset_seconds=-2.0)
+        rng = np.random.default_rng(0)
+        onset = _resolve_onset_s(ev, 5.0, None, rng)
+        assert onset == 0.0
+
+
+# ---------------------------------------------------------------------------
+# NoiseMixer.mix — no assets (pure synthetic)
+# ---------------------------------------------------------------------------
+
+
+class TestNoiseMixerNoAssets:
+    def setup_method(self):
+        self.mixer = NoiseMixer(assets_dir=Path("/tmp/nonexistent_assets_dir"))
+        self.samples = _sine()
+
+    def test_no_events_returns_original(self):
+        config = _make_config(background_events=[])
+        out, events, snr = self.mixer.mix(self.samples, _SR, config)
+        np.testing.assert_array_equal(out, self.samples)
+        assert events == []
+        assert snr == math.inf
+
+    def test_ambient_event_adds_noise(self):
+        config = _make_config(background_events=[_ambient_event()])
+        out, events, snr = self.mixer.mix(self.samples, _SR, config)
+        assert not np.allclose(out, self.samples)
+        assert len(events) == 1
+
+    def test_ambient_event_produces_one_record(self):
+        config = _make_config(background_events=[_ambient_event("hvac_hum")])
+        _, events, _ = self.mixer.mix(self.samples, _SR, config)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.type == "hvac_hum"
+        assert ev.onset_s == 0.0
+        assert ev.offset_s == pytest.approx(len(self.samples) / _SR)
+
+    def test_snr_is_near_target(self):
+        """SNR should be within 3 dB of the target for a normal speech signal."""
+        config = _make_config(background_events=[_ambient_event()], snr_target_db=20.0)
+        _, _, snr = self.mixer.mix(self.samples, _SR, config)
+        assert abs(snr - 20.0) < 3.0
+
+    def test_sfx_event_appended_to_events(self):
+        config = _make_config(background_events=[_sfx_event("ACOU_SLAM", onset_seconds=0.5)])
+        _, events, _ = self.mixer.mix(self.samples, _SR, config)
+        assert len(events) == 1
+        assert events[0].type == "ACOU_SLAM"
+
+    def test_sfx_onset_within_bounds(self):
+        config = _make_config(background_events=[_sfx_event(onset_seconds=0.5)])
+        _, events, _ = self.mixer.mix(self.samples, _SR, config)
+        assert 0.0 <= events[0].onset_s < len(self.samples) / _SR
+
+    def test_sfx_offset_after_onset(self):
+        config = _make_config(background_events=[_sfx_event(onset_seconds=0.5)])
+        _, events, _ = self.mixer.mix(self.samples, _SR, config)
+        assert events[0].offset_s > events[0].onset_s
+
+    def test_sfx_level_db_applied(self):
+        """SFX at an explicit level_db should not be silent."""
+        config = _make_config(
+            background_events=[_sfx_event("ACOU_SLAM", onset_seconds=0.3, level_db=-20.0)]
+        )
+        out, events, _ = self.mixer.mix(self.samples, _SR, config)
+        ev = events[0]
+        assert ev.level_db == pytest.approx(-20.0, abs=0.1)
+
+    def test_output_same_length_as_input(self):
+        config = _make_config(
+            background_events=[
+                _ambient_event(),
+                _sfx_event("ACOU_FALL", onset_seconds=0.8),
+            ]
+        )
+        out, _, _ = self.mixer.mix(self.samples, _SR, config)
+        assert len(out) == len(self.samples)
+
+    def test_output_dtype_float32(self):
+        config = _make_config(background_events=[_ambient_event()])
+        out, _, _ = self.mixer.mix(self.samples, _SR, config)
+        assert out.dtype == np.float32
+
+    def test_reproducible_with_same_seed(self):
+        config = _make_config(background_events=[_ambient_event(), _sfx_event(onset_seconds=0.5)])
+        out1, _, _ = self.mixer.mix(self.samples, _SR, config, rng_seed=7)
+        out2, _, _ = self.mixer.mix(self.samples, _SR, config, rng_seed=7)
+        np.testing.assert_array_equal(out1, out2)
+
+    def test_different_seeds_differ(self):
+        config = _make_config(background_events=[_ambient_event()])
+        out1, _, _ = self.mixer.mix(self.samples, _SR, config, rng_seed=0)
+        out2, _, _ = self.mixer.mix(self.samples, _SR, config, rng_seed=99)
+        assert not np.allclose(out1, out2)
+
+    def test_multiple_ambient_events(self):
+        config = _make_config(
+            background_events=[
+                _ambient_event("tv_ambient"),
+                _ambient_event("hvac_hum"),
+            ]
+        )
+        out, events, _ = self.mixer.mix(self.samples, _SR, config)
+        assert len(events) == 2
+
+    def test_sfx_onset_clamped_to_near_end(self):
+        """_resolve_onset_s clamps very large onset_seconds to duration_s - 0.1."""
+        config = _make_config(background_events=[_sfx_event(onset_seconds=9999.0)])
+        _, events, _ = self.mixer.mix(self.samples, _SR, config)
+        # Event is clamped to near end of clip, not dropped
+        duration_s = len(self.samples) / _SR
+        if events:
+            assert events[0].onset_s <= duration_s
+
+    def test_phase_boundaries_used_for_onset(self):
+        ev = BackgroundEvent(type="ACOU_SLAM", loop=False, onset_at_phase="tension")
+        config = _make_config(background_events=[ev])
+        phase_boundaries = {"tension": 0.8}
+        _, events, _ = self.mixer.mix(
+            self.samples, _SR, config, rng_seed=0, phase_boundaries=phase_boundaries
+        )
+        assert len(events) == 1
+        assert events[0].onset_s == pytest.approx(0.8, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# NoiseMixer.mix — with real WAV assets
+# ---------------------------------------------------------------------------
+
+
+class TestNoiseMixerWithAssets:
+    def _write_wav(self, path: Path, n: int = _SR) -> None:
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal(n).astype(np.float32) * 0.1
+        sf.write(str(path), data, _SR)
+
+    def test_ambient_asset_loaded_when_present(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assets_dir = Path(tmpdir)
+            ambient_dir = assets_dir / "ambient"
+            ambient_dir.mkdir()
+            self._write_wav(ambient_dir / "tv_ambient_001.wav")
+
+            mixer = NoiseMixer(assets_dir=assets_dir)
+            samples = _sine()
+            config = _make_config(background_events=[_ambient_event("tv_ambient")])
+            out, events, _ = mixer.mix(samples, _SR, config)
+            assert len(events) == 1
+            assert not np.allclose(out, samples)
+
+    def test_sfx_asset_loaded_when_present(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assets_dir = Path(tmpdir)
+            sfx_dir = assets_dir / "sfx"
+            sfx_dir.mkdir()
+            self._write_wav(sfx_dir / "ACOU_SLAM_001.wav", n=_SR // 4)
+
+            mixer = NoiseMixer(assets_dir=assets_dir)
+            samples = _sine()
+            config = _make_config(background_events=[_sfx_event("ACOU_SLAM", onset_seconds=0.5)])
+            out, events, _ = mixer.mix(samples, _SR, config)
+            assert len(events) == 1
+
+    def test_explicit_asset_path_used(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asset_file = Path(tmpdir) / "custom_sfx.wav"
+            self._write_wav(asset_file, n=_SR // 4)
+
+            ev = BackgroundEvent(
+                type="ACOU_SLAM",
+                loop=False,
+                onset_seconds=0.3,
+                asset_path=str(asset_file),
+            )
+            mixer = NoiseMixer(assets_dir=Path("/tmp/nonexistent"))
+            samples = _sine()
+            config = _make_config(background_events=[ev])
+            _, events, _ = mixer.mix(samples, _SR, config)
+            assert len(events) == 1

--- a/tests/unit/test_noise_mixer.py
+++ b/tests/unit/test_noise_mixer.py
@@ -579,8 +579,8 @@ class TestAugmentationResult:
         assert d["snr_db_actual"] == pytest.approx(18.3, abs=0.01)
         assert len(d["background_events"]) == 1
         assert d["background_events"][0]["type"] == "tv_ambient"
-        assert d["background_events"][0]["onset_s"] == pytest.approx(0.0)
-        assert d["background_events"][0]["offset_s"] == pytest.approx(2.0)
+        assert d["background_events"][0]["onset"] == pytest.approx(0.0)
+        assert d["background_events"][0]["offset"] == pytest.approx(2.0)
 
     def test_acoustic_scene_dict_empty_events(self):
         from synthbanshee.augment.types import AugmentationResult

--- a/tests/unit/test_noise_mixer.py
+++ b/tests/unit/test_noise_mixer.py
@@ -515,6 +515,27 @@ class TestNoiseMixerWithAssets:
         _, events, _ = mixer.mix(samples, _SR, config)
         assert len(events) == 1  # synthetic fallback used
 
+    def test_ambient_asset_path_missing_falls_through_to_dir_search(self):
+        """Ambient asset_path set but file missing → _has_asset falls through to dir search."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assets_dir = Path(tmpdir)
+            ambient_dir = assets_dir / "ambient"
+            ambient_dir.mkdir()
+            self._write_wav(ambient_dir / "tv_ambient_001.wav")
+
+            ev = BackgroundEvent(
+                type="tv_ambient",
+                loop=True,
+                onset_seconds=0.0,
+                asset_path="/tmp/nonexistent_ambient_99999.wav",
+            )
+            mixer = NoiseMixer(assets_dir=assets_dir)
+            samples = _sine()
+            config = _make_config(background_events=[ev])
+            _, events, _ = mixer.mix(samples, _SR, config)
+            # Falls through to ambient dir; asset loaded, not synthetic
+            assert len(events) == 1
+
     def test_sfx_dir_exists_but_no_matching_files_uses_synthetic(self):
         """sfx_dir exists but no files match event type → synthesise fallback."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/test_noise_mixer.py
+++ b/tests/unit/test_noise_mixer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -13,6 +14,8 @@ import soundfile as sf
 from synthbanshee.augment.noise_mixer import (
     _PHASE_FRACTIONS,
     NoiseMixer,
+    _load_audio,
+    _pad_or_trim,
     _resolve_onset_s,
     _rms,
     _snr_db,
@@ -90,6 +93,12 @@ class TestAudioHelpers:
     def test_to_dbfs_silence(self):
         assert _to_dbfs(np.zeros(100, dtype=np.float32)) == -math.inf
 
+    def test_speech_rms_short_signal_falls_back_to_rms(self):
+        """Signal shorter than one frame triggers the early-return path."""
+        short = np.ones(100, dtype=np.float32) * 0.5
+        result = _speech_rms(short, frame_ms=20, sr=_SR)
+        assert result == pytest.approx(0.5, abs=1e-4)
+
     def test_speech_rms_excludes_silence_frames(self):
         # Mix loud active frames with silent frames
         n_frames = 100
@@ -114,6 +123,47 @@ class TestAudioHelpers:
 
     def test_snr_db_silent_noise(self):
         assert _snr_db(_sine(), np.zeros(_N, dtype=np.float32)) == math.inf
+
+
+# ---------------------------------------------------------------------------
+# _pad_or_trim tests
+# ---------------------------------------------------------------------------
+
+
+class TestPadOrTrim:
+    def test_empty_audio_returns_zeros(self):
+        result = _pad_or_trim(np.array([], dtype=np.float32), 100)
+        assert len(result) == 100
+        assert np.all(result == 0.0)
+        assert result.dtype == np.float32
+
+    def test_longer_audio_is_truncated(self):
+        audio = np.ones(200, dtype=np.float32)
+        result = _pad_or_trim(audio, 100)
+        assert len(result) == 100
+
+    def test_shorter_audio_is_tiled(self):
+        audio = np.array([1.0, 2.0], dtype=np.float32)
+        result = _pad_or_trim(audio, 5)
+        assert len(result) == 5
+        assert result[0] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# _load_audio resampling test
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAudio:
+    def test_resample_from_44100_to_16000(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test_44100.wav"
+            data = (np.sin(np.linspace(0, 2 * np.pi, 44100)) * 0.5).astype(np.float32)
+            sf.write(str(path), data, 44100)
+            result = _load_audio(path, sr=_SR)
+            # Resampled length should be ~16000 (within rounding margin)
+            assert abs(len(result) - _SR) < 10
+            assert result.dtype == np.float32
 
 
 # ---------------------------------------------------------------------------
@@ -221,6 +271,19 @@ class TestResolveOnsetS:
 
     def test_negative_clamped_to_zero(self):
         ev = self._make_ev(onset_seconds=0.5, onset_offset_seconds=-2.0)
+        rng = np.random.default_rng(0)
+        onset = _resolve_onset_s(ev, 5.0, None, rng)
+        assert onset == 0.0
+
+    def test_neither_onset_nor_phase_defaults_to_zero(self):
+        """Bypass validator to test the defensive else-branch (base=0)."""
+        ev = BackgroundEvent.model_construct(
+            type="ACOU_SLAM",
+            loop=False,
+            onset_seconds=None,
+            onset_at_phase=None,
+            onset_offset_seconds=None,
+        )
         rng = np.random.default_rng(0)
         onset = _resolve_onset_s(ev, 5.0, None, rng)
         assert onset == 0.0
@@ -345,6 +408,25 @@ class TestNoiseMixerNoAssets:
         assert len(events) == 1
         assert events[0].onset_s == pytest.approx(0.8, abs=0.01)
 
+    def test_silent_speech_skips_snr_scaling(self):
+        """When speech is silent, SNR scaling branch is skipped (speech_rms == 0)."""
+        silence = np.zeros(_N, dtype=np.float32)
+        config = _make_config(background_events=[_ambient_event()], snr_target_db=20.0)
+        out, events, _ = self.mixer.mix(silence, _SR, config)
+        assert len(events) == 1
+        # Output equals the unscaled ambient (no gain applied)
+        assert out.shape == silence.shape
+
+    def test_sfx_skipped_when_copy_n_zero(self):
+        """SFX with zero-length audio is skipped (copy_n <= 0 branch)."""
+        config = _make_config(background_events=[_sfx_event(onset_seconds=0.5)])
+        with patch(
+            "synthbanshee.augment.noise_mixer.NoiseMixer._load_or_synthesise_sfx",
+            return_value=np.array([], dtype=np.float32),
+        ):
+            _, events, _ = self.mixer.mix(self.samples, _SR, config)
+        assert len(events) == 0
+
 
 # ---------------------------------------------------------------------------
 # NoiseMixer.mix — with real WAV assets
@@ -400,3 +482,96 @@ class TestNoiseMixerWithAssets:
             config = _make_config(background_events=[ev])
             _, events, _ = mixer.mix(samples, _SR, config)
             assert len(events) == 1
+
+    def test_ambient_explicit_asset_path_used(self):
+        """Covers _has_asset and _resolve_asset_path with asset_path set on ambient event."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asset_file = Path(tmpdir) / "custom_ambient.wav"
+            self._write_wav(asset_file, n=_SR * 2)
+
+            ev = BackgroundEvent(
+                type="tv_ambient",
+                loop=True,
+                onset_seconds=0.0,
+                asset_path=str(asset_file),
+            )
+            mixer = NoiseMixer(assets_dir=Path("/tmp/nonexistent"))
+            samples = _sine()
+            config = _make_config(background_events=[ev])
+            _, events, _ = mixer.mix(samples, _SR, config)
+            assert len(events) == 1
+
+    def test_sfx_asset_path_missing_falls_through_to_synthetic(self):
+        """SFX asset_path set but file missing → synthesise fallback (_load_or_synthesise_sfx)."""
+        ev = BackgroundEvent(
+            type="ACOU_SLAM",
+            loop=False,
+            onset_seconds=0.3,
+            asset_path="/tmp/nonexistent_sfx_12345.wav",
+        )
+        mixer = NoiseMixer(assets_dir=Path("/tmp/nonexistent"))
+        samples = _sine()
+        config = _make_config(background_events=[ev])
+        _, events, _ = mixer.mix(samples, _SR, config)
+        assert len(events) == 1  # synthetic fallback used
+
+    def test_sfx_dir_exists_but_no_matching_files_uses_synthetic(self):
+        """sfx_dir exists but no files match event type → synthesise fallback."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assets_dir = Path(tmpdir)
+            sfx_dir = assets_dir / "sfx"
+            sfx_dir.mkdir()
+            # Put a file for a different type, not ACOU_SLAM
+            self._write_wav(sfx_dir / "ACOU_FALL_001.wav", n=_SR // 4)
+
+            mixer = NoiseMixer(assets_dir=assets_dir)
+            samples = _sine()
+            config = _make_config(background_events=[_sfx_event("ACOU_SLAM", onset_seconds=0.5)])
+            _, events, _ = mixer.mix(samples, _SR, config)
+            assert len(events) == 1  # synthetic fallback used
+
+
+# ---------------------------------------------------------------------------
+# AugmentationResult.acoustic_scene_dict (types.py)
+# ---------------------------------------------------------------------------
+
+
+class TestAugmentationResult:
+    def test_acoustic_scene_dict_structure(self):
+        from synthbanshee.augment.types import AugmentationResult, AugmentedEvent
+
+        result = AugmentationResult(
+            samples=np.zeros(100, dtype=np.float32),
+            sample_rate=_SR,
+            room_type="small_bedroom",
+            device="phone_in_hand",
+            ir_source="pyroomacoustics",
+            speaker_distance_meters=1.5,
+            snr_db_actual=18.3,
+            events=[
+                AugmentedEvent(type="tv_ambient", onset_s=0.0, offset_s=2.0, level_db=-30.5),
+            ],
+        )
+        d = result.acoustic_scene_dict
+        assert d["room_type"] == "small_bedroom"
+        assert d["device"] == "phone_in_hand"
+        assert d["snr_db_actual"] == pytest.approx(18.3, abs=0.01)
+        assert len(d["background_events"]) == 1
+        assert d["background_events"][0]["type"] == "tv_ambient"
+        assert d["background_events"][0]["onset_s"] == pytest.approx(0.0)
+        assert d["background_events"][0]["offset_s"] == pytest.approx(2.0)
+
+    def test_acoustic_scene_dict_empty_events(self):
+        from synthbanshee.augment.types import AugmentationResult
+
+        result = AugmentationResult(
+            samples=np.zeros(100, dtype=np.float32),
+            sample_rate=_SR,
+            room_type="clinic_office",
+            device="pi_budget_mic",
+            ir_source="pyroomacoustics",
+            speaker_distance_meters=2.0,
+            snr_db_actual=25.0,
+        )
+        d = result.acoustic_scene_dict
+        assert d["background_events"] == []

--- a/tests/unit/test_room_sim.py
+++ b/tests/unit/test_room_sim.py
@@ -114,12 +114,13 @@ def test_different_seeds_differ():
 
 def test_unknown_room_type_raises():
     sim = RoomSimulator()
+    config = AcousticSceneConfig.model_construct(
+        room_type="nonexistent_room",
+        room_dimensions_range=None,
+        rt60_range=None,
+        speaker_distance_meters=1.0,
+    )
     with pytest.raises(KeyError):
-        config = AcousticSceneConfig.__new__(AcousticSceneConfig)
-        object.__setattr__(config, "room_type", "nonexistent_room")
-        object.__setattr__(config, "room_dimensions_range", None)
-        object.__setattr__(config, "rt60_range", None)
-        object.__setattr__(config, "speaker_distance_meters", 1.0)
         sim.apply(_make_samples(), _SR, config, rng_seed=0)
 
 

--- a/tests/unit/test_room_sim.py
+++ b/tests/unit/test_room_sim.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pytest
 
@@ -160,3 +162,28 @@ def test_silent_input_produces_silent_output():
     out = sim.apply(silence, _SR, config, rng_seed=0)
     # After convolving silence with any RIR the result must still be (near) silence
     assert np.max(np.abs(out)) < 1e-6
+
+
+def test_output_zero_padded_when_reverbed_shorter_than_input():
+    """Cover the zero-pad branch when the simulated signal is shorter than input."""
+
+    sim = RoomSimulator()
+    samples = _make_samples()
+    config = _make_config()
+
+    # Patch ShoeBox so mic_array.signals[0] is shorter than the input
+    short_reverb = np.zeros(_N // 2, dtype=np.float32)
+    mock_room = MagicMock()
+    mock_room.mic_array.signals = [short_reverb]
+
+    with (
+        patch("pyroomacoustics.ShoeBox", return_value=mock_room),
+        patch("pyroomacoustics.inverse_sabine", return_value=(0.5, 8)),
+        patch("pyroomacoustics.Material", return_value=MagicMock()),
+    ):
+        out = sim.apply(samples, _SR, config, rng_seed=0)
+
+    assert len(out) == _N
+    assert out.dtype == np.float32
+    # Tail should be zero-padded
+    assert np.all(out[_N // 2 :] == 0.0)

--- a/tests/unit/test_room_sim.py
+++ b/tests/unit/test_room_sim.py
@@ -1,0 +1,162 @@
+"""Unit tests for synthbanshee.augment.room_sim."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from synthbanshee.augment.room_sim import _ROOM_PRESETS, RoomSimulator
+from synthbanshee.config.acoustic_config import AcousticSceneConfig
+
+# Short 0.5-s synthetic speech signal at 16 kHz
+_SR = 16_000
+_N = _SR // 2  # 0.5 s
+
+
+def _make_samples(n: int = _N, sr: int = _SR) -> np.ndarray:
+    """Return a deterministic float32 sine wave."""
+    t = np.arange(n, dtype=np.float32) / sr
+    return (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+
+
+def _make_config(
+    room_type: str = "small_bedroom",
+    speaker_distance_meters: float = 1.0,
+) -> AcousticSceneConfig:
+    return AcousticSceneConfig(
+        room_type=room_type,
+        device="phone_in_hand",
+        speaker_distance_meters=speaker_distance_meters,
+        victim_distance_meters=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _ROOM_PRESETS sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_all_preset_room_types_present():
+    expected = {
+        "small_bedroom",
+        "apartment_kitchen",
+        "living_room",
+        "clinic_office",
+        "welfare_office",
+        "open_office_corridor",
+    }
+    assert set(_ROOM_PRESETS.keys()) == expected
+
+
+def test_preset_dims_consistent():
+    """Each preset's min dims must be < max dims for all three axes."""
+    for room_type, (dims_min, dims_max, _) in _ROOM_PRESETS.items():
+        for axis, (lo, hi) in enumerate(zip(dims_min, dims_max, strict=False)):
+            assert lo < hi, f"{room_type} axis {axis}: min={lo} >= max={hi}"
+
+
+def test_preset_rt60_ranges_positive():
+    for room_type, (_, _, (rt60_lo, rt60_hi)) in _ROOM_PRESETS.items():
+        assert 0 < rt60_lo < rt60_hi, f"{room_type} RT60 range invalid"
+
+
+# ---------------------------------------------------------------------------
+# RoomSimulator.apply — output shape and dtype
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("room_type", list(_ROOM_PRESETS.keys()))
+def test_output_length_matches_input(room_type):
+    sim = RoomSimulator()
+    samples = _make_samples()
+    config = _make_config(room_type=room_type)
+    out = sim.apply(samples, _SR, config, rng_seed=0)
+    assert out.shape == samples.shape, f"{room_type}: shape mismatch"
+
+
+@pytest.mark.parametrize("room_type", list(_ROOM_PRESETS.keys()))
+def test_output_dtype_is_float32(room_type):
+    sim = RoomSimulator()
+    samples = _make_samples()
+    config = _make_config(room_type=room_type)
+    out = sim.apply(samples, _SR, config, rng_seed=0)
+    assert out.dtype == np.float32, f"{room_type}: dtype {out.dtype}"
+
+
+def test_output_is_not_identical_to_input():
+    """Room sim should change the signal (not a no-op)."""
+    sim = RoomSimulator()
+    samples = _make_samples()
+    config = _make_config()
+    out = sim.apply(samples, _SR, config, rng_seed=0)
+    assert not np.allclose(out, samples), "RoomSimulator returned unmodified input"
+
+
+def test_reproducible_with_same_seed():
+    sim = RoomSimulator()
+    samples = _make_samples()
+    config = _make_config()
+    out1 = sim.apply(samples, _SR, config, rng_seed=42)
+    out2 = sim.apply(samples, _SR, config, rng_seed=42)
+    np.testing.assert_array_equal(out1, out2)
+
+
+def test_different_seeds_differ():
+    sim = RoomSimulator()
+    samples = _make_samples()
+    config = _make_config()
+    out1 = sim.apply(samples, _SR, config, rng_seed=0)
+    out2 = sim.apply(samples, _SR, config, rng_seed=99)
+    assert not np.allclose(out1, out2)
+
+
+def test_unknown_room_type_raises():
+    sim = RoomSimulator()
+    with pytest.raises(KeyError):
+        config = AcousticSceneConfig.__new__(AcousticSceneConfig)
+        object.__setattr__(config, "room_type", "nonexistent_room")
+        object.__setattr__(config, "room_dimensions_range", None)
+        object.__setattr__(config, "rt60_range", None)
+        object.__setattr__(config, "speaker_distance_meters", 1.0)
+        sim.apply(_make_samples(), _SR, config, rng_seed=0)
+
+
+def test_custom_room_dimensions_used():
+    """Explicit room_dimensions_range should be accepted without error."""
+    from synthbanshee.config.acoustic_config import RoomDimensionsRange
+
+    config = AcousticSceneConfig(
+        room_type="living_room",
+        device="phone_in_hand",
+        speaker_distance_meters=1.0,
+        victim_distance_meters=1.0,
+        room_dimensions_range=RoomDimensionsRange(
+            min=[5.0, 4.0, 2.5],
+            max=[5.5, 4.5, 3.0],
+        ),
+    )
+    sim = RoomSimulator()
+    out = sim.apply(_make_samples(), _SR, config, rng_seed=0)
+    assert out.shape == (_N,)
+
+
+def test_custom_rt60_range_used():
+    config = AcousticSceneConfig(
+        room_type="clinic_office",
+        device="phone_in_hand",
+        speaker_distance_meters=1.0,
+        victim_distance_meters=1.0,
+        rt60_range=[0.10, 0.15],
+    )
+    sim = RoomSimulator()
+    out = sim.apply(_make_samples(), _SR, config, rng_seed=0)
+    assert out.shape == (_N,)
+
+
+def test_silent_input_produces_silent_output():
+    sim = RoomSimulator()
+    silence = np.zeros(_N, dtype=np.float32)
+    config = _make_config()
+    out = sim.apply(silence, _SR, config, rng_seed=0)
+    # After convolving silence with any RIR the result must still be (near) silence
+    assert np.max(np.abs(out)) < 1e-6

--- a/tests/unit/test_room_sim.py
+++ b/tests/unit/test_room_sim.py
@@ -143,6 +143,27 @@ def test_custom_room_dimensions_used():
     assert out.shape == (_N,)
 
 
+def test_low_ceiling_room_clamps_mic_src_z():
+    """Room height < 1.2 m: mic/src z must be clamped inside the room bounds."""
+    from synthbanshee.config.acoustic_config import RoomDimensionsRange
+
+    # Room height of 1.0 m is below both default mic (1.2 m) and src (1.6 m)
+    config = AcousticSceneConfig(
+        room_type="small_bedroom",
+        device="phone_in_hand",
+        speaker_distance_meters=0.3,
+        victim_distance_meters=0.3,
+        room_dimensions_range=RoomDimensionsRange(
+            min=[3.0, 3.0, 1.0],
+            max=[3.1, 3.1, 1.0],
+        ),
+    )
+    sim = RoomSimulator()
+    # Should not raise — mic/src z are clamped to [0.1, 0.9]
+    out = sim.apply(_make_samples(), _SR, config, rng_seed=0)
+    assert out.shape == (_N,)
+
+
 def test_custom_rt60_range_used():
     config = AcousticSceneConfig(
         room_type="clinic_office",


### PR DESCRIPTION
## Summary

- **`augment/types.py`** — `AugmentedEvent` and `AugmentationResult` dataclasses; `acoustic_scene_dict` property for `ClipMetadata` serialisation (spec §5)
- **`augment/room_sim.py`** — `RoomSimulator` using pyroomacoustics ShoeBox/ISM; 6 room presets (`small_bedroom` → `open_office_corridor`) with per-type RT60/dimension bounds; ISM order capped at 12
- **`augment/device_profiles.py`** — `DeviceProfiler` with 4 profiles (`phone_in_hand`, `phone_in_pocket`, `phone_on_table`, `pi_budget_mic`); scipy Butterworth HP+LP chain, optional 50 Hz mains hum injection, broadband level adjustment
- **`augment/noise_mixer.py`** — `NoiseMixer`; ambient tracks scaled to `snr_target_db`; foreground ACOU_* events placed at phase-relative onsets; synthetic fallbacks (pink noise, NANP ring, footstep clicks, transient bursts) available without WAV assets
- **`augment/__init__.py`** — exports all new public classes

## Test plan

- [ ] 96 new unit tests across `test_room_sim.py`, `test_device_profiles.py`, `test_noise_mixer.py`
- [ ] Full suite: 519 tests, all passing (`pytest -q`)
- [ ] ruff, ruff-format, mypy all clean (pre-commit passes)
- [ ] Verify `RoomSimulator` output length equals input length for all 6 presets
- [ ] Verify `NoiseMixer` SNR lands within ±3 dB of target for normal speech
- [ ] Verify synthetic fallbacks used when no WAV assets present
- [ ] Verify WAV asset loaded (over synthetic) when present in `assets/sfx/` or `assets/ambient/`

## Notes

PR B (Tier B pipeline integration) will wire these into `_run_generate_pipeline()` as Stage 3, feeding `AugmentationResult.events` → label timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)