### PR TITLE
feat(phase-2): strong labels JSONL + Tier B scene configs + integration test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,19 +55,25 @@ tests/
 
 All generated audio is **Hebrew (he-IL)**. Transcripts are UTF-8 Hebrew. Filenames and metadata strings must be ASCII only (no UTF-8 above U+00A1 in filenames or JSON keys/values — Hebrew text goes in transcript `.txt` files only, not in filenames or metadata string fields).
 
-## The four pipeline stages
+## The five pipeline stages
 
-Every clip is produced by four sequential stages. Keep them modular with clean interfaces.
+Every clip is produced by five sequential stages. Keep them modular with clean interfaces.
 
 ```
 SceneConfig (YAML)
-  → [1] Script Generator   → dialogue JSON  (LLM fills Jinja2 template)
-  → [2] TTS Renderer       → per-speaker WAV segments (Azure/Google he-IL)
-  → [3] Acoustic Augmenter → augmented scene WAV (room IR, device profile, noise)
-  → [4] Label Generator    → AVDP-schema JSONL (auto-derived from script + augmentation log)
+  → [1]  Script Generator      → DialogueTurns  (LLM fills Jinja2 template)
+  → [2]  TTS Renderer          → MixedScene WAV (Azure/Google he-IL, per-speaker segments mixed)
+  → [3a] Preprocessing         → spec-compliant WAV (16 kHz, mono, normalized, silence-padded)
+  → [3b] Acoustic Augmentation → augmented WAV (room IR, device profile, noise) — Tier B only
+  → [4a] Transcript Writer     → {clip_id}.txt  (per-turn text with onset/offset markers)
+  → [4b] Strong Label Writer   → {clip_id}.jsonl (per-event EventLabel records)
+  → [4c] Metadata Writer       → {clip_id}.json  (ClipMetadata — weak labels, speaker info, etc.)
+  → [5]  Validator             → pass/fail + warnings (validate_clip)
 ```
 
-The augmentation log from Stage 3 is the source of truth for SFX onset/offset times in Stage 4 labels. Don't derive label timings from anything else.
+Stage 3b runs only for Tier B scenes (those with an `acoustic_scene` block). For Tier A scenes the pipeline goes directly from Stage 3a to Stage 4a.
+
+The augmentation log produced by Stage 3b is the source of truth for SFX onset/offset times used in Stage 4b labels. Don't derive SFX label timings from anything else — only speech-turn timings come from the TTS mixer output (Stage 2).
 
 ## Key schema constraints (from spec.md)
 

--- a/configs/examples/scene_elephant_SV_example.yaml
+++ b/configs/examples/scene_elephant_SV_example.yaml
@@ -47,7 +47,7 @@ acoustic_scene:
   device: pi_budget_mic                  # Fixed device type for Elephant
   speaker_distance_meters: 1.2          # Closer — smaller room
   victim_distance_meters: 0.8
-  ir_source: pyroomacoustics
+  ir_source: pyroomacoustics_ism
   room_dimensions_range:
     min: [2.5, 2.0, 2.4]
     max: [4.0, 3.5, 2.8]

--- a/configs/examples/scene_tier_c_confusor_example.yaml
+++ b/configs/examples/scene_tier_c_confusor_example.yaml
@@ -37,7 +37,7 @@ acoustic_scene:
   room_type: apartment_living_room
   device: phone_on_table
   speaker_distance_meters: 2.0
-  ir_source: pyroomacoustics
+  ir_source: pyroomacoustics_ism
   room_dimensions_range:
     min: [4.0, 3.5, 2.4]
     max: [6.0, 5.0, 2.8]

--- a/configs/run_configs/tier_b_1000_elephant.yaml
+++ b/configs/run_configs/tier_b_1000_elephant.yaml
@@ -1,0 +1,37 @@
+# Phase 2 — Tier B generation run: Elephant in the Room project
+# Target: 1 000 acoustically augmented clips (room IR + device profile + noise mix).
+# Scene configs must exist in scene_configs_dir before running.
+# Each scene config must include an acoustic_scene block (required for Tier B).
+# See docs/implementation_plan.md §2 for scale targets.
+#
+# Elephant scenes: 1–4 min, pi_budget_mic device profile.
+# Room types: clinic_office, welfare_office, open_office_corridor.
+
+run_id: tier_b_1000_elephant
+project: elephant_in_the_room
+tier: B
+language: he
+random_seed: 17
+output_dir: data/he
+scene_configs_dir: configs/scenes/elephant_tier_b
+
+# --- Per-typology clip count targets (total: 1 000) ---
+targets:
+  - violence_typology: SV    # Situational Violence (client attacks worker)
+    count: 300
+  - violence_typology: IT    # Intimidation / verbal threat escalation
+    count: 300
+  - violence_typology: NEG   # Negative / animated-but-non-violent confusor
+    count: 300
+  - violence_typology: NEU   # Neutral / routine intake sessions
+    count: 100
+
+# --- Speaker-disjoint split fractions ---
+splits:
+  train: 0.70
+  val: 0.15
+  test: 0.15
+
+# --- Error handling ---
+max_retries: 3
+fail_fast: false

--- a/configs/run_configs/tier_b_1000_she_proves.yaml
+++ b/configs/run_configs/tier_b_1000_she_proves.yaml
@@ -1,0 +1,37 @@
+# Phase 2 — Tier B generation run: She-Proves project
+# Target: 1 000 acoustically augmented clips (room IR + device profile + noise mix).
+# Scene configs must exist in scene_configs_dir before running.
+# Each scene config must include an acoustic_scene block (required for Tier B).
+# See docs/implementation_plan.md §2 for scale targets.
+#
+# She-Proves scenes: 3–6 min, phone_in_pocket / phone_on_table / phone_in_hand device.
+# Room types: small_bedroom, apartment_kitchen, living_room.
+
+run_id: tier_b_1000_she_proves
+project: she_proves
+tier: B
+language: he
+random_seed: 42
+output_dir: data/he
+scene_configs_dir: configs/scenes/she_proves_tier_b
+
+# --- Per-typology clip count targets (total: 1 000) ---
+targets:
+  - violence_typology: IT    # Intimate Terrorism
+    count: 300
+  - violence_typology: SV    # Situational Violence
+    count: 300
+  - violence_typology: NEG   # Negative / Confusor
+    count: 300
+  - violence_typology: NEU   # Neutral / ambient
+    count: 100
+
+# --- Speaker-disjoint split fractions ---
+splits:
+  train: 0.70
+  val: 0.15
+  test: 0.15
+
+# --- Error handling ---
+max_retries: 3
+fail_fast: false             # Continue batch even if individual clips fail

--- a/configs/scenes/elephant_tier_b/el_it_b_0001.yaml
+++ b/configs/scenes/elephant_tier_b/el_it_b_0001.yaml
@@ -1,0 +1,43 @@
+scene_id: EL_IT_B_0001
+project: elephant_in_the_room
+language: he
+violence_typology: IT
+tier: B
+random_seed: 201
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/it_benefits_denial_escalation.j2
+script_slots:
+  scene_type: intake_interview
+  dispute_subject: disability_allowance
+  office_setting: clinic_office
+  trigger: repeated_denial
+intensity_arc: [1, 2, 3, 4, 5]
+elephant:
+  scene_type: intake_interview
+  alert_triggered: true
+  alert_at_phase: peak
+  alert_onset_fraction: 0.68
+  attack_type: PHYS_SOFT
+target_duration_minutes: 2.0
+min_pre_alert_seconds: 50
+acoustic_scene:
+  room_type: clinic_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.0
+  victim_distance_meters: 0.7
+  snr_target_db: 24
+  rt60_range: [0.14, 0.26]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -42
+      loop: true
+    - type: ACOU_SLAM
+      onset_at_phase: peak
+      onset_offset_seconds: 2.0
+      asset_path: null
+output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_it_b_0002.yaml
+++ b/configs/scenes/elephant_tier_b/el_it_b_0002.yaml
@@ -1,0 +1,47 @@
+scene_id: EL_IT_B_0002
+project: elephant_in_the_room
+language: he
+violence_typology: IT
+tier: B
+random_seed: 202
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/it_child_custody_confrontation.j2
+script_slots:
+  scene_type: benefits_dispute
+  dispute_subject: child_custody_order
+  office_setting: welfare_office
+  trigger: court_order_served
+intensity_arc: [2, 3, 4, 5, 4]
+elephant:
+  scene_type: benefits_dispute
+  alert_triggered: true
+  alert_at_phase: peak
+  alert_onset_fraction: 0.62
+  attack_type: PHYS_HARD
+target_duration_minutes: 2.5
+min_pre_alert_seconds: 55
+acoustic_scene:
+  room_type: welfare_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.3
+  victim_distance_meters: 0.9
+  snr_target_db: 21
+  rt60_range: [0.16, 0.30]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -40
+      loop: true
+    - type: ACOU_FOOT
+      onset_at_phase: escalation
+      onset_offset_seconds: 3.0
+      asset_path: null
+    - type: ACOU_SLAM
+      onset_at_phase: peak
+      onset_offset_seconds: 1.0
+      asset_path: null
+output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_neg_b_0001.yaml
+++ b/configs/scenes/elephant_tier_b/el_neg_b_0001.yaml
@@ -1,0 +1,37 @@
+scene_id: EL_NEG_B_0001
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: B
+random_seed: 301
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/neg_successful_deescalation.j2
+script_slots:
+  scene_type: routine_followup
+  dispute_subject: document_request
+  office_setting: welfare_office
+intensity_arc: [1, 2, 3, 2, 1]
+elephant:
+  scene_type: routine_followup
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.0
+acoustic_scene:
+  room_type: welfare_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.4
+  victim_distance_meters: 1.0
+  snr_target_db: 20
+  rt60_range: [0.16, 0.30]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -38
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_neg_b_0002.yaml
+++ b/configs/scenes/elephant_tier_b/el_neg_b_0002.yaml
@@ -23,7 +23,7 @@ elephant:
   attack_type: null
 target_duration_minutes: 2.5
 acoustic_scene:
-  room_type: open_office
+  room_type: open_office_corridor
   device: pi_budget_mic
   speaker_distance_meters: 1.8
   victim_distance_meters: 1.4

--- a/configs/scenes/elephant_tier_b/el_neg_b_0002.yaml
+++ b/configs/scenes/elephant_tier_b/el_neg_b_0002.yaml
@@ -1,0 +1,37 @@
+scene_id: EL_NEG_B_0002
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: B
+random_seed: 302
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/neg_supervisor_intervention.j2
+script_slots:
+  scene_type: benefits_dispute
+  dispute_subject: payment_delay
+  office_setting: open_office
+intensity_arc: [2, 3, 3, 2, 1]
+elephant:
+  scene_type: benefits_dispute
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.5
+acoustic_scene:
+  room_type: open_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.8
+  victim_distance_meters: 1.4
+  snr_target_db: 16
+  rt60_range: [0.22, 0.40]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -36
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_neu_b_0001.yaml
+++ b/configs/scenes/elephant_tier_b/el_neu_b_0001.yaml
@@ -1,0 +1,36 @@
+scene_id: EL_NEU_B_0001
+project: elephant_in_the_room
+language: he
+violence_typology: NEU
+tier: B
+random_seed: 401
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/neu_routine_intake_session.j2
+script_slots:
+  scene_type: intake_interview
+  office_setting: clinic_office
+intensity_arc: [1, 1, 2, 1, 1]
+elephant:
+  scene_type: intake_interview
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.0
+acoustic_scene:
+  room_type: clinic_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.2
+  victim_distance_meters: 0.8
+  snr_target_db: 25
+  rt60_range: [0.14, 0.26]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -42
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_neu_b_0002.yaml
+++ b/configs/scenes/elephant_tier_b/el_neu_b_0002.yaml
@@ -1,0 +1,36 @@
+scene_id: EL_NEU_B_0002
+project: elephant_in_the_room
+language: he
+violence_typology: NEU
+tier: B
+random_seed: 402
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/neu_follow_up_appointment.j2
+script_slots:
+  scene_type: routine_followup
+  office_setting: welfare_office
+intensity_arc: [1, 1, 1, 2, 1]
+elephant:
+  scene_type: routine_followup
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 1.5
+acoustic_scene:
+  room_type: welfare_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.3
+  victim_distance_meters: 0.9
+  snr_target_db: 24
+  rt60_range: [0.16, 0.28]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -40
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_sv_b_0001.yaml
+++ b/configs/scenes/elephant_tier_b/el_sv_b_0001.yaml
@@ -1,0 +1,47 @@
+scene_id: EL_SV_B_0001
+project: elephant_in_the_room
+language: he
+violence_typology: SV
+tier: B
+random_seed: 101
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/sv_physical_threat_to_worker.j2
+script_slots:
+  scene_type: benefits_dispute
+  dispute_subject: housing_assistance
+  office_setting: clinic_office
+  trigger: application_denied
+intensity_arc: [1, 2, 3, 4, 5]
+elephant:
+  scene_type: benefits_dispute
+  alert_triggered: true
+  alert_at_phase: peak
+  alert_onset_fraction: 0.65
+  attack_type: PHYS_HARD
+target_duration_minutes: 2.5
+min_pre_alert_seconds: 60
+acoustic_scene:
+  room_type: clinic_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.2
+  victim_distance_meters: 0.8
+  snr_target_db: 22
+  rt60_range: [0.15, 0.28]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -40
+      loop: true
+    - type: ACOU_SLAM
+      onset_at_phase: escalation
+      onset_offset_seconds: 6.0
+      asset_path: null
+    - type: ACOU_FALL
+      onset_at_phase: peak
+      onset_offset_seconds: 2.0
+      asset_path: null
+output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_sv_b_0002.yaml
+++ b/configs/scenes/elephant_tier_b/el_sv_b_0002.yaml
@@ -1,0 +1,47 @@
+scene_id: EL_SV_B_0002
+project: elephant_in_the_room
+language: he
+violence_typology: SV
+tier: B
+random_seed: 102
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/sv_object_brandished.j2
+script_slots:
+  scene_type: crisis_visit
+  dispute_subject: child_welfare_decision
+  office_setting: welfare_office
+  trigger: removal_order
+intensity_arc: [1, 2, 4, 5, 3]
+elephant:
+  scene_type: crisis_visit
+  alert_triggered: true
+  alert_at_phase: peak
+  alert_onset_fraction: 0.60
+  attack_type: PHYS_WEAP
+target_duration_minutes: 3.0
+min_pre_alert_seconds: 60
+acoustic_scene:
+  room_type: welfare_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.5
+  victim_distance_meters: 1.0
+  snr_target_db: 20
+  rt60_range: [0.18, 0.32]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -38
+      loop: true
+    - type: ACOU_THROW
+      onset_at_phase: escalation
+      onset_offset_seconds: 5.0
+      asset_path: null
+    - type: ACOU_BREAK
+      onset_at_phase: peak
+      onset_offset_seconds: 1.5
+      asset_path: null
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_it_b_0001.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_it_b_0001.yaml
@@ -1,0 +1,41 @@
+scene_id: SP_IT_B_0001
+project: she_proves
+language: he
+violence_typology: IT
+tier: B
+random_seed: 101
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/intimate_terror_coercive_control.j2
+script_slots:
+  relationship: spouse
+  setting: small_bedroom
+  grievance: coming_home_late
+intensity_arc: [1, 2, 3, 4, 5, 4, 3]
+she_proves:
+  incident_window_start_fraction: 0.35
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation, peak]
+  post_incident_phases: [aftermath, de-escalation]
+target_duration_minutes: 4.0
+min_pre_incident_seconds: 80
+acoustic_scene:
+  room_type: small_bedroom
+  device: phone_in_pocket
+  speaker_distance_meters: 2.0
+  victim_distance_meters: 1.5
+  snr_target_db: 18
+  rt60_range: [0.22, 0.38]
+  background_events:
+    - type: tv_ambient
+      onset_seconds: 0.0
+      level_db: -32
+      loop: true
+    - type: ACOU_SLAM
+      onset_at_phase: peak
+      onset_offset_seconds: 3.0
+      asset_path: null
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_it_b_0002.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_it_b_0002.yaml
@@ -1,0 +1,41 @@
+scene_id: SP_IT_B_0002
+project: she_proves
+language: he
+violence_typology: IT
+tier: B
+random_seed: 102
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/intimate_terror_isolation_tactics.j2
+script_slots:
+  relationship: spouse
+  setting: apartment_kitchen
+  grievance: contact_with_family
+intensity_arc: [1, 2, 3, 4, 5, 3]
+she_proves:
+  incident_window_start_fraction: 0.40
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation, peak]
+  post_incident_phases: [aftermath]
+target_duration_minutes: 3.5
+min_pre_incident_seconds: 70
+acoustic_scene:
+  room_type: apartment_kitchen
+  device: phone_in_hand
+  speaker_distance_meters: 1.5
+  victim_distance_meters: 1.0
+  snr_target_db: 15
+  rt60_range: [0.18, 0.32]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -38
+      loop: true
+    - type: ACOU_BREAK
+      onset_at_phase: peak
+      onset_offset_seconds: 2.0
+      asset_path: null
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_neg_b_0001.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_neg_b_0001.yaml
@@ -1,0 +1,36 @@
+scene_id: SP_NEG_B_0001
+project: she_proves
+language: he
+violence_typology: NEG
+tier: B
+random_seed: 301
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/negative_argument_deescalation.j2
+script_slots:
+  relationship: spouse
+  setting: small_bedroom
+  grievance: household_chores
+intensity_arc: [1, 2, 3, 3, 2, 1]
+she_proves:
+  incident_window_start_fraction: 0.50
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation]
+  post_incident_phases: [de-escalation]
+target_duration_minutes: 3.0
+acoustic_scene:
+  room_type: small_bedroom
+  device: phone_in_hand
+  speaker_distance_meters: 1.5
+  victim_distance_meters: 1.2
+  snr_target_db: 16
+  rt60_range: [0.20, 0.38]
+  background_events:
+    - type: tv_ambient
+      onset_seconds: 0.0
+      level_db: -35
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_neg_b_0002.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_neg_b_0002.yaml
@@ -1,0 +1,36 @@
+scene_id: SP_NEG_B_0002
+project: she_proves
+language: he
+violence_typology: NEG
+tier: B
+random_seed: 302
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/negative_third_party_intervention.j2
+script_slots:
+  relationship: spouse
+  setting: apartment_kitchen
+  grievance: financial_disagreement
+intensity_arc: [2, 3, 3, 2, 1]
+she_proves:
+  incident_window_start_fraction: 0.45
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation]
+  post_incident_phases: [de-escalation]
+target_duration_minutes: 3.5
+acoustic_scene:
+  room_type: apartment_kitchen
+  device: phone_on_table
+  speaker_distance_meters: 1.8
+  victim_distance_meters: 1.4
+  snr_target_db: 14
+  rt60_range: [0.16, 0.30]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -40
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_neu_b_0001.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_neu_b_0001.yaml
@@ -1,0 +1,33 @@
+scene_id: SP_NEU_B_0001
+project: she_proves
+language: he
+violence_typology: NEU
+tier: B
+random_seed: 401
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/neutral_domestic_routine.j2
+script_slots: {}
+intensity_arc: [1, 1, 1, 2, 1]
+she_proves:
+  incident_window_start_fraction: 0.90
+  pre_incident_phases: [baseline]
+  incident_phases: []
+  post_incident_phases: []
+target_duration_minutes: 3.0
+acoustic_scene:
+  room_type: apartment_kitchen
+  device: phone_in_hand
+  speaker_distance_meters: 1.2
+  victim_distance_meters: 1.0
+  snr_target_db: 12
+  rt60_range: [0.16, 0.28]
+  background_events:
+    - type: tv_ambient
+      onset_seconds: 0.0
+      level_db: -30
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_neu_b_0002.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_neu_b_0002.yaml
@@ -1,0 +1,33 @@
+scene_id: SP_NEU_B_0002
+project: she_proves
+language: he
+violence_typology: NEU
+tier: B
+random_seed: 402
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/neutral_family_coordination.j2
+script_slots: {}
+intensity_arc: [1, 1, 2, 1, 1]
+she_proves:
+  incident_window_start_fraction: 0.95
+  pre_incident_phases: [baseline]
+  incident_phases: []
+  post_incident_phases: []
+target_duration_minutes: 3.5
+acoustic_scene:
+  room_type: small_bedroom
+  device: phone_on_table
+  speaker_distance_meters: 1.0
+  victim_distance_meters: 0.8
+  snr_target_db: 10
+  rt60_range: [0.20, 0.36]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -42
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_sv_b_0001.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_sv_b_0001.yaml
@@ -1,0 +1,45 @@
+scene_id: SP_SV_B_0001
+project: she_proves
+language: he
+violence_typology: SV
+tier: B
+random_seed: 201
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/physical_assault_escalation.j2
+script_slots:
+  relationship: spouse
+  setting: living_room
+  grievance: money_dispute
+intensity_arc: [2, 3, 4, 5, 4, 2]
+she_proves:
+  incident_window_start_fraction: 0.30
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation, peak]
+  post_incident_phases: [aftermath]
+target_duration_minutes: 3.5
+min_pre_incident_seconds: 60
+acoustic_scene:
+  room_type: living_room
+  device: phone_on_table
+  speaker_distance_meters: 2.5
+  victim_distance_meters: 2.0
+  snr_target_db: 20
+  rt60_range: [0.32, 0.55]
+  background_events:
+    - type: tv_ambient
+      onset_seconds: 0.0
+      level_db: -28
+      loop: true
+    - type: ACOU_THROW
+      onset_at_phase: escalation
+      onset_offset_seconds: 5.0
+      asset_path: null
+    - type: ACOU_FALL
+      onset_at_phase: peak
+      onset_offset_seconds: 2.0
+      asset_path: null
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_sv_b_0002.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_sv_b_0002.yaml
@@ -1,0 +1,41 @@
+scene_id: SP_SV_B_0002
+project: she_proves
+language: he
+violence_typology: SV
+tier: B
+random_seed: 202
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/physical_threat_object_use.j2
+script_slots:
+  relationship: partner
+  setting: living_room
+  grievance: jealousy_accusation
+intensity_arc: [1, 2, 4, 5, 3]
+she_proves:
+  incident_window_start_fraction: 0.25
+  pre_incident_phases: [baseline]
+  incident_phases: [tension, escalation, peak]
+  post_incident_phases: [aftermath]
+target_duration_minutes: 3.0
+min_pre_incident_seconds: 45
+acoustic_scene:
+  room_type: living_room
+  device: phone_in_pocket
+  speaker_distance_meters: 3.0
+  victim_distance_meters: 2.5
+  snr_target_db: 22
+  rt60_range: [0.30, 0.58]
+  background_events:
+    - type: ACOU_SLAM
+      onset_at_phase: tension
+      onset_offset_seconds: 4.0
+      asset_path: null
+    - type: ACOU_BREAK
+      onset_at_phase: peak
+      onset_offset_seconds: 1.0
+      asset_path: null
+output_dir: data/he

--- a/docs/design_approaches.md
+++ b/docs/design_approaches.md
@@ -62,13 +62,18 @@ All generated datasets must conform to:
 
 Every element of a generated clip — script, voices, acoustic environment, label — is determined by a declarative YAML/JSON configuration. The pipeline is a pure function of its config: given the same config and a fixed random seed, you get the same dataset. This makes it straightforward to reproduce, diff, and improve.
 
-The architecture decomposes into four independent, swappable stages:
+The architecture decomposes into five sequential stages (Stage 3 and Stage 4 each have sub-stages):
 
 ```
-ScriptConfig → [Script Generator] → dialogue JSON
-dialogue JSON → [TTS Renderer]     → per-speaker WAV segments
-segments      → [Acoustic Augmenter] → augmented scene WAV
-scene WAV     → [Label Generator]  → AVDP-schema JSONL metadata
+SceneConfig (YAML)
+  → [1]  Script Generator      → DialogueTurns      (LLM fills Jinja2 template)
+  → [2]  TTS Renderer          → MixedScene WAV     (per-speaker segments mixed)
+  → [3a] Preprocessing         → spec-compliant WAV (16 kHz, mono, normalized, silence-padded)
+  → [3b] Acoustic Augmentation → augmented WAV      (room IR, device profile, noise) — Tier B only
+  → [4a] Transcript Writer     → {clip_id}.txt      (per-turn text with onset/offset markers)
+  → [4b] Strong Label Writer   → {clip_id}.jsonl    (per-event EventLabel records)
+  → [4c] Metadata Writer       → {clip_id}.json     (ClipMetadata — weak labels, speaker info)
+  → [5]  Validator             → pass/fail + warnings
 ```
 
 Each stage is a Python module with a clean interface; teams can develop and test stages in isolation.
@@ -77,12 +82,12 @@ Each stage is a Python module with a clean interface; teams can develop and test
 
 | Stage | Primary Tools | Notes |
 |---|---|---|
-| Script generation | Claude API / GPT-4 API, Jinja2 templates, hand-authored Hebrew scene templates | LLM fills parameterized template slots; always constrained by a config schema |
-| Hebrew TTS | Azure Cognitive Services (he-IL voices, SSML), Google Cloud TTS (Chirp 3 HD, he-IL) | Azure SSML supports multi-speaker, style tags, pitch/rate/volume control; compare expressiveness in evaluation |
-| Acoustic augmentation | `pydub`, `pyroomacoustics`, `torchaudio`, `sox`/`ffmpeg` | Room IR simulation, device codec emulation, SNR degradation |
-| Soundscape / noise mixing | `Scaper`, MUSAN corpus, Freesound-licensed clips | Background TV, traffic, office chatter, appliances |
-| Label generation | Python, auto-derived from script + augmentation logs | Onset/offset precise because TTS + augmentation are fully logged |
-| Dataset packaging | Python, JSONL, CSV manifests | AVDP directory structure, manifest for weak/strong labels, split stratification |
+| 1 — Script generation | Claude API / GPT-4 API, Jinja2 templates, hand-authored Hebrew scene templates | LLM fills parameterized template slots; always constrained by a config schema |
+| 2 — Hebrew TTS | Azure Cognitive Services (he-IL voices, SSML), Google Cloud TTS (Chirp 3 HD, he-IL) | Azure SSML supports multi-speaker, style tags, pitch/rate/volume control |
+| 3a — Preprocessing | `scipy`, `soundfile` (no torchaudio) | Resample → downmix → low-pass → Wiener denoise → normalize → silence pad |
+| 3b — Acoustic augmentation | `pyroomacoustics`, `synthbanshee.augment` | Room IR simulation (ISM), device codec emulation, SNR degradation — Tier B only |
+| 4a–4c — Label generation | Python, auto-derived from script + augmentation logs | Onset/offset precise because TTS mixer + Stage 3b are fully logged |
+| 5 — Validation & packaging | Python, JSONL, CSV manifests | validate_clip(), manifest CSV, speaker-disjoint splits |
 
 #### Config Schema Sketch
 

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -17,7 +17,7 @@
 
 **Labels derive from structure, not from post-hoc review.** Tier A labels are auto-generated from the scene script and augmentation log. Human review is reserved for validation, not primary labeling. This keeps the labeling bottleneck out of the critical path.
 
-**Develop in modules, test in integration.** Each pipeline stage (script generation, TTS rendering, augmentation, labeling, packaging) has its own interface and tests. Integration is a separate step.
+**Develop in modules, test in integration.** Each pipeline stage (Stage 1: script generation, Stage 2: TTS rendering, Stage 3a/3b: preprocessing and acoustic augmentation, Stage 4a–4c: labeling and transcript, Stage 5: validation and packaging) has its own interface and tests. Integration is a separate step.
 
 ---
 

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -277,7 +277,7 @@ Each template defines:
 
 **Acceptance criteria:** QA suite passes with < 1% clip failure rate; statistics report shows balanced distribution across stratification variables; AI teams confirm they can load the dataset.
 
-**✓ Complete** — `run_qa()` in `synthbanshee/package/qa.py` validates every clip via `validate_clip()`, re-parses `ClipMetadata`, accumulates `DatasetStats` (total/failed clips, duration, typology/split/speaker counts, quality-flagged clips), and returns a `QAReport` (pass/fail based on configurable `max_failure_rate`, default 2%). `qa-report` CLI command prints a Rich table summary and optionally writes a JSON report file; exits 1 if the report fails. `generate_manifest()` in `synthbanshee/package/manifest.py` produces a flat CSV with 11 columns (clip_id, project, violence_typology, tier, duration_seconds, speaker_ids, has_violence, max_intensity, quality_flags, split, wav_path).
+**✓ Complete** — `run_qa()` in `synthbanshee/package/qa.py` validates every clip via `validate_clip()`, re-parses `ClipMetadata`, accumulates `DatasetStats` (total/failed clips, duration, typology/split/speaker counts, quality-flagged clips), and returns a `QAReport` (pass/fail based on configurable `max_failure_rate`, default 2%). `qa-report` CLI command prints a Rich table summary and optionally writes a JSON report file; exits 1 if the report fails. `generate_manifest()` in `synthbanshee/package/manifest.py` produces a flat CSV with 12 columns (clip_id, project, violence_typology, tier, duration_seconds, speaker_ids, has_violence, max_intensity, quality_flags, split, wav_path, strong_labels_path).
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -308,7 +308,7 @@ Every clip has a companion `{clip_id}.json` file with this schema:
 
 ### 5.2 Per-Event Strong Labels (JSONL)
 
-One record per labeled event, stored **per-clip** as `{clip_id}.jsonl` in the same directory as the corresponding `.wav`, `.txt`, and `.json` files. The pipeline writes this file automatically at generation time (Stage 4). Each line is a JSON object:
+One record per labeled event, stored **per-clip** as `{clip_id}.jsonl` in the same directory as the corresponding `.wav`, `.txt`, and `.json` files. The pipeline writes this file automatically during Stage 4b (Strong Label Writer). Each line is a JSON object:
 
 ```json
 {

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -28,11 +28,11 @@ data/
       {clip_id}.wav
       {clip_id}.txt         ← transcript (UTF-8, Hebrew in he-IL clips)
       {clip_id}.json        ← per-clip metadata (see §5)
+      {clip_id}.jsonl       ← per-clip strong labels, one event per line (see §5.2)
 
 metadata/
-  {split}_manifest.csv      ← clip-level manifest for train/val/test splits
+  {split}_manifest.csv      ← clip-level manifest for train/val/test splits (see §5.3)
   {split}_labels_weak.jsonl ← weak (clip-level) labels
-  {split}_labels_strong.jsonl ← strong (event-level) labels with onset/offset
 
 configs/
   scenes/                   ← scene YAML configs used to generate each clip
@@ -308,7 +308,7 @@ Every clip has a companion `{clip_id}.json` file with this schema:
 
 ### 5.2 Per-Event Strong Labels (JSONL)
 
-One record per labeled event, stored in `metadata/{split}_labels_strong.jsonl`. Each line is a JSON object:
+One record per labeled event, stored **per-clip** as `{clip_id}.jsonl` in the same directory as the corresponding `.wav`, `.txt`, and `.json` files. The pipeline writes this file automatically at generation time (Stage 4). Each line is a JSON object:
 
 ```json
 {
@@ -337,13 +337,14 @@ One manifest CSV per generation run, written to the output directory (e.g. `data
 One row per clip, for fast dataset loading:
 
 ```
-clip_id, project, violence_typology, tier, duration_seconds, speaker_ids, has_violence, max_intensity, quality_flags, split, wav_path
+clip_id, project, violence_typology, tier, duration_seconds, speaker_ids, has_violence, max_intensity, quality_flags, split, wav_path, strong_labels_path
 ```
 
 - `speaker_ids`: pipe-separated list of `speaker_id` values (e.g. `AGG_M_30-45_001|VIC_F_25-40_002`)
 - `quality_flags`: comma-separated list of flag strings, empty string if none
 - `split`: `train` | `val` | `test`, or empty string if unassigned
-- `wav_path`: path to the `.wav` file; `.txt` and `.json` share the same stem
+- `wav_path`: path to the `.wav` file; `.txt`, `.json`, and `.jsonl` share the same stem
+- `strong_labels_path`: path to the per-clip `.jsonl` strong-labels file, or empty string if absent
 - `language` is implicit in the `data/{language_code}/` directory structure and omitted from the manifest
 - `violence_categories` and the redundant `txt_path`/`json_path` columns from the original spec are superseded by this schema
 

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -219,6 +219,13 @@ def _run_generate_pipeline(
                     _np.float32
                 )
 
+            # Restore silence padding regions that ambient mixing or room reverb tails
+            # may have contaminated.  validate_audio() requires the first and last
+            # silence_pad_applied_s seconds to remain below −40 dBFS.
+            pad_n = int(result.silence_pad_applied_s * audio_sr)
+            aug_samples[:pad_n] = 0.0
+            aug_samples[-pad_n:] = 0.0
+
             # Peak-normalize augmented signal to −1.0 dBFS
             peak = float(_np.max(_np.abs(aug_samples)))
             if peak > 0.0:
@@ -226,11 +233,10 @@ def _run_generate_pipeline(
                 aug_samples = (aug_samples * (target_peak / peak)).astype(_np.float32)
             _sf.write(str(clip_wav), aug_samples, audio_sr, subtype="PCM_16")
 
-            ir_src = getattr(scene.acoustic_scene, "ir_source", None) or "pyroomacoustics_ism"
             acoustic_scene_meta = ClipAcousticScene(
                 room_type=scene.acoustic_scene.room_type,
                 device=scene.acoustic_scene.device,
-                ir_source=ir_src,
+                ir_source="pyroomacoustics_ism",
                 speaker_distance_meters=scene.acoustic_scene.speaker_distance_meters,
                 snr_db_actual=round(snr_actual, 2),
                 background_events=[

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -103,6 +103,7 @@ def _run_generate_pipeline(
     from synthbanshee.script.generator import ScriptGenerator
     from synthbanshee.tts.renderer import TTSRenderer
 
+    # Pre-pipeline: load configs (not a numbered stage — no data transformation occurs)
     # 1. Load scene config
     try:
         scene = SceneConfig.from_yaml(config)
@@ -122,6 +123,7 @@ def _run_generate_pipeline(
         except Exception as exc:
             return None, [f"Speaker config parse error: {exc}"]
 
+    # Stage 1 — Script Generation
     # 3. Generate script
     script_gen = ScriptGenerator(cache_dir=script_cache_dir)
     try:
@@ -148,6 +150,7 @@ def _run_generate_pipeline(
     except Exception as exc:
         return None, [f"Script generation error: {exc}"]
 
+    # Stage 2 — TTS Rendering
     # 4. Render multi-speaker scene
     renderer = TTSRenderer(cache_dir=cache_dir)
     try:
@@ -160,6 +163,7 @@ def _run_generate_pipeline(
     except Exception as exc:
         return None, [f"TTS render error: {exc}"]
 
+    # Stage 3a — Preprocessing
     # 5. Write raw mix to temp WAV, preprocess to final output path
     clip_id = scene.scene_id.lower().replace("-", "_")
     first_speaker_ref = scene.speakers[0]
@@ -176,7 +180,8 @@ def _run_generate_pipeline(
     except Exception as exc:
         return None, [f"Pipeline error: {exc}"]
 
-    # 5b. Stage 3 (Tier B): Room simulation → device profile → noise mix
+    # Stage 3b — Acoustic Augmentation (Tier B only)
+    # 5b. Room simulation → device profile → noise mix
     #
     # Stage 3 receives the fully preprocessed (16 kHz, mono, silence-padded) WAV.
     # NoiseMixer therefore operates on padded audio, so its returned AugmentedEvent
@@ -259,6 +264,7 @@ def _run_generate_pipeline(
         except Exception as exc:
             return None, [f"Acoustic augmentation error: {exc}"]
 
+    # Stage 4a — Transcript
     # 6. Write structured multi-speaker transcript
     # preprocess() prepends result.silence_pad_applied_s of silence unconditionally,
     # so all MixedScene timings must be shifted forward by that amount.
@@ -281,6 +287,7 @@ def _run_generate_pipeline(
         lines.append(f"[ACTION: {tier2} | INTENSITY: {turn.intensity}]")
     clip_txt.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
+    # Stage 4b — Strong Labels
     # 7. Build per-turn event labels from MixedScene timing (authoritative per spec)
     # Same pad_s offset applied here to match the processed audio.
     events: list[ScriptEvent] = []
@@ -304,7 +311,7 @@ def _run_generate_pipeline(
                 emotional_state=turn.emotional_state,
             )
         )
-    # Stage 3 ACOU_* SFX events (Tier B only). Their onset/offset times are
+    # Stage 3b ACOU_* SFX events (Tier B only). Their onset/offset times are
     # already in padded-audio coordinates — no pad_s shift needed.
     for aug_ev in _aug_acou_events:
         events.append(
@@ -320,10 +327,11 @@ def _run_generate_pipeline(
 
     event_labels = label_gen.generate_event_labels(f"{clip_id}_00", events)
 
-    # 7b. Write per-clip strong labels JSONL alongside the WAV
+    # 7b. Write per-clip strong labels JSONL alongside the WAV (Stage 4b output)
     clip_jsonl = speaker_dir / f"{clip_id}_00.jsonl"
     label_gen.write_strong_labels_jsonl(event_labels, clip_jsonl)
 
+    # Stage 4c — Clip Metadata JSON
     # 8. Write clip metadata JSON
     speakers_meta = [
         SpeakerInfo(
@@ -360,6 +368,7 @@ def _run_generate_pipeline(
     )
     label_gen.write_clip_metadata_json(metadata, clip_json)
 
+    # Stage 5 — Validation
     # 9. Validate
     validation = validate_clip(clip_wav)
     if not validation.is_valid:
@@ -821,6 +830,12 @@ def qa_report(data_dir: Path, output: Path | None, max_failure_rate: float) -> N
     )
     table.add_row("Unique speakers", str(stats.speaker_count))
     table.add_row("Quality-flagged", str(stats.quality_flagged_clips))
+    missing_jsonl_label = (
+        f"[yellow]{stats.clips_missing_strong_labels}[/yellow]"
+        if stats.clips_missing_strong_labels > 0
+        else "0"
+    )
+    table.add_row("Missing strong-labels JSONL (Stage 4b)", missing_jsonl_label)
     console.print(table)
 
     if stats.clips_by_typology:
@@ -858,6 +873,7 @@ def qa_report(data_dir: Path, output: Path | None, max_failure_rate: float) -> N
                 "total_duration_seconds": stats.total_duration_seconds,
                 "speaker_count": stats.speaker_count,
                 "quality_flagged_clips": stats.quality_flagged_clips,
+                "clips_missing_strong_labels": stats.clips_missing_strong_labels,
                 "clips_by_typology": stats.clips_by_typology,
                 "clips_by_split": stats.clips_by_split,
                 "clips_by_tier": stats.clips_by_tier,

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -178,9 +178,13 @@ def _run_generate_pipeline(
 
     # 5b. Stage 3 (Tier B): Room simulation → device profile → noise mix
     #
-    # Runs on the fully preprocessed audio (16 kHz mono, silence-padded).
-    # AugmentedEvent onset/offset times are therefore already in padded-audio
-    # coordinates and must NOT receive the extra pad_s offset that speech turns do.
+    # Stage 3 receives the fully preprocessed (16 kHz, mono, silence-padded) WAV.
+    # NoiseMixer therefore operates on padded audio, so its returned AugmentedEvent
+    # onset/offset values are measured from the start of the *padded* clip — they are
+    # already in final clip coordinates and must NOT be shifted by pad_s again.
+    # (This differs from the AugmentedEvent docstring convention, which assumes
+    # NoiseMixer receives the raw un-padded MixedScene.  Here we pass padded audio
+    # intentionally so the placed events align with audible speech, not with silence.)
     acoustic_scene_meta = None
     _aug_acou_events: list = []  # ACOU_* SFX events for strong-label generation
     if scene.tier == "B" and scene.acoustic_scene is not None:
@@ -191,9 +195,11 @@ def _run_generate_pipeline(
             from synthbanshee.augment.device_profiles import DeviceProfiler
             from synthbanshee.augment.noise_mixer import NoiseMixer
             from synthbanshee.augment.room_sim import RoomSimulator
+            from synthbanshee.config.taxonomy import tier2_subtype_codes
             from synthbanshee.labels.schema import ClipAcousticScene
 
             audio_data, audio_sr = _sf.read(str(clip_wav), dtype="float32", always_2d=False)
+            n_orig = len(audio_data)
             reverbed = RoomSimulator().apply(
                 audio_data, audio_sr, scene.acoustic_scene, rng_seed=scene.random_seed
             )
@@ -204,6 +210,15 @@ def _run_generate_pipeline(
                 device_colored, audio_sr, scene.acoustic_scene, rng_seed=scene.random_seed
             )
 
+            # Enforce exact length match with the input WAV so metadata.duration_seconds
+            # and transcript timings remain consistent after the write-back.
+            if len(aug_samples) > n_orig:
+                aug_samples = aug_samples[:n_orig]
+            elif len(aug_samples) < n_orig:
+                aug_samples = _np.pad(aug_samples, (0, n_orig - len(aug_samples))).astype(
+                    _np.float32
+                )
+
             # Peak-normalize augmented signal to −1.0 dBFS
             peak = float(_np.max(_np.abs(aug_samples)))
             if peak > 0.0:
@@ -211,10 +226,11 @@ def _run_generate_pipeline(
                 aug_samples = (aug_samples * (target_peak / peak)).astype(_np.float32)
             _sf.write(str(clip_wav), aug_samples, audio_sr, subtype="PCM_16")
 
+            ir_src = getattr(scene.acoustic_scene, "ir_source", None) or "pyroomacoustics_ism"
             acoustic_scene_meta = ClipAcousticScene(
                 room_type=scene.acoustic_scene.room_type,
                 device=scene.acoustic_scene.device,
-                ir_source="pyroomacoustics_ism",
+                ir_source=ir_src,
                 speaker_distance_meters=scene.acoustic_scene.speaker_distance_meters,
                 snr_db_actual=round(snr_actual, 2),
                 background_events=[
@@ -227,8 +243,13 @@ def _run_generate_pipeline(
                     for ev in aug_events
                 ],
             )
-            # Keep only foreground ACOU_* SFX for strong-label generation
-            _aug_acou_events = [ev for ev in aug_events if ev.type.startswith("ACOU_")]
+            # Keep foreground ACOU_* SFX that are valid taxonomy tier2 codes.
+            # Unknown/mis-typed ACOU_* values are silently dropped rather than
+            # crashing label generation with a cryptic validation error.
+            _valid_tier2 = tier2_subtype_codes()
+            _aug_acou_events = [
+                ev for ev in aug_events if ev.type.startswith("ACOU_") and ev.type in _valid_tier2
+            ]
         except Exception as exc:
             return None, [f"Acoustic augmentation error: {exc}"]
 

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -320,6 +320,10 @@ def _run_generate_pipeline(
 
     event_labels = label_gen.generate_event_labels(f"{clip_id}_00", events)
 
+    # 7b. Write per-clip strong labels JSONL alongside the WAV
+    clip_jsonl = speaker_dir / f"{clip_id}_00.jsonl"
+    label_gen.write_strong_labels_jsonl(event_labels, clip_jsonl)
+
     # 8. Write clip metadata JSON
     speakers_meta = [
         SpeakerInfo(

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -236,7 +236,7 @@ def _run_generate_pipeline(
             acoustic_scene_meta = ClipAcousticScene(
                 room_type=scene.acoustic_scene.room_type,
                 device=scene.acoustic_scene.device,
-                ir_source="pyroomacoustics_ism",
+                ir_source=scene.acoustic_scene.ir_source,
                 speaker_distance_meters=scene.acoustic_scene.speaker_distance_meters,
                 snr_db_actual=round(snr_actual, 2),
                 background_events=[

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -176,6 +176,62 @@ def _run_generate_pipeline(
     except Exception as exc:
         return None, [f"Pipeline error: {exc}"]
 
+    # 5b. Stage 3 (Tier B): Room simulation → device profile → noise mix
+    #
+    # Runs on the fully preprocessed audio (16 kHz mono, silence-padded).
+    # AugmentedEvent onset/offset times are therefore already in padded-audio
+    # coordinates and must NOT receive the extra pad_s offset that speech turns do.
+    acoustic_scene_meta = None
+    _aug_acou_events: list = []  # ACOU_* SFX events for strong-label generation
+    if scene.tier == "B" and scene.acoustic_scene is not None:
+        try:
+            import numpy as _np
+            import soundfile as _sf
+
+            from synthbanshee.augment.device_profiles import DeviceProfiler
+            from synthbanshee.augment.noise_mixer import NoiseMixer
+            from synthbanshee.augment.room_sim import RoomSimulator
+            from synthbanshee.labels.schema import ClipAcousticScene
+
+            audio_data, audio_sr = _sf.read(str(clip_wav), dtype="float32", always_2d=False)
+            reverbed = RoomSimulator().apply(
+                audio_data, audio_sr, scene.acoustic_scene, rng_seed=scene.random_seed
+            )
+            device_colored = DeviceProfiler().apply(
+                reverbed, audio_sr, scene.acoustic_scene.device, rng_seed=scene.random_seed
+            )
+            aug_samples, aug_events, snr_actual = NoiseMixer().mix(
+                device_colored, audio_sr, scene.acoustic_scene, rng_seed=scene.random_seed
+            )
+
+            # Peak-normalize augmented signal to −1.0 dBFS
+            peak = float(_np.max(_np.abs(aug_samples)))
+            if peak > 0.0:
+                target_peak = 10.0 ** (-1.0 / 20.0)
+                aug_samples = (aug_samples * (target_peak / peak)).astype(_np.float32)
+            _sf.write(str(clip_wav), aug_samples, audio_sr, subtype="PCM_16")
+
+            acoustic_scene_meta = ClipAcousticScene(
+                room_type=scene.acoustic_scene.room_type,
+                device=scene.acoustic_scene.device,
+                ir_source="pyroomacoustics_ism",
+                speaker_distance_meters=scene.acoustic_scene.speaker_distance_meters,
+                snr_db_actual=round(snr_actual, 2),
+                background_events=[
+                    {
+                        "type": ev.type,
+                        "onset": round(ev.onset_s, 3),
+                        "offset": round(ev.offset_s, 3),
+                        "level_db": round(ev.level_db, 1),
+                    }
+                    for ev in aug_events
+                ],
+            )
+            # Keep only foreground ACOU_* SFX for strong-label generation
+            _aug_acou_events = [ev for ev in aug_events if ev.type.startswith("ACOU_")]
+        except Exception as exc:
+            return None, [f"Acoustic augmentation error: {exc}"]
+
     # 6. Write structured multi-speaker transcript
     # preprocess() prepends result.silence_pad_applied_s of silence unconditionally,
     # so all MixedScene timings must be shifted forward by that amount.
@@ -221,6 +277,20 @@ def _run_generate_pipeline(
                 emotional_state=turn.emotional_state,
             )
         )
+    # Stage 3 ACOU_* SFX events (Tier B only). Their onset/offset times are
+    # already in padded-audio coordinates — no pad_s shift needed.
+    for aug_ev in _aug_acou_events:
+        events.append(
+            ScriptEvent(
+                tier1_category="ACOU",
+                tier2_subtype=aug_ev.type,
+                onset=aug_ev.onset_s,
+                offset=max(aug_ev.offset_s, aug_ev.onset_s + 0.1),
+                intensity=3,  # default mid-intensity for physical SFX events
+                notes="sfx_augmentation",
+            )
+        )
+
     event_labels = label_gen.generate_event_labels(f"{clip_id}_00", events)
 
     # 8. Write clip metadata JSON
@@ -255,6 +325,7 @@ def _run_generate_pipeline(
         preprocessing=preprocessing_meta,
         dirty_file_path=str(result.dirty_path) if result.dirty_path else None,
         transcript_path=str(clip_txt),
+        acoustic_scene=acoustic_scene_meta,
     )
     label_gen.write_clip_metadata_json(metadata, clip_json)
 

--- a/synthbanshee/config/acoustic_config.py
+++ b/synthbanshee/config/acoustic_config.py
@@ -58,7 +58,7 @@ class AcousticSceneConfig(BaseModel):
     device: str
     speaker_distance_meters: float = Field(gt=0)
     victim_distance_meters: float = Field(gt=0)
-    ir_source: str = "pyroomacoustics"
+    ir_source: str = "pyroomacoustics_ism"
     room_dimensions_range: RoomDimensionsRange | None = None
     rt60_range: Annotated[list[float], Field(min_length=2, max_length=2)] | None = None
     background_events: list[BackgroundEvent] = Field(default_factory=list)

--- a/synthbanshee/package/manifest.py
+++ b/synthbanshee/package/manifest.py
@@ -27,6 +27,7 @@ _MANIFEST_COLUMNS = [
     "quality_flags",
     "split",
     "wav_path",
+    "strong_labels_path",
 ]
 
 
@@ -45,6 +46,7 @@ class ManifestRow:
     quality_flags: str  # comma-separated, empty string if none
     split: str  # "train" | "val" | "test" | "" (empty if unassigned)
     wav_path: str
+    strong_labels_path: str  # path to .jsonl, empty string if absent
 
 
 def generate_manifest(
@@ -90,6 +92,7 @@ def generate_manifest(
         if not json_path.with_suffix(".wav").exists():
             continue
 
+        jsonl_path = json_path.with_suffix(".jsonl")
         rows.append(
             ManifestRow(
                 clip_id=metadata.clip_id,
@@ -103,6 +106,7 @@ def generate_manifest(
                 quality_flags=",".join(metadata.quality_flags),
                 split=(splits or {}).get(metadata.clip_id, ""),
                 wav_path=str(json_path.with_suffix(".wav")),
+                strong_labels_path=str(jsonl_path) if jsonl_path.exists() else "",
             )
         )
 
@@ -124,6 +128,7 @@ def generate_manifest(
                     "quality_flags": row.quality_flags,
                     "split": row.split,
                     "wav_path": row.wav_path,
+                    "strong_labels_path": row.strong_labels_path,
                 }
             )
 

--- a/synthbanshee/package/qa.py
+++ b/synthbanshee/package/qa.py
@@ -4,14 +4,17 @@ Runs validate_clip() on every WAV in a data directory and accumulates
 aggregate statistics. Produces a QAReport that AI teams can inspect before
 loading the dataset for training.
 
-Checks performed per clip:
+Checks performed per clip (Stage 5 — Validation):
   1. All three required files present (.wav, .txt, .json)
   2. WAV: 16 kHz, mono, 16-bit PCM, −1.0 dBFS peak, ≥ 0.5 s silence padding
   3. Metadata JSON parses as ClipMetadata with is_synthetic=True
   4. Filename stem is ASCII-only lowercase
+  5. Strong labels JSONL present alongside the clip (warning — not a hard error)
 
 Dataset-level checks (via report.passed):
   - Failure rate ≤ max_failure_rate (default 2 %)
+  - clips_missing_strong_labels is reported for observability but does not
+    affect report.passed (missing JSONL is a warning, not a failure)
 """
 
 from __future__ import annotations
@@ -39,6 +42,7 @@ class DatasetStats:
     speaker_count: int = 0
     failed_clips: int = 0
     quality_flagged_clips: int = 0
+    clips_missing_strong_labels: int = 0  # Stage 4b JSONL absent (warning only)
 
 
 @dataclass
@@ -119,6 +123,10 @@ def run_qa(
         if metadata.quality_flags:
             stats.quality_flagged_clips += 1
             report.quality_flagged[metadata.clip_id] = list(metadata.quality_flags)
+
+        # Count Stage 4b JSONL warnings surfaced by validate_clip()
+        if any("Strong labels JSONL missing" in w for w in validation.warnings):
+            stats.clips_missing_strong_labels += 1
 
     stats.clips_by_typology = dict(_by_typology)
     stats.clips_by_split = dict(_by_split)

--- a/synthbanshee/package/validator.py
+++ b/synthbanshee/package/validator.py
@@ -52,6 +52,7 @@ def validate_clip(clip_path: Path | str) -> ValidationResult:
     parent = clip_path.parent
     txt_path = parent / f"{stem}.txt"
     json_path = parent / f"{stem}.json"
+    jsonl_path = parent / f"{stem}.jsonl"
 
     # ------------------------------------------------------------------
     # 1. Filename constraints (spec §2.5)
@@ -109,6 +110,12 @@ def validate_clip(clip_path: Path | str) -> ValidationResult:
         txt_path.read_text(encoding="utf-8")
     except Exception as exc:
         errors.append(f"Cannot read transcript: {exc}")
+
+    # ------------------------------------------------------------------
+    # 6. Strong labels JSONL (warning only — not a hard spec requirement)
+    # ------------------------------------------------------------------
+    if not jsonl_path.exists():
+        warnings.append(f"Strong labels JSONL missing: {jsonl_path}")
 
     return ValidationResult(
         is_valid=len(errors) == 0,

--- a/tests/integration/test_tier_b_pipeline.py
+++ b/tests/integration/test_tier_b_pipeline.py
@@ -1,0 +1,213 @@
+"""Integration test: Tier B end-to-end pipeline (strong labels + acoustic augmentation).
+
+Wires all four stages together for a Tier B scene config:
+  SceneConfig → ScriptGenerator (mocked) → TTSRenderer (mocked)
+  → preprocess() → RoomSimulator / DeviceProfiler / NoiseMixer (mocked)
+  → strong-labels JSONL → ClipMetadata JSON → validate_clip
+
+No real TTS or room-simulation credentials are required.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import wave
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import soundfile as sf
+
+from synthbanshee.cli import _run_generate_pipeline
+from synthbanshee.package.validator import validate_clip
+
+SCENES_DIR = Path(__file__).parent.parent.parent / "configs" / "scenes"
+TIER_B_SCENE = SCENES_DIR / "she_proves_tier_b" / "sp_sv_b_0001.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_wav_bytes(sample_rate: int = 24000, duration_s: float = 5.0) -> bytes:
+    n = int(sample_rate * duration_s)
+    buf = io.BytesIO()
+    with wave.open(buf, "w") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        t = np.linspace(0, duration_s, n, endpoint=False)
+        samples = (0.3 * np.sin(2 * np.pi * 440 * t) * 32767).astype(np.int16)
+        w.writeframes(samples.tobytes())
+    return buf.getvalue()
+
+
+def _make_mixed_scene(duration_s: float = 5.0):
+    """Return a MixedScene stub with two speaker turns for mocking render_scene."""
+    from synthbanshee.script.types import MixedScene
+
+    sr = 16_000
+    n = int(sr * duration_s)
+    samples = (0.3 * np.sin(2 * np.pi * 440 * np.linspace(0, duration_s, n))).astype(np.float32)
+    turn_dur = duration_s * 0.4
+    return MixedScene(
+        samples=samples,
+        sample_rate=sr,
+        turn_onsets_s=[0.3, 0.3 + turn_dur],
+        turn_offsets_s=[0.3 + turn_dur - 0.05, 0.3 + 2 * turn_dur - 0.05],
+        duration_s=duration_s,
+        speaker_ids=["AGG_M_30-45_001", "VIC_F_25-40_002"],
+    )
+
+
+def _make_dialogue_turns():
+    from synthbanshee.script.types import DialogueTurn
+
+    return [
+        DialogueTurn(speaker_id="AGG_M_30-45_001", text="תשלם לי!", intensity=4),
+        DialogueTurn(speaker_id="VIC_F_25-40_002", text="בבקשה, תרגע.", intensity=2),
+    ]
+
+
+def _build_aug_audio(mixed, pad_s: float = 0.5) -> np.ndarray:
+    """Build a valid augmented-audio array: sine in speech region, zeros in pads."""
+    sr = 16_000
+    pad_n = int(pad_s * sr)
+    total = mixed.samples.shape[0] + 2 * pad_n
+    audio = np.zeros(total, dtype=np.float32)
+    t = np.arange(mixed.samples.shape[0], dtype=np.float32) / sr
+    audio[pad_n : total - pad_n] = 0.5 * np.sin(2 * np.pi * 440 * t)
+    peak = float(np.max(np.abs(audio)))
+    if peak > 0.0:
+        audio = (audio * (10.0 ** (-1.0 / 20.0) / peak)).astype(np.float32)
+    return audio
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+class TestTierBPipeline:
+    def _run(self, tmp_path: Path, *, acou_events=None):
+        """Run the full Tier B pipeline and return (wav_path, errors)."""
+        from synthbanshee.augment.types import AugmentedEvent
+
+        mixed = _make_mixed_scene()
+        turns = _make_dialogue_turns()
+        aug_audio = _build_aug_audio(mixed)
+
+        if acou_events is None:
+            acou_events = []
+        aug_event_objs = [
+            AugmentedEvent(
+                type=ev["type"],
+                onset_s=ev["onset_s"],
+                offset_s=ev["offset_s"],
+                level_db=ev["level_db"],
+            )
+            for ev in acou_events
+        ]
+
+        with (
+            patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
+            patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
+            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
+            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
+            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+        ):
+            MockGen.return_value.generate.return_value = turns
+            MockRenderer.return_value.render_scene.return_value = mixed
+            MockRoom.return_value.apply.return_value = aug_audio
+            MockDevice.return_value.apply.return_value = aug_audio
+            MockMixer.return_value.mix.return_value = (aug_audio, aug_event_objs, 18.5)
+
+            return _run_generate_pipeline(
+                TIER_B_SCENE,
+                tmp_path / "out",
+                tmp_path / "cache",
+                tmp_path / "dirty",
+                tmp_path / "scripts",
+            )
+
+    def test_pipeline_succeeds(self, tmp_path):
+        """Tier B pipeline with mocked Stage 3 completes without errors."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        assert errors == []
+
+    def test_all_four_output_files_present(self, tmp_path):
+        """WAV, TXT, JSON, and JSONL are all written alongside each other."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        stem = wav.stem
+        parent = wav.parent
+        assert wav.exists(), "WAV missing"
+        assert (parent / f"{stem}.txt").exists(), "Transcript missing"
+        assert (parent / f"{stem}.json").exists(), "Metadata JSON missing"
+        assert (parent / f"{stem}.jsonl").exists(), "Strong labels JSONL missing"
+
+    def test_clip_passes_validator(self, tmp_path):
+        """The output clip (with JSONL present) passes validate_clip with no errors."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        result = validate_clip(wav)
+        assert result.is_valid, f"Validation errors: {result.errors}"
+        # JSONL present → no 'Strong labels JSONL missing' warning
+        jsonl_warnings = [w for w in result.warnings if "Strong labels JSONL missing" in w]
+        assert jsonl_warnings == [], f"Unexpected JSONL warning: {jsonl_warnings}"
+
+    def test_metadata_is_synthetic_and_tier_b(self, tmp_path):
+        """Clip metadata marks is_synthetic=True and tier='B'."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        assert meta["is_synthetic"] is True
+        assert meta["tier"] == "B"
+
+    def test_acoustic_scene_in_metadata(self, tmp_path):
+        """acoustic_scene block contains room_type, device, ir_source, snr_db_actual."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        scene = meta["acoustic_scene"]
+        assert scene["room_type"] == "living_room"
+        assert scene["device"] == "phone_on_table"
+        assert scene["ir_source"] == "pyroomacoustics_ism"
+        assert scene["snr_db_actual"] == 18.5
+
+    def test_acou_events_appear_in_weak_label(self, tmp_path):
+        """ACOU_* events from Stage 3 contribute 'ACOU' to weak_label.violence_categories."""
+        acou_events = [
+            {"type": "ACOU_THROW", "onset_s": 3.0, "offset_s": 3.4, "level_db": -20.0},
+        ]
+        wav, errors = self._run(tmp_path, acou_events=acou_events)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        assert "ACOU" in meta["weak_label"]["violence_categories"]
+
+    def test_strong_labels_jsonl_is_valid_json_lines(self, tmp_path):
+        """Every line in the JSONL is parseable JSON with required event fields."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        jsonl_path = wav.with_suffix(".jsonl")
+        assert jsonl_path.exists()
+        lines = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) > 0, "JSONL must not be empty"
+        for line in lines:
+            record = json.loads(line)
+            assert "clip_id" in record
+            assert "onset" in record
+            assert "offset" in record
+            assert "tier1_category" in record
+
+    def test_wav_is_spec_compliant(self, tmp_path):
+        """Output WAV is 16 kHz, mono, with non-zero peak-normalized audio."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        data, sr = sf.read(str(wav))
+        assert sr == 16_000
+        assert data.ndim == 1  # mono
+        assert float(np.max(np.abs(data))) > 0.0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1157,7 +1157,7 @@ class TestRunGeneratePipelineTierB:
         scene = meta["acoustic_scene"]
         assert scene["room_type"] == "small_bedroom"
         assert scene["device"] == "phone_in_hand"
-        assert scene["ir_source"] == "pyroomacoustics"  # value from AcousticSceneConfig default
+        assert scene["ir_source"] == "pyroomacoustics_ism"
         assert scene["speaker_distance_meters"] == 1.5
 
     def test_tier_b_snr_db_actual_in_metadata(self, tmp_path):
@@ -1252,3 +1252,24 @@ class TestRunGeneratePipelineTierB:
         assert wav is not None, errors
         data, _ = _sf.read(str(wav))
         assert abs(len(data) / sr - 6.0) < 0.05
+
+    def test_tier_b_pad_regions_zeroed_after_augmentation(self, tmp_path):
+        """Ambient energy in silence-pad regions is zeroed before write-back.
+
+        Covers the validate_audio() head/tail silence requirement: even when
+        NoiseMixer fills the entire clip (including padding) with ambient noise,
+        the written WAV must have silence in the first/last 0.5 s.
+        """
+        import soundfile as _sf
+
+        sr = 16_000
+        pad = int(0.5 * sr)
+        total = sr * 6  # 6 s preprocessed length
+        # Build audio where the pad regions are NOT silent — simulating ambient bleed
+        noisy_pad_audio = np.full(total, 0.1, dtype=np.float32)
+        wav, errors = self._run_tier_b(tmp_path, aug_audio_override=noisy_pad_audio)
+        assert wav is not None, errors
+        data, _ = _sf.read(str(wav))
+        # First and last 0.5 s must be silent after Stage 3 pad-zeroing
+        assert np.all(data[:pad] == 0.0), "head pad should be zeroed"
+        assert np.all(data[-pad:] == 0.0), "tail pad should be zeroed"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1076,6 +1076,7 @@ class TestRunGeneratePipelineTierB:
         aug_events=None,
         snr_actual: float = 12.0,
         aug_side_effect=None,
+        aug_all_zeros: bool = False,
     ):
         """Helper: run Tier B pipeline with mocked TTS + mocked augmentation stack.
 
@@ -1086,20 +1087,22 @@ class TestRunGeneratePipelineTierB:
         if aug_events is None:
             aug_events = []
 
+        turns = _make_dialogue_turns(n=1, intensity=3)
+        # MixedScene duration is 5 s; preprocess() adds 0.5 s pad at each end → 6 s WAV.
+        mixed = _make_mixed_scene(duration_s=5.0, n_turns=1)
         sr = 16_000
         pad = int(0.5 * sr)
-        total = sr * 5  # 5 seconds
-        aug_audio = np.zeros(total, dtype=np.float32)
-        # Place a sine tone in the middle, leaving ≥ 0.5 s silence at each end
-        t = np.arange(total - 2 * pad, dtype=np.float32) / sr
-        aug_audio[pad : total - pad] = 0.5 * np.sin(2 * np.pi * 440 * t)
-        # Peak-normalize to −1.0 dBFS (as the pipeline does before writing)
-        peak = float(np.max(np.abs(aug_audio)))
-        if peak > 0.0:
-            aug_audio = (aug_audio * (10.0 ** (-1.0 / 20.0) / peak)).astype(np.float32)
-
-        turns = _make_dialogue_turns(n=1, intensity=3)
-        mixed = _make_mixed_scene(n_turns=1)
+        # Build aug_audio to match the preprocessed WAV length (6 s = 5 s + 2 × 0.5 s pad).
+        total = mixed.samples.shape[0] + 2 * pad  # 6 × 16 000 = 96 000 samples
+        if aug_all_zeros:
+            aug_audio = np.zeros(total, dtype=np.float32)
+        else:
+            aug_audio = np.zeros(total, dtype=np.float32)
+            t = np.arange(total - 2 * pad, dtype=np.float32) / sr
+            aug_audio[pad : total - pad] = 0.5 * np.sin(2 * np.pi * 440 * t)
+            peak = float(np.max(np.abs(aug_audio)))
+            if peak > 0.0:
+                aug_audio = (aug_audio * (10.0 ** (-1.0 / 20.0) / peak)).astype(np.float32)
 
         mock_aug_events = [
             AugmentedEvent(
@@ -1151,7 +1154,7 @@ class TestRunGeneratePipelineTierB:
         scene = meta["acoustic_scene"]
         assert scene["room_type"] == "small_bedroom"
         assert scene["device"] == "phone_in_hand"
-        assert scene["ir_source"] == "pyroomacoustics_ism"
+        assert scene["ir_source"] == "pyroomacoustics"  # value from AcousticSceneConfig default
         assert scene["speaker_distance_meters"] == 1.5
 
     def test_tier_b_snr_db_actual_in_metadata(self, tmp_path):
@@ -1191,3 +1194,34 @@ class TestRunGeneratePipelineTierB:
         )
         assert wav is None
         assert any("Acoustic augmentation error" in e for e in errors)
+
+    def test_tier_b_silent_augmented_output_skips_normalization(self, tmp_path):
+        """When NoiseMixer returns all-zero audio, peak==0 branch is skipped gracefully."""
+        # Covers the `if peak > 0.0` False branch (line 209 in cli.py)
+        wav, errors = self._run_tier_b(tmp_path, aug_all_zeros=True)
+        assert wav is not None, errors
+        # WAV must still exist and be the correct length (not crash on zero-peak input)
+        import soundfile as _sf
+
+        data, sr = _sf.read(str(wav))
+        assert len(data) > 0
+
+    def test_tier_b_unknown_acou_type_is_dropped(self, tmp_path):
+        """ACOU_* events with unrecognised tier2 codes are dropped, not propagated as labels."""
+        aug_events = [
+            {"type": "ACOU_UNKNOWN_XYZ", "onset_s": 1.0, "offset_s": 1.5, "level_db": -20.0},
+        ]
+        wav, errors = self._run_tier_b(tmp_path, aug_events=aug_events)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        assert "ACOU" not in meta["weak_label"]["violence_categories"]
+
+    def test_tier_b_output_wav_length_preserved(self, tmp_path):
+        """Stage 3 write-back keeps the WAV at exactly the preprocessed length."""
+        import soundfile as _sf
+
+        wav, errors = self._run_tier_b(tmp_path)
+        assert wav is not None, errors
+        data, sr = _sf.read(str(wav))
+        # Preprocessed duration = MixedScene 5 s + 2 × 0.5 s pad = 6 s
+        assert abs(len(data) / sr - 6.0) < 0.05

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1253,6 +1253,19 @@ class TestRunGeneratePipelineTierB:
         data, _ = _sf.read(str(wav))
         assert abs(len(data) / sr - 6.0) < 0.05
 
+    def test_tier_b_strong_labels_jsonl_written(self, tmp_path):
+        """Stage 7b writes a .jsonl strong-labels file alongside the clip WAV."""
+        wav, errors = self._run_tier_b(tmp_path)
+        assert wav is not None, errors
+        jsonl_path = wav.with_suffix(".jsonl")
+        assert jsonl_path.exists(), f"Expected strong labels JSONL at {jsonl_path}"
+        # Each line must be valid JSON
+        import json as _json
+
+        lines = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+        for line in lines:
+            _json.loads(line)  # raises on malformed JSON
+
     def test_tier_b_pad_regions_zeroed_after_augmentation(self, tmp_path):
         """Ambient energy in silence-pad regions is zeroed before write-back.
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1077,6 +1077,7 @@ class TestRunGeneratePipelineTierB:
         snr_actual: float = 12.0,
         aug_side_effect=None,
         aug_all_zeros: bool = False,
+        aug_audio_override: np.ndarray | None = None,
     ):
         """Helper: run Tier B pipeline with mocked TTS + mocked augmentation stack.
 
@@ -1094,7 +1095,9 @@ class TestRunGeneratePipelineTierB:
         pad = int(0.5 * sr)
         # Build aug_audio to match the preprocessed WAV length (6 s = 5 s + 2 × 0.5 s pad).
         total = mixed.samples.shape[0] + 2 * pad  # 6 × 16 000 = 96 000 samples
-        if aug_all_zeros:
+        if aug_audio_override is not None:
+            aug_audio = aug_audio_override
+        elif aug_all_zeros:
             aug_audio = np.zeros(total, dtype=np.float32)
         else:
             aug_audio = np.zeros(total, dtype=np.float32)
@@ -1224,4 +1227,28 @@ class TestRunGeneratePipelineTierB:
         assert wav is not None, errors
         data, sr = _sf.read(str(wav))
         # Preprocessed duration = MixedScene 5 s + 2 × 0.5 s pad = 6 s
+        assert abs(len(data) / sr - 6.0) < 0.05
+
+    def test_tier_b_aug_samples_trimmed_when_too_long(self, tmp_path):
+        """aug_samples longer than the input WAV are trimmed to n_orig (line 215-216)."""
+        import soundfile as _sf
+
+        sr = 16_000
+        # 7 s > 6 s expected preprocessed length — exercises the > n_orig trim branch
+        long_audio = np.zeros(sr * 7, dtype=np.float32)
+        wav, errors = self._run_tier_b(tmp_path, aug_audio_override=long_audio)
+        assert wav is not None, errors
+        data, _ = _sf.read(str(wav))
+        assert abs(len(data) / sr - 6.0) < 0.05
+
+    def test_tier_b_aug_samples_padded_when_too_short(self, tmp_path):
+        """aug_samples shorter than the input WAV are zero-padded to n_orig (line 217-220)."""
+        import soundfile as _sf
+
+        sr = 16_000
+        # 3 s < 6 s expected preprocessed length — exercises the < n_orig pad branch
+        short_audio = np.zeros(sr * 3, dtype=np.float32)
+        wav, errors = self._run_tier_b(tmp_path, aug_audio_override=short_audio)
+        assert wav is not None, errors
+        data, _ = _sf.read(str(wav))
         assert abs(len(data) / sr - 6.0) < 0.05

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1030,3 +1030,164 @@ class TestDeriveEventType:
     def test_unknown_typology_defaults_to_ambient(self):
         t1, t2 = _derive_event_type("UNKNOWN", 3)
         assert t1 == "NONE" and t2 == "NONE_AMBIENT"
+
+
+# ---------------------------------------------------------------------------
+# Tier B pipeline — Stage 3 acoustic augmentation branch
+# ---------------------------------------------------------------------------
+
+_TIER_B_SCENE_YAML = """\
+scene_id: SP_SV_B_TEST01
+project: she_proves
+language: he
+violence_typology: SV
+tier: B
+random_seed: 0
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+script_template: synthbanshee/script/templates/she_proves/neutral_domestic_routine.j2
+script_slots: {}
+intensity_arc: [2, 3, 5]
+target_duration_minutes: 3.0
+acoustic_scene:
+  room_type: small_bedroom
+  device: phone_in_hand
+  speaker_distance_meters: 1.5
+  victim_distance_meters: 1.0
+  snr_target_db: 15
+output_dir: data/he
+"""
+
+
+def _make_tier_b_scene_yaml(tmp_path: Path) -> Path:
+    p = tmp_path / "tier_b_scene.yaml"
+    p.write_text(_TIER_B_SCENE_YAML, encoding="utf-8")
+    return p
+
+
+class TestRunGeneratePipelineTierB:
+    """Cover the Stage 3 acoustic augmentation branch in _run_generate_pipeline."""
+
+    def _run_tier_b(
+        self,
+        tmp_path: Path,
+        *,
+        aug_events=None,
+        snr_actual: float = 12.0,
+        aug_side_effect=None,
+    ):
+        """Helper: run Tier B pipeline with mocked TTS + mocked augmentation stack.
+
+        Returns (wav_path, errors).
+        """
+        from synthbanshee.augment.types import AugmentedEvent
+
+        if aug_events is None:
+            aug_events = []
+
+        sr = 16_000
+        pad = int(0.5 * sr)
+        total = sr * 5  # 5 seconds
+        aug_audio = np.zeros(total, dtype=np.float32)
+        # Place a sine tone in the middle, leaving ≥ 0.5 s silence at each end
+        t = np.arange(total - 2 * pad, dtype=np.float32) / sr
+        aug_audio[pad : total - pad] = 0.5 * np.sin(2 * np.pi * 440 * t)
+        # Peak-normalize to −1.0 dBFS (as the pipeline does before writing)
+        peak = float(np.max(np.abs(aug_audio)))
+        if peak > 0.0:
+            aug_audio = (aug_audio * (10.0 ** (-1.0 / 20.0) / peak)).astype(np.float32)
+
+        turns = _make_dialogue_turns(n=1, intensity=3)
+        mixed = _make_mixed_scene(n_turns=1)
+
+        mock_aug_events = [
+            AugmentedEvent(
+                type=ev["type"],
+                onset_s=ev["onset_s"],
+                offset_s=ev["offset_s"],
+                level_db=ev["level_db"],
+            )
+            for ev in aug_events
+        ]
+
+        with (
+            patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
+            patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
+            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
+            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
+            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+        ):
+            MockGen.return_value.generate.return_value = turns
+            MockRenderer.return_value.render_scene.return_value = mixed
+            MockRoom.return_value.apply.return_value = aug_audio
+            MockDevice.return_value.apply.return_value = aug_audio
+            if aug_side_effect is not None:
+                MockMixer.return_value.mix.side_effect = aug_side_effect
+            else:
+                MockMixer.return_value.mix.return_value = (aug_audio, mock_aug_events, snr_actual)
+
+            wav, errors = _run_generate_pipeline(
+                _make_tier_b_scene_yaml(tmp_path),
+                tmp_path / "out",
+                tmp_path / "cache",
+                tmp_path / "dirty",
+                tmp_path / "scripts",
+            )
+        return wav, errors
+
+    def test_tier_b_pipeline_succeeds(self, tmp_path):
+        """Tier B pipeline with mocked augmentation stack completes without error."""
+        wav, errors = self._run_tier_b(tmp_path)
+        assert wav is not None, errors
+
+    def test_tier_b_acoustic_scene_in_metadata(self, tmp_path):
+        """acoustic_scene block in metadata JSON contains room_type, device, ir_source."""
+        wav, errors = self._run_tier_b(tmp_path)
+        assert wav is not None, errors
+        json_path = wav.with_suffix(".json")
+        assert json_path.exists()
+        meta = json.loads(json_path.read_text(encoding="utf-8"))
+        scene = meta["acoustic_scene"]
+        assert scene["room_type"] == "small_bedroom"
+        assert scene["device"] == "phone_in_hand"
+        assert scene["ir_source"] == "pyroomacoustics_ism"
+        assert scene["speaker_distance_meters"] == 1.5
+
+    def test_tier_b_snr_db_actual_in_metadata(self, tmp_path):
+        """snr_db_actual is populated in acoustic_scene metadata for Tier B clips."""
+        wav, errors = self._run_tier_b(tmp_path, snr_actual=14.75)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        assert meta["acoustic_scene"]["snr_db_actual"] == 14.75
+
+    def test_tier_b_acou_sfx_appear_in_weak_label(self, tmp_path):
+        """ACOU_* SFX from Stage 3 contribute 'ACOU' to weak_label.violence_categories."""
+        aug_events = [
+            {"type": "ACOU_SLAM", "onset_s": 2.5, "offset_s": 2.9, "level_db": -18.0},
+        ]
+        wav, errors = self._run_tier_b(tmp_path, aug_events=aug_events)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        assert "ACOU" in meta["weak_label"]["violence_categories"]
+
+    def test_tier_b_ambient_events_not_in_weak_label(self, tmp_path):
+        """Non-ACOU ambient events (tv_ambient) are NOT added as ScriptEvents."""
+        # tv_ambient is not an ACOU_* event so it should not appear in violence_categories
+        aug_events = [
+            {"type": "tv_ambient", "onset_s": 0.0, "offset_s": 5.0, "level_db": -30.0},
+        ]
+        wav, errors = self._run_tier_b(tmp_path, aug_events=aug_events)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        # ACOU should NOT appear (only VERB from the SV speech turns at intensity 3)
+        assert "ACOU" not in meta["weak_label"]["violence_categories"]
+
+    def test_tier_b_augmentation_error_returns_error(self, tmp_path):
+        """When Stage 3 augmentation raises, pipeline returns (None, [augmentation error])."""
+        wav, errors = self._run_tier_b(
+            tmp_path,
+            aug_side_effect=RuntimeError("pyroomacoustics simulation failed"),
+        )
+        assert wav is None
+        assert any("Acoustic augmentation error" in e for e in errors)

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -103,6 +103,7 @@ class TestManifestRow:
             quality_flags="",
             split="train",
             wav_path="data/he/test_clip.wav",
+            strong_labels_path="",
         )
         assert row.clip_id == "test_clip"
         assert row.split == "train"
@@ -257,6 +258,27 @@ class TestGenerateManifest:
         rows = generate_manifest(tmp_path, out, clip_ids=None)
 
         assert {r.clip_id for r in rows} == {"clip_a_00", "clip_b_00"}
+
+    def test_strong_labels_path_populated_when_jsonl_exists(self, tmp_path):
+        """strong_labels_path is the .jsonl path when the file exists alongside the clip."""
+        clip_dir = tmp_path / "spk_000"
+        wav = _write_valid_clip(clip_dir, "clip_000_00")
+        jsonl_path = wav.with_suffix(".jsonl")
+        jsonl_path.write_text('{"clip_id":"clip_000_00"}\n', encoding="utf-8")
+        out = tmp_path / "manifest.csv"
+
+        rows = generate_manifest(tmp_path, out)
+
+        assert rows[0].strong_labels_path == str(jsonl_path)
+
+    def test_strong_labels_path_empty_when_jsonl_absent(self, tmp_path):
+        """strong_labels_path is empty string when no .jsonl exists alongside the clip."""
+        _write_valid_clip(tmp_path / "spk_000", "clip_000_00")
+        out = tmp_path / "manifest.csv"
+
+        rows = generate_manifest(tmp_path, out)
+
+        assert rows[0].strong_labels_path == ""
 
     def test_json_without_sibling_wav_is_skipped(self, tmp_path):
         """A metadata JSON whose sibling .wav does not exist is excluded from the manifest."""

--- a/tests/unit/test_qa.py
+++ b/tests/unit/test_qa.py
@@ -289,3 +289,26 @@ class TestRunQAMetadataReparseFails:
         assert report.stats.failed_clips == 1
         assert report.stats.total_clips == 0
         assert "clip_001_00" in report.failed_clip_ids
+
+    def test_clips_missing_strong_labels_counted(self, tmp_path):
+        """Clips without a sibling .jsonl increment clips_missing_strong_labels."""
+        _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        # No .jsonl written alongside the clip
+
+        report = run_qa(tmp_path)
+
+        assert report.stats.clips_missing_strong_labels == 1
+        # Missing JSONL is a warning, not a failure — clip still passes
+        assert report.stats.total_clips == 1
+        assert report.stats.failed_clips == 0
+
+    def test_clips_with_strong_labels_not_counted(self, tmp_path):
+        """Clips with a sibling .jsonl do NOT increment clips_missing_strong_labels."""
+        wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        wav.with_suffix(".jsonl").write_text(
+            '{"clip_id":"clip_001_00","onset":0.5,"offset":1.0}\n', encoding="utf-8"
+        )
+
+        report = run_qa(tmp_path)
+
+        assert report.stats.clips_missing_strong_labels == 0


### PR DESCRIPTION
## Summary

- **Strong labels JSONL** (`cli.py` step 7b): every generated clip now gets a sibling `.jsonl` file containing per-event strong labels, written by `LabelGenerator.write_strong_labels_jsonl()` immediately after label generation
- **Validator warning**: `validate_clip()` emits a warning (not an error) when the `.jsonl` is absent, keeping the spec constraint soft while making gaps visible in QA reports
- **Manifest column**: `generate_manifest()` adds a `strong_labels_path` column populated with the absolute path to the `.jsonl` if it exists, or an empty string
- **16 Tier B scene configs**: `configs/scenes/she_proves_tier_b/` (8 files) and `configs/scenes/elephant_tier_b/` (8 files), covering all four violence typologies (SV, IT, NEG, NEU) × 2 variants each; all ACOU event codes validated against `configs/taxonomy.yaml`
- **Unit tests**: new assertion in `TestRunGeneratePipelineTierB` that `.jsonl` is written; two new `test_manifest.py` tests for `strong_labels_path` presence/absence; `ManifestRow` fixture updated with required `strong_labels_path` field
- **Integration test** (`tests/integration/test_tier_b_pipeline.py`): 8 end-to-end assertions wiring ScriptGenerator → TTSRenderer → Stage 3 augmentation (all mocked) → JSONL → metadata → `validate_clip`

## Test plan

- [ ] `pytest tests/unit/test_manifest.py` — 2 new strong-labels-path tests pass
- [ ] `pytest tests/unit/test_cli.py::TestRunGeneratePipelineTierB` — all 13 Tier B unit tests pass (including new JSONL assertion)
- [ ] `pytest tests/integration/test_tier_b_pipeline.py` — all 8 integration tests pass
- [ ] `pytest` (full suite, 559 tests) — 0 failures
- [ ] Verify ACOU codes in all 16 scene configs are in `configs/taxonomy.yaml` tier2_subtype

🤖 Generated with [Claude Code](https://claude.com/claude-code)