### PR TITLE
feat: Phase 3 Tier C hard-negative (confusor) pipeline

### DIFF
--- a/configs/run_configs/tier_c_500_elephant.yaml
+++ b/configs/run_configs/tier_c_500_elephant.yaml
@@ -1,0 +1,32 @@
+# Phase 3 — Tier C generation run: Elephant in the Room project
+# Target: 500 hard-negative (confusor) clips — animated but non-violent office interactions.
+# All clips use violence_typology NEG; scene configs must include an acoustic_scene block.
+# See docs/implementation_plan.md §3 for context on Tier C confusors.
+#
+# Elephant confusor scenes: 2–2.5 min, pi_budget_mic device.
+# Room types: clinic_office, welfare_office, open_office_corridor.
+# IMPORTANT: expert review of templates recommended before large-scale generation
+# (see implementation_plan.md §3.1).
+
+run_id: tier_c_500_elephant
+project: elephant_in_the_room
+tier: C
+language: he
+random_seed: 44
+output_dir: data/he
+scene_configs_dir: configs/scenes/elephant_tier_c
+
+# --- Per-typology clip count targets (total: 500) ---
+targets:
+  - violence_typology: NEG   # All confusor clips
+    count: 500
+
+# --- Speaker-disjoint split fractions ---
+splits:
+  train: 0.70
+  val: 0.15
+  test: 0.15
+
+# --- Error handling ---
+max_retries: 3
+fail_fast: false

--- a/configs/run_configs/tier_c_500_she_proves.yaml
+++ b/configs/run_configs/tier_c_500_she_proves.yaml
@@ -1,0 +1,33 @@
+# Phase 3 — Tier C generation run: She-Proves project
+# Target: 500 hard-negative (confusor) clips — acoustically intense but non-violent.
+# All clips use violence_typology NEG; scene configs must include an acoustic_scene block.
+# See docs/implementation_plan.md §3 for context on Tier C confusors.
+#
+# She-Proves confusor scenes: 2.5–3.5 min, all phone device types.
+# Room types: apartment_kitchen, living_room, small_bedroom.
+# IMPORTANT: expert review of templates recommended before large-scale generation
+# (see implementation_plan.md §3.1).
+
+run_id: tier_c_500_she_proves
+project: she_proves
+tier: C
+language: he
+random_seed: 43
+output_dir: data/he
+scene_configs_dir: configs/scenes/she_proves_tier_c
+
+# --- Per-typology clip count targets (total: 500) ---
+# Tier C is exclusively NEG (hard negatives) — no SV/IT clips in this tier.
+targets:
+  - violence_typology: NEG   # All confusor clips
+    count: 500
+
+# --- Speaker-disjoint split fractions ---
+splits:
+  train: 0.70
+  val: 0.15
+  test: 0.15
+
+# --- Error handling ---
+max_retries: 3
+fail_fast: false

--- a/configs/scenes/elephant_tier_c/el_neg_c_0001.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0001.yaml
@@ -1,0 +1,37 @@
+scene_id: EL_NEG_C_0001
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 601
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/confusor_animated_nonviolent_intake.j2
+script_slots:
+  scene_type: intake_interview
+  dispute_subject: benefit_delay
+  office_setting: clinic_office
+intensity_arc: [1, 2, 3, 3, 2, 1]
+elephant:
+  scene_type: intake_interview
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.0
+acoustic_scene:
+  room_type: clinic_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.2
+  victim_distance_meters: 0.8
+  snr_target_db: 22
+  rt60_range: [0.14, 0.26]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -40
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0002.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0002.yaml
@@ -1,0 +1,37 @@
+scene_id: EL_NEG_C_0002
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 602
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/confusor_client_in_distress_no_aggression.j2
+script_slots:
+  scene_type: crisis_visit
+  distress_cause: domestic_situation_at_home
+  office_setting: welfare_office
+intensity_arc: [1, 2, 3, 3, 2, 1]
+elephant:
+  scene_type: crisis_visit
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.5
+acoustic_scene:
+  room_type: welfare_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.3
+  victim_distance_meters: 0.9
+  snr_target_db: 20
+  rt60_range: [0.16, 0.30]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -42
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0003.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0003.yaml
@@ -1,0 +1,38 @@
+scene_id: EL_NEG_C_0003
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 603
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/confusor_heated_complaint_resolved.j2
+script_slots:
+  scene_type: benefits_dispute
+  complaint_subject: processing_error
+  office_setting: open_office_corridor
+  resolution_type: supervisor_called
+intensity_arc: [2, 3, 4, 3, 2, 1]
+elephant:
+  scene_type: benefits_dispute
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.5
+acoustic_scene:
+  room_type: open_office_corridor
+  device: pi_budget_mic
+  speaker_distance_meters: 1.8
+  victim_distance_meters: 1.4
+  snr_target_db: 16
+  rt60_range: [0.22, 0.40]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -36
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0004.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0004.yaml
@@ -1,0 +1,36 @@
+scene_id: EL_NEG_C_0004
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 604
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/confusor_phone_call_overheard.j2
+script_slots:
+  phone_call_subject: family_dispute_over_phone
+  office_setting: welfare_office
+intensity_arc: [1, 2, 4, 3, 1, 1]
+elephant:
+  scene_type: routine_followup
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.0
+acoustic_scene:
+  room_type: welfare_office
+  device: pi_budget_mic
+  speaker_distance_meters: 2.0
+  victim_distance_meters: 1.5
+  snr_target_db: 18
+  rt60_range: [0.16, 0.30]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -38
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0005.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0005.yaml
@@ -1,0 +1,36 @@
+scene_id: EL_NEG_C_0005
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 605
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/confusor_loud_waiting_room.j2
+script_slots:
+  office_setting: open_office_corridor
+  crowd_cause: system_outage_long_wait
+intensity_arc: [2, 2, 3, 3, 2, 1]
+elephant:
+  scene_type: routine_followup
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.0
+acoustic_scene:
+  room_type: open_office_corridor
+  device: pi_budget_mic
+  speaker_distance_meters: 2.5
+  victim_distance_meters: 2.0
+  snr_target_db: 14
+  rt60_range: [0.22, 0.40]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -34
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0006.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0006.yaml
@@ -1,0 +1,37 @@
+scene_id: EL_NEG_C_0006
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 606
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/confusor_grief_disclosure.j2
+script_slots:
+  scene_type: routine_followup
+  loss_type: bereavement
+  office_setting: clinic_office
+intensity_arc: [1, 2, 3, 2, 1, 1]
+elephant:
+  scene_type: routine_followup
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.5
+acoustic_scene:
+  room_type: clinic_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.0
+  victim_distance_meters: 0.8
+  snr_target_db: 24
+  rt60_range: [0.14, 0.26]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -44
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0007.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0007.yaml
@@ -1,0 +1,37 @@
+scene_id: EL_NEG_C_0007
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 607
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/confusor_frustrated_waiting_client.j2
+script_slots:
+  scene_type: intake_interview
+  wait_duration: two_hours
+  office_setting: welfare_office
+intensity_arc: [2, 3, 4, 3, 2, 1]
+elephant:
+  scene_type: intake_interview
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.0
+acoustic_scene:
+  room_type: welfare_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.5
+  victim_distance_meters: 1.0
+  snr_target_db: 20
+  rt60_range: [0.16, 0.30]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -38
+      loop: true
+output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0008.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0008.yaml
@@ -1,0 +1,37 @@
+scene_id: EL_NEG_C_0008
+project: elephant_in_the_room
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 608
+speakers:
+  - speaker_id: BEN_M_40-55_003
+    role: AGG
+  - speaker_id: SW_F_30-45_001
+    role: VIC
+script_template: synthbanshee/script/templates/elephant/confusor_animated_nonviolent_intake.j2
+script_slots:
+  scene_type: benefits_dispute
+  dispute_subject: housing_assistance_denial
+  office_setting: welfare_office
+intensity_arc: [1, 2, 3, 4, 2, 1]
+elephant:
+  scene_type: benefits_dispute
+  alert_triggered: false
+  alert_at_phase: null
+  alert_onset_fraction: null
+  attack_type: null
+target_duration_minutes: 2.5
+acoustic_scene:
+  room_type: welfare_office
+  device: pi_budget_mic
+  speaker_distance_meters: 1.4
+  victim_distance_meters: 1.0
+  snr_target_db: 21
+  rt60_range: [0.16, 0.30]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -40
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0001.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0001.yaml
@@ -1,0 +1,31 @@
+scene_id: SP_NEG_C_0001
+project: she_proves
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 501
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/confusor_heated_but_resolved.j2
+script_slots:
+  relationship: spouses
+  grievance: parenting_disagreement
+  resolution_type: mutual_apology
+intensity_arc: [1, 2, 3, 4, 3, 2, 1]
+target_duration_minutes: 3.5
+acoustic_scene:
+  room_type: apartment_kitchen
+  device: phone_on_table
+  speaker_distance_meters: 1.5
+  victim_distance_meters: 1.2
+  snr_target_db: 14
+  rt60_range: [0.16, 0.30]
+  background_events:
+    - type: tv_ambient
+      onset_seconds: 0.0
+      level_db: -32
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0002.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0002.yaml
@@ -1,0 +1,31 @@
+scene_id: SP_NEG_C_0002
+project: she_proves
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 502
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/confusor_sports_tv_yelling.j2
+script_slots:
+  sport: football
+  team: Maccabi_Tel_Aviv
+  match_moment: last_minute_goal
+intensity_arc: [1, 2, 3, 4, 4, 2, 1]
+target_duration_minutes: 3.0
+acoustic_scene:
+  room_type: living_room
+  device: phone_in_hand
+  speaker_distance_meters: 2.0
+  victim_distance_meters: 1.8
+  snr_target_db: 16
+  rt60_range: [0.28, 0.50]
+  background_events:
+    - type: tv_ambient
+      onset_seconds: 0.0
+      level_db: -22
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0003.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0003.yaml
@@ -1,0 +1,34 @@
+scene_id: SP_NEG_C_0003
+project: she_proves
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 503
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/confusor_cooking_accident.j2
+script_slots:
+  meal: dinner
+  accident_type: pot_dropped
+intensity_arc: [1, 1, 4, 3, 1, 1]
+target_duration_minutes: 2.5
+acoustic_scene:
+  room_type: apartment_kitchen
+  device: phone_on_table
+  speaker_distance_meters: 1.2
+  victim_distance_meters: 1.0
+  snr_target_db: 18
+  rt60_range: [0.16, 0.28]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -40
+      loop: true
+    - type: ACOU_FALL
+      onset_at_phase: peak
+      onset_offset_seconds: 0.5
+      asset_path: null
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0004.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0004.yaml
@@ -1,0 +1,30 @@
+scene_id: SP_NEG_C_0004
+project: she_proves
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 504
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/confusor_medical_emergency_alarm.j2
+script_slots:
+  emergency_type: choking_incident
+  who_affected: child
+intensity_arc: [1, 1, 5, 4, 2, 1]
+target_duration_minutes: 3.0
+acoustic_scene:
+  room_type: apartment_kitchen
+  device: phone_in_hand
+  speaker_distance_meters: 1.5
+  victim_distance_meters: 1.2
+  snr_target_db: 20
+  rt60_range: [0.16, 0.28]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -42
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0005.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0005.yaml
@@ -1,0 +1,30 @@
+scene_id: SP_NEG_C_0005
+project: she_proves
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 505
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/confusor_grief_crying.j2
+script_slots:
+  loss_type: bereavement
+  relationship_to_deceased: parent
+intensity_arc: [1, 2, 3, 3, 2, 1]
+target_duration_minutes: 3.5
+acoustic_scene:
+  room_type: small_bedroom
+  device: phone_on_table
+  speaker_distance_meters: 1.0
+  victim_distance_meters: 0.8
+  snr_target_db: 20
+  rt60_range: [0.20, 0.36]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -44
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0006.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0006.yaml
@@ -1,0 +1,30 @@
+scene_id: SP_NEG_C_0006
+project: she_proves
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 506
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/confusor_child_tantrum.j2
+script_slots:
+  tantrum_trigger: bedtime_refusal
+  child_age: "3"
+intensity_arc: [1, 2, 3, 3, 2, 1]
+target_duration_minutes: 3.0
+acoustic_scene:
+  room_type: small_bedroom
+  device: phone_in_hand
+  speaker_distance_meters: 1.5
+  victim_distance_meters: 1.2
+  snr_target_db: 14
+  rt60_range: [0.20, 0.36]
+  background_events:
+    - type: hvac_hum
+      onset_seconds: 0.0
+      level_db: -40
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0007.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0007.yaml
@@ -1,0 +1,30 @@
+scene_id: SP_NEG_C_0007
+project: she_proves
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 507
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/confusor_laughter_excitement.j2
+script_slots:
+  trigger: surprise_gift
+  context: living_room
+intensity_arc: [1, 2, 3, 3, 2, 1]
+target_duration_minutes: 3.0
+acoustic_scene:
+  room_type: living_room
+  device: phone_in_pocket
+  speaker_distance_meters: 2.5
+  victim_distance_meters: 2.0
+  snr_target_db: 18
+  rt60_range: [0.28, 0.50]
+  background_events:
+    - type: tv_ambient
+      onset_seconds: 0.0
+      level_db: -35
+      loop: true
+output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0008.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0008.yaml
@@ -1,0 +1,30 @@
+scene_id: SP_NEG_C_0008
+project: she_proves
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 508
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/confusor_loud_celebration.j2
+script_slots:
+  occasion: job_promotion
+  participants: couple
+intensity_arc: [2, 3, 4, 4, 3, 2]
+target_duration_minutes: 3.0
+acoustic_scene:
+  room_type: living_room
+  device: phone_on_table
+  speaker_distance_meters: 2.0
+  victim_distance_meters: 1.8
+  snr_target_db: 16
+  rt60_range: [0.28, 0.50]
+  background_events:
+    - type: tv_ambient
+      onset_seconds: 0.0
+      level_db: -30
+      loop: true
+output_dir: data/he

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -180,7 +180,7 @@ def _run_generate_pipeline(
     except Exception as exc:
         return None, [f"Pipeline error: {exc}"]
 
-    # Stage 3b — Acoustic Augmentation (Tier B only)
+    # Stage 3b — Acoustic Augmentation (Tier B and Tier C)
     # 5b. Room simulation → device profile → noise mix
     #
     # Stage 3 receives the fully preprocessed (16 kHz, mono, silence-padded) WAV.
@@ -311,7 +311,7 @@ def _run_generate_pipeline(
                 emotional_state=turn.emotional_state,
             )
         )
-    # Stage 3b ACOU_* SFX events (Tier B only). Their onset/offset times are
+    # Stage 3b ACOU_* SFX events (Tier B and Tier C). Their onset/offset times are
     # already in padded-audio coordinates — no pad_s shift needed.
     for aug_ev in _aug_acou_events:
         events.append(

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -192,7 +192,7 @@ def _run_generate_pipeline(
     # intentionally so the placed events align with audible speech, not with silence.)
     acoustic_scene_meta = None
     _aug_acou_events: list = []  # ACOU_* SFX events for strong-label generation
-    if scene.tier == "B" and scene.acoustic_scene is not None:
+    if scene.tier in ("B", "C") and scene.acoustic_scene is not None:
         try:
             import numpy as _np
             import soundfile as _sf

--- a/synthbanshee/script/templates/elephant/confusor_animated_nonviolent_intake.j2
+++ b/synthbanshee/script/templates/elephant/confusor_animated_nonviolent_intake.j2
@@ -1,0 +1,39 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — animated but ultimately non-violent intake session.
+   Typology: NEG  Slots: scene_type, dispute_subject, office_setting
+   Purpose: hard negative — loud agitated client who stays within non-violent bounds.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           elephant_in_the_room (welfare/clinic office monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Animated Non-Violent Intake
+Scene type:        {{ script_slots.get('scene_type', 'intake_interview') }}
+Dispute subject:   {{ script_slots.get('dispute_subject', 'benefit_delay') }}
+Office setting:    {{ script_slots.get('office_setting', 'clinic_office') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (peaks with client frustration, resolves without violence)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+A client is genuinely frustrated about a bureaucratic issue. The social worker handles it professionally.
+  1. Greeting — standard intake; client is already tense but controlled.
+  2. Frustration build — client raises their voice about the dispute subject; complaints intensify.
+  3. Peak — client is loud and agitated; speaks over the social worker; uses emphatic language.
+  4. Social worker response — calm, professional de-escalation; acknowledges the client's feelings.
+  5. Resolution — client accepts the social worker's response or a concrete next step; tension drops.
+IMPORTANT: the client must NOT make explicit threats, touch the social worker, or display
+weapon-like behaviour. Raised voice, pacing language, and strong dissatisfaction are the
+ACOUSTIC CONFUSOR. The social worker models exemplary professional conduct throughout.
+
+{{ common_rules(target_duration_minutes, [
+  "The client's frustration must be directed at the SYSTEM or SITUATION, not personally at the worker.",
+  "The social worker should use named de-escalation techniques (validation, paraphrasing, offering options).",
+  "No alert should be triggered — this clip tests false-positive resistance."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/elephant/confusor_client_in_distress_no_aggression.j2
+++ b/synthbanshee/script/templates/elephant/confusor_client_in_distress_no_aggression.j2
@@ -1,0 +1,40 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — client in emotional distress (crying, pleading) without aggression toward the worker.
+   Typology: NEG  Slots: scene_type, distress_cause, office_setting
+   Purpose: hard negative — DIST_CRY / DIST_PLEAD acoustics with no interpersonal violence.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           elephant_in_the_room (welfare/clinic office monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Client in Distress (No Aggression)
+Scene type:        {{ script_slots.get('scene_type', 'crisis_visit') }}
+Distress cause:    {{ script_slots.get('distress_cause', 'domestic_situation_at_home') }}
+Office setting:    {{ script_slots.get('office_setting', 'welfare_office') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (emotional distress arc, not violence arc)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+The client is in genuine emotional pain — crying, shaking, barely coherent at times.
+The social worker provides therapeutic support.
+  1. Arrival — client arrives visibly distressed; social worker receives them calmly.
+  2. Disclosure — client describes their situation; breaks down while speaking.
+  3. Distress peak — audible crying, broken sentences, pleading for help.
+  4. Support — social worker validates and stabilises; client gradually regains composure.
+  5. Action plan — concrete next steps are agreed; client leaves calmer than they arrived.
+IMPORTANT: distress vocalisations (crying, sobbing, strained voice) are the ACOUSTIC CONFUSOR.
+The client must not direct any hostility toward the social worker. This tests whether the
+classifier can distinguish victim-of-circumstance distress from victim-of-perpetrator distress.
+
+{{ common_rules(target_duration_minutes, [
+  "The social worker should NOT raise their voice at any point.",
+  "The client's distress is self-directed or situation-directed — never toward the worker.",
+  "Silences and audible breathing between broken sentences are realistic and expected."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/elephant/confusor_frustrated_waiting_client.j2
+++ b/synthbanshee/script/templates/elephant/confusor_frustrated_waiting_client.j2
@@ -1,0 +1,39 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — frustrated client who has been waiting; vents loudly then accepts resolution.
+   Typology: NEG  Slots: scene_type, wait_duration, office_setting
+   Purpose: hard negative — extends neu_frustrated_waiting_client into a higher-intensity confusor.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           elephant_in_the_room (welfare/clinic office monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Frustrated Waiting Client (Intense Venting)
+Scene type:        {{ script_slots.get('scene_type', 'intake_interview') }}
+Wait duration:     {{ script_slots.get('wait_duration', 'two_hours') }}
+Office setting:    {{ script_slots.get('office_setting', 'welfare_office') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (intense venting in first half; drops once addressed)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+A client has been waiting much longer than promised and confronts the social worker about it.
+  1. Confrontation — client approaches the worker with clear anger about the wait time.
+  2. Venting — client speaks loudly and rapidly; lists grievances; the worker can barely interject.
+  3. Intense peak — the client's frustration reaches its highest point; they may raise their hands, pace.
+  4. Social worker acknowledgement — genuine apology and explanation; the worker takes responsibility.
+  5. Resolution — client's frustration drops noticeably; the appointment proceeds.
+IMPORTANT: the client is venting about a legitimate service failure, not attacking the person.
+No threats, no physical approach, no coercive language. The acoustic energy of the vent
+phase is the CONFUSOR — it should sound loud and confrontational without being violent.
+
+{{ common_rules(target_duration_minutes, [
+  "The client's language should be forceful but not profane or threatening.",
+  "The social worker should NOT become defensive — model professional grace under pressure.",
+  "The resolution must feel authentic — the client is genuinely mollified, not just silenced."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/elephant/confusor_grief_disclosure.j2
+++ b/synthbanshee/script/templates/elephant/confusor_grief_disclosure.j2
@@ -1,0 +1,39 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — client discloses personal loss or grief in session; social worker provides support.
+   Typology: NEG  Slots: scene_type, loss_type, office_setting
+   Purpose: hard negative — DIST_CRY and DIST_PLEAD acoustics in a therapeutic context.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           elephant_in_the_room (welfare/clinic office monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Grief Disclosure in Session
+Scene type:        {{ script_slots.get('scene_type', 'routine_followup') }}
+Loss type:         {{ script_slots.get('loss_type', 'bereavement') }}
+Office setting:    {{ script_slots.get('office_setting', 'clinic_office') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (emotional depth arc, not violence arc)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+During a routine session, the client discloses a significant personal loss or painful life event.
+  1. Opening — routine session start; the social worker checks in on the client's week.
+  2. Disclosure — client begins to describe the loss; voice becomes strained and emotional.
+  3. Distress — client cries or becomes visibly overwhelmed; speech becomes halting.
+  4. Therapeutic response — social worker uses reflective listening, validates grief, offers presence.
+  5. Stabilisation — client regains enough composure to continue; session moves toward closure.
+IMPORTANT: this is grief work. The client is in pain but is NOT aggressive. The social worker
+is skilled and empathic. Crying and distress sounds are the ACOUSTIC CONFUSOR — they must
+not cause the system to flag an alert.
+
+{{ common_rules(target_duration_minutes, [
+  "The social worker should use reflective techniques (תוקף, פרפרזה, שאלות פתוחות).",
+  "The client's voice may break — stuttering, incomplete sentences, long pauses are expected.",
+  "No hostility of any kind should appear. This is a professional, caring exchange."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/elephant/confusor_heated_complaint_resolved.j2
+++ b/synthbanshee/script/templates/elephant/confusor_heated_complaint_resolved.j2
@@ -1,0 +1,40 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — heated complaint session that is fully resolved without violence.
+   Typology: NEG  Slots: scene_type, complaint_subject, office_setting, resolution_type
+   Purpose: hard negative — sustained loud confrontation that never crosses the violence threshold.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           elephant_in_the_room (welfare/clinic office monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Heated Complaint (Fully Resolved)
+Scene type:        {{ script_slots.get('scene_type', 'benefits_dispute') }}
+Complaint subject: {{ script_slots.get('complaint_subject', 'processing_error') }}
+Office setting:    {{ script_slots.get('office_setting', 'open_office_corridor') }}
+Resolution type:   {{ script_slots.get('resolution_type', 'supervisor_called') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (sustained high intensity then drops sharply at resolution)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+The client has a legitimate grievance and pursues it loudly but without crossing into violence.
+  1. Confrontation — client raises the complaint at volume; worker tries to respond.
+  2. Escalation — client talks over the worker; raises objections louder; gestures in speech.
+  3. Peak — maximum volume and frustration; social worker remains calm but firm.
+  4. Resolution trigger — the resolution type from the slot occurs (supervisor arrives, error found, etc.).
+  5. Resolution — client accepts the outcome; anger subsides; formal close of the meeting.
+IMPORTANT: at peak intensity, an observer might mistake this for a pre-violence situation.
+That is the test. The client must stop short of ANY explicit threats or physical advance.
+The resolution must feel earned by the social worker's professional response.
+
+{{ common_rules(target_duration_minutes, [
+  "The client should use emphatic but non-threatening Hebrew (אני לא מוכן לקבל את זה, זה פשוט לא בסדר).",
+  "The social worker must not become defensive or raise their voice.",
+  "The resolution moment should be acoustically distinct — a clear change in tone."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/elephant/confusor_loud_waiting_room.j2
+++ b/synthbanshee/script/templates/elephant/confusor_loud_waiting_room.j2
@@ -1,0 +1,38 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — chaotic waiting room; multiple people talking; social worker manages the crowd.
+   Typology: NEG  Slots: office_setting, crowd_cause
+   Purpose: hard negative — high ambient noise + raised voices in a crowded office context.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           elephant_in_the_room (welfare/clinic office monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Loud Waiting Room
+Office setting:    {{ script_slots.get('office_setting', 'open_office_corridor') }}
+Crowd cause:       {{ script_slots.get('crowd_cause', 'system_outage_long_wait') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (noisy throughout; no dramatic peak)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+The waiting room is unusually busy. Multiple clients are impatient. The social worker manages it.
+  1. Arrival — social worker enters the waiting area; immediately deals with noise and questions.
+  2. Multiple demands — several clients speak at once; social worker addresses them one by one.
+  3. Friction — one client speaks loudly about the wait; social worker acknowledges and explains.
+  4. Stabilisation — the social worker calms the room; promises updates; crowd noise diminishes.
+  5. Resolution — the immediate situation is managed; the worker returns to their duties.
+IMPORTANT: The acoustic confusor here is overlapping speech + ambient noise + raised voices
+from impatience — none of which constitutes interpersonal violence. No single person is
+threatening the social worker; the frustration is collective and situational.
+
+{{ common_rules(target_duration_minutes, [
+  "The social worker speaks over background noise — naturally higher volume, not aggression.",
+  "Client frustration is about waiting, not about the social worker personally.",
+  "The scene should feel like a busy public office, not a confrontation."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/elephant/confusor_phone_call_overheard.j2
+++ b/synthbanshee/script/templates/elephant/confusor_phone_call_overheard.j2
@@ -1,0 +1,39 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — social worker overhears client's agitated phone call; then checks in.
+   Typology: NEG  Slots: phone_call_subject, office_setting
+   Purpose: hard negative — one-sided loud argument (phone call) followed by routine check-in.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           elephant_in_the_room (welfare/clinic office monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Agitated Phone Call Overheard
+Phone call about:  {{ script_slots.get('phone_call_subject', 'family_dispute_over_phone') }}
+Office setting:    {{ script_slots.get('office_setting', 'welfare_office') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (phone call peak in first half; check-in is calm)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+The client is in the waiting area or corridor and makes / receives a loud personal phone call.
+The social worker overhears it and — once the call ends — approaches to check in.
+  1. Phone call start — client answers or dials; listener hears only their side.
+  2. Escalation — the call becomes heated; client raises their voice at whoever is on the line.
+  3. Peak — loud, one-sided argument (only the client is audible on the mic).
+  4. Call ends — client hangs up; possibly still emotional.
+  5. Check-in — social worker approaches; brief, calm exchange; client is embarrassed or deflated.
+IMPORTANT: the agitation is directed at the phone-call counterpart, NOT the social worker.
+When the social worker enters the scene, the interaction is entirely non-threatening.
+The loud phone-call phase is the ACOUSTIC CONFUSOR.
+
+{{ common_rules(target_duration_minutes, [
+  "The phone-call half should feel naturalistic — pauses where the other person responds.",
+  "The client's language during the call may be strong but must not include explicit violence threats.",
+  "The check-in dialogue should be brief and calm — a professional welfare check."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/she_proves/confusor_child_tantrum.j2
+++ b/synthbanshee/script/templates/she_proves/confusor_child_tantrum.j2
@@ -1,0 +1,38 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — child tantrum; parents coordinate calmly while child screams in background.
+   Typology: NEG  Slots: tantrum_trigger, child_age
+   Purpose: hard negative — child screaming is DIST_CHILD acoustic event; parents not violent.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           she_proves (smartphone passive monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Child Tantrum
+Tantrum trigger:   {{ script_slots.get('tantrum_trigger', 'bedtime_refusal') }}
+Child age:         {{ script_slots.get('child_age', '3') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (mirrors tantrum arc, not adult conflict)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+A young child is having a tantrum in the background. The two adults (parents/caregivers)
+are talking to each other — and occasionally to the child — to manage the situation.
+  1. Onset — child begins to fuss; parents acknowledge it.
+  2. Escalation — child screams; adults speak slightly louder to be heard over the noise.
+  3. Intervention — one parent goes to the child or both try verbal de-escalation of child.
+  4. Resolution — child calms or is removed from the scene; adults exchange brief relief.
+IMPORTANT: the adult speakers must remain COOPERATIVE with each other throughout.
+Mild exasperation directed at the SITUATION is acceptable; directed hostility is not.
+The child's cries are the ACOUSTIC CONFUSOR.
+
+{{ common_rules(target_duration_minutes, [
+  "The adults may call out to the child by name or use diminutives ('ילד שלי', 'נשמה').",
+  "Short, interrupted sentences are realistic when speaking over a screaming child.",
+  "No adult speaker should raise their voice at the other adult — only at/for the child."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/she_proves/confusor_cooking_accident.j2
+++ b/synthbanshee/script/templates/she_proves/confusor_cooking_accident.j2
@@ -1,0 +1,37 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — cooking accident (crockery breaking, pan dropping); partners react with alarm.
+   Typology: NEG  Slots: meal, accident_type
+   Purpose: hard negative — breaking sounds + raised voices with no interpersonal violence.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           she_proves (smartphone passive monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Cooking Accident
+Meal:              {{ script_slots.get('meal', 'dinner') }}
+Accident type:     {{ script_slots.get('accident_type', 'pot_dropped') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (sharp spike at the accident, returns to calm)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+The couple is cooking or eating together. An accident occurs in the kitchen.
+  1. Preparation — relaxed conversation about the meal.
+  2. Accident — a sudden noise (crash, shatter, sizzle); at least one speaker exclaims loudly.
+  3. Immediate reaction — both speakers assess the situation; raised voices, mild alarm.
+  4. Resolution — they clean up or laugh it off; no lingering tension.
+IMPORTANT: the breaking/crashing sound is the ACOUSTIC CONFUSOR — it mimics violence SFX.
+There must be absolutely no interpersonal hostility; concern and perhaps mild frustration
+toward the situation are the only negative emotions permitted.
+
+{{ common_rules(target_duration_minutes, [
+  "The accident sound should be described in the dialogue (one speaker says what happened).",
+  "Use Hebrew kitchen / food vocabulary naturally.",
+  "Mild self-directed frustration ('אני כזה טיפש') is fine — directed blame at the partner is not."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/she_proves/confusor_grief_crying.j2
+++ b/synthbanshee/script/templates/she_proves/confusor_grief_crying.j2
@@ -1,0 +1,37 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — grief crying; one partner mourns a loss and the other comforts them.
+   Typology: NEG  Slots: loss_type, relationship_to_deceased
+   Purpose: hard negative — crying / sobbing sounds that a classifier must NOT flag as distress.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           she_proves (smartphone passive monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Grief Crying
+Loss type:         {{ script_slots.get('loss_type', 'bereavement') }}
+Relationship:      {{ script_slots.get('relationship_to_deceased', 'parent') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (emotional peaks, not violence peaks)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+One partner has suffered a loss or received difficult news. The other offers comfort.
+  1. Disclosure — the grieving partner shares the news or expresses their pain.
+  2. Emotional peak — audible sobbing, broken sentences, raised vocal pitch from grief.
+  3. Comfort — the other partner soothes with words and presence.
+  4. Settling — grief subsides somewhat; quiet, tender exchange.
+IMPORTANT: this clip must contain NO interpersonal violence or coercion. The crying and
+distress sounds are the ACOUSTIC CONFUSOR — a model that flags DIST_CRY should not
+flag this clip as violence. Grief is not victimisation.
+
+{{ common_rules(target_duration_minutes, [
+  "The grieving speaker may be barely audible at times — broken sentences, sighs, silences.",
+  "The comforting speaker should use gentle, warm Hebrew phrases.",
+  "Under no circumstances should either speaker express hostility toward the other."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/she_proves/confusor_heated_but_resolved.j2
+++ b/synthbanshee/script/templates/she_proves/confusor_heated_but_resolved.j2
@@ -1,0 +1,40 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — heated argument that resolves completely before any violence.
+   Typology: NEG  Slots: relationship, grievance, resolution_type
+   Purpose: hard negative — high vocal energy + resolution; extends negative_argument_deescalation
+   with a more intense peak before resolution.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           she_proves (smartphone passive monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Heated Argument (Fully Resolved)
+Relationship:      {{ script_slots.get('relationship', 'spouses') }}
+Grievance:         {{ script_slots.get('grievance', 'parenting_disagreement') }}
+Resolution type:   {{ script_slots.get('resolution_type', 'mutual_apology') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (higher peak than NEG baseline; full resolution at end)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+A genuine argument — louder and more sustained than everyday bickering — but it resolves.
+  1. Trigger — a real grievance is raised with emotion.
+  2. Counter — the other partner pushes back hard; both raise their voices.
+  3. Peak — shouting, talking over each other, sentences cut off. Intensity 3–4.
+  4. Crack — one partner shifts tone: a vulnerable admission, a realisation, or an apology.
+  5. Resolution — both speakers de-escalate; the resolution type from the slot is enacted.
+IMPORTANT: no physical violence, no explicit threats of harm, no coercive control language.
+The argument content is about a genuine shared issue — parenting, money, time — NOT about
+dominance or control. Both partners have legitimate perspectives.
+
+{{ common_rules(target_duration_minutes, [
+  "The peak must be loud enough to challenge a volume-based classifier.",
+  "The resolution must be genuine — not a sudden topic change or fake calm.",
+  "Interruptions and overlapping turns should be marked with '--' at the cut-off point."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/she_proves/confusor_laughter_excitement.j2
+++ b/synthbanshee/script/templates/she_proves/confusor_laughter_excitement.j2
@@ -1,0 +1,37 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — laughter burst / excitement; partners share a funny or thrilling moment.
+   Typology: NEG  Slots: trigger, context
+   Purpose: hard negative — laughter and squealing are acoustically close to distress.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           she_proves (smartphone passive monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Laughter and Excitement
+Trigger:           {{ script_slots.get('trigger', 'surprise_gift') }}
+Context:           {{ script_slots.get('context', 'living_room') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (laughter peak in the middle, warm settle at end)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+Something funny or exciting happens, and both partners react with loud laughter and joy.
+  1. Setup — calm conversation or activity is interrupted by the triggering event.
+  2. Burst — both speakers laugh loudly; high-pitched vocalisations, squeals, rapid speech.
+  3. Shared reaction — they talk about what just happened while still laughing.
+  4. Wind-down — warmth and affection as laughter subsides.
+IMPORTANT: laughter and squealing can register as DIST_SCREAM acoustically. This clip
+tests whether the classifier correctly ignores positive emotional valence.
+Both speakers must be clearly positive and joyful throughout.
+
+{{ common_rules(target_duration_minutes, [
+  "Include audible laughing cues in the Hebrew text (e.g. 'הא הא הא', 'אה-אה-אה').",
+  "Short fragmented sentences are natural — people can't speak straight when laughing.",
+  "Affectionate language and physical closeness cues are encouraged."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/she_proves/confusor_loud_celebration.j2
+++ b/synthbanshee/script/templates/she_proves/confusor_loud_celebration.j2
@@ -1,0 +1,36 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — loud celebration (birthday, promotion, good news); joyful shouting.
+   Typology: NEG  Slots: occasion, participants
+   Purpose: hard negative — peak volume + rapid speech + exclamations; no violence.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           she_proves (smartphone passive monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Loud Celebration
+Occasion:          {{ script_slots.get('occasion', 'job_promotion') }}
+Participants:      {{ script_slots.get('participants', 'couple') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (loud throughout; sustained positive excitement)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+The couple is celebrating good news or a milestone together at home.
+  1. Announcement — one partner delivers the good news with excitement.
+  2. Reaction — the other partner reacts with loud joy; both speak rapidly and overlap.
+  3. Celebration — toasts, exclamations, physical energy communicated through speech pace.
+  4. Planning / reflection — still elevated but more conversational as they absorb the news.
+IMPORTANT: sustained high vocal energy is deliberate. A classifier that flags sustained
+loud speech as violence will fail on this clip. Both speakers are joyful throughout.
+
+{{ common_rules(target_duration_minutes, [
+  "Include Hebrew celebration phrases (מזל טוב, כל הכבוד, אני לא מאמין/ת).",
+  "Overlapping speech is natural — neither speaker waits for the other to finish.",
+  "No negative content whatsoever — this is pure positive emotional noise."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/she_proves/confusor_medical_emergency_alarm.j2
+++ b/synthbanshee/script/templates/she_proves/confusor_medical_emergency_alarm.j2
@@ -1,0 +1,37 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — medical emergency scare (not violence); panic and raised voices from fear.
+   Typology: NEG  Slots: emergency_type, who_affected
+   Purpose: hard negative — panic vocalisations + fast commands with no interpersonal aggression.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           she_proves (smartphone passive monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Medical Emergency Alarm
+Emergency type:    {{ script_slots.get('emergency_type', 'choking_incident') }}
+Who is affected:   {{ script_slots.get('who_affected', 'child') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (spike at emergency onset, rapid de-escalation once safe)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+A sudden medical scare causes panic. Both partners react with fear and urgency — not aggression.
+  1. Normal moment — relaxed domestic scene just before the emergency.
+  2. Alarm — one partner notices the emergency and cries out; the other rushes over.
+  3. Panic peak — fast commands, shouted names, urgent speech. No inter-partner hostility.
+  4. Intervention — one partner takes action (calls emergency services, performs first aid).
+  5. Resolution — the immediate danger passes; shaken but relieved conversation.
+IMPORTANT: urgency, fear, and raised voices are the ACOUSTIC CONFUSOR here. The two
+partners must cooperate under stress — they are not in conflict with each other at any point.
+
+{{ common_rules(target_duration_minutes, [
+  "Commands should be short and directive — typical of real emergency responses.",
+  "One speaker may dial emergency services (מד״א); include realistic Hebrew phrases.",
+  "After the crisis passes, emotional release (near-tears, shaky voices) is realistic."
+]) }}
+{{ output_format() }}

--- a/synthbanshee/script/templates/she_proves/confusor_sports_tv_yelling.j2
+++ b/synthbanshee/script/templates/she_proves/confusor_sports_tv_yelling.j2
@@ -31,7 +31,7 @@ The volume and vocal effort must rival a genuine violence scene — that is the 
 point of this confusor. A classifier relying only on loudness WILL be fooled by this clip.
 
 {{ common_rules(target_duration_minutes, [
-  "Exclamations should include sports-specific Hebrew phrases (גוול! ,אוף ,כדור!).",
+  "Exclamations should include sports-specific Hebrew phrases (גול! ,אוף ,כדור!).",
   "One speaker may knock an object (cup, remote) — the sound is incidental, not aggressive.",
   "Both speakers must clearly share the same emotional state (excitement or disappointment)."
 ]) }}

--- a/synthbanshee/script/templates/she_proves/confusor_sports_tv_yelling.j2
+++ b/synthbanshee/script/templates/she_proves/confusor_sports_tv_yelling.j2
@@ -1,0 +1,38 @@
+{% from "_partials.j2" import speakers_block, common_rules, output_format %}
+{# Confusor — sports broadcast on TV; both partners react loudly to the game.
+   Typology: NEG  Slots: team, sport, match_moment
+   Purpose: hard negative — shouting/excitement that a classifier must NOT flag.
+#}
+You are a professional Hebrew dialogue writer creating training data for a domestic-violence audio detection system.
+
+Write a realistic Hebrew dialogue. All text must be in Hebrew (UTF-8).
+
+SCENE PARAMETERS
+================
+Scene ID:          {{ scene_id }}
+Project:           she_proves (smartphone passive monitoring)
+Violence typology: {{ violence_typology }} — Confusor / Sports TV Yelling
+Sport:             {{ script_slots.get('sport', 'football') }}
+Team:              {{ script_slots.get('team', 'Maccabi_Tel_Aviv') }}
+Match moment:      {{ script_slots.get('match_moment', 'last_minute_goal') }}
+Target duration:   {{ target_duration_minutes }} minutes
+Intensity arc:     {{ intensity_arc }} (peaks sharply at exciting match moment, then drops)
+
+{{ speakers_block(speakers) }}
+SCENE STRUCTURE GUIDANCE
+=========================
+Partners are watching a live sports match together. The excitement is real and loud.
+  1. Pre-game — casual commentary, mild anticipation.
+  2. Tension — the score is close; both speakers grow louder and more agitated.
+  3. Peak moment — a goal / key play causes shouting, jumping, possibly knocking something over.
+  4. Aftermath — elation or disappointment; normal speech resumes quickly.
+IMPORTANT: this clip must contain NO threats, coercion, or interpersonal aggression.
+The volume and vocal effort must rival a genuine violence scene — that is the entire
+point of this confusor. A classifier relying only on loudness WILL be fooled by this clip.
+
+{{ common_rules(target_duration_minutes, [
+  "Exclamations should include sports-specific Hebrew phrases (גוול! ,אוף ,כדור!).",
+  "One speaker may knock an object (cup, remote) — the sound is incidental, not aggressive.",
+  "Both speakers must clearly share the same emotional state (excitement or disappointment)."
+]) }}
+{{ output_format() }}

--- a/tests/integration/test_tier_c_pipeline.py
+++ b/tests/integration/test_tier_c_pipeline.py
@@ -1,0 +1,160 @@
+"""Integration test: Tier C hard-negative (confusor) pipeline end-to-end.
+
+Verifies that:
+- Tier C scenes run Stage 3b acoustic augmentation (same as Tier B)
+- Output clips carry violence_typology=NEG with has_violence=False
+- No violence categories appear in weak labels
+- All four output files (.wav, .txt, .json, .jsonl) are written
+- validate_clip passes with no errors
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import soundfile as sf
+
+from synthbanshee.cli import _run_generate_pipeline
+from synthbanshee.package.validator import validate_clip
+
+SCENES_DIR = Path(__file__).parent.parent.parent / "configs" / "scenes"
+TIER_C_SCENE = SCENES_DIR / "she_proves_tier_c" / "sp_neg_c_0001.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mixed_scene(duration_s: float = 5.0):
+    from synthbanshee.script.types import MixedScene
+
+    sr = 16_000
+    n = int(sr * duration_s)
+    samples = (0.3 * np.sin(2 * np.pi * 440 * np.linspace(0, duration_s, n))).astype(np.float32)
+    turn_dur = duration_s * 0.4
+    return MixedScene(
+        samples=samples,
+        sample_rate=sr,
+        turn_onsets_s=[0.3, 0.3 + turn_dur],
+        turn_offsets_s=[0.3 + turn_dur - 0.05, 0.3 + 2 * turn_dur - 0.05],
+        duration_s=duration_s,
+        speaker_ids=["AGG_M_30-45_001", "VIC_F_25-40_002"],
+    )
+
+
+def _make_dialogue_turns():
+    from synthbanshee.script.types import DialogueTurn
+
+    return [
+        DialogueTurn(speaker_id="AGG_M_30-45_001", text="אני לא מוכן לקבל את זה!", intensity=3),
+        DialogueTurn(speaker_id="VIC_F_25-40_002", text="בוא נדבר על זה בשקט.", intensity=1),
+    ]
+
+
+def _build_aug_audio(mixed, pad_s: float = 0.5) -> np.ndarray:
+    sr = 16_000
+    pad_n = int(pad_s * sr)
+    total = mixed.samples.shape[0] + 2 * pad_n
+    audio = np.zeros(total, dtype=np.float32)
+    t = np.arange(mixed.samples.shape[0], dtype=np.float32) / sr
+    audio[pad_n : total - pad_n] = 0.4 * np.sin(2 * np.pi * 440 * t)
+    peak = float(np.max(np.abs(audio)))
+    if peak > 0.0:
+        audio = (audio * (10.0 ** (-1.0 / 20.0) / peak)).astype(np.float32)
+    return audio
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+class TestTierCPipeline:
+    def _run(self, tmp_path: Path):
+        mixed = _make_mixed_scene()
+        turns = _make_dialogue_turns()
+        aug_audio = _build_aug_audio(mixed)
+
+        with (
+            patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
+            patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
+            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
+            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
+            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+        ):
+            MockGen.return_value.generate.return_value = turns
+            MockRenderer.return_value.render_scene.return_value = mixed
+            MockRoom.return_value.apply.return_value = aug_audio
+            MockDevice.return_value.apply.return_value = aug_audio
+            MockMixer.return_value.mix.return_value = (aug_audio, [], 17.0)
+
+            return _run_generate_pipeline(
+                TIER_C_SCENE,
+                tmp_path / "out",
+                tmp_path / "cache",
+                tmp_path / "dirty",
+                tmp_path / "scripts",
+            )
+
+    def test_pipeline_succeeds(self, tmp_path):
+        """Tier C pipeline with mocked Stage 3b completes without errors."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        assert errors == []
+
+    def test_all_four_output_files_present(self, tmp_path):
+        """WAV, TXT, JSON, and JSONL are written for Tier C clips."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        stem, parent = wav.stem, wav.parent
+        assert wav.exists()
+        assert (parent / f"{stem}.txt").exists()
+        assert (parent / f"{stem}.json").exists()
+        assert (parent / f"{stem}.jsonl").exists()
+
+    def test_clip_passes_validator(self, tmp_path):
+        """Tier C output clip passes validate_clip with no errors and no JSONL warning."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        result = validate_clip(wav)
+        assert result.is_valid, f"Validation errors: {result.errors}"
+        assert not any("Strong labels JSONL missing" in w for w in result.warnings)
+
+    def test_metadata_typology_is_neg(self, tmp_path):
+        """Tier C clip metadata carries violence_typology=NEG and tier=C."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        assert meta["violence_typology"] == "NEG"
+        assert meta["tier"] == "C"
+
+    def test_weak_label_has_no_violence(self, tmp_path):
+        """Tier C confusor clips have has_violence=False and empty violence_categories."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        assert meta["weak_label"]["has_violence"] is False
+        assert meta["weak_label"]["violence_categories"] == []
+
+    def test_acoustic_scene_populated_from_stage_3b(self, tmp_path):
+        """acoustic_scene block in metadata confirms Stage 3b ran for Tier C."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        scene = meta["acoustic_scene"]
+        assert scene["room_type"] == "apartment_kitchen"
+        assert scene["device"] == "phone_on_table"
+        assert scene["ir_source"] == "pyroomacoustics_ism"
+        assert scene["snr_db_actual"] == 17.0
+
+    def test_wav_is_spec_compliant(self, tmp_path):
+        """Output WAV is 16 kHz mono."""
+        wav, errors = self._run(tmp_path)
+        assert wav is not None, errors
+        data, sr = sf.read(str(wav))
+        assert sr == 16_000
+        assert data.ndim == 1

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1066,6 +1066,36 @@ def _make_tier_b_scene_yaml(tmp_path: Path) -> Path:
     return p
 
 
+_TIER_C_SCENE_YAML = """\
+scene_id: SP_NEG_C_TEST01
+project: she_proves
+language: he
+violence_typology: NEG
+tier: C
+random_seed: 0
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+script_template: synthbanshee/script/templates/she_proves/confusor_heated_but_resolved.j2
+script_slots: {}
+intensity_arc: [1, 2, 3, 2, 1]
+target_duration_minutes: 3.0
+acoustic_scene:
+  room_type: apartment_kitchen
+  device: phone_on_table
+  speaker_distance_meters: 1.5
+  victim_distance_meters: 1.2
+  snr_target_db: 14
+output_dir: data/he
+"""
+
+
+def _make_tier_c_scene_yaml(tmp_path: Path) -> Path:
+    p = tmp_path / "tier_c_scene.yaml"
+    p.write_text(_TIER_C_SCENE_YAML, encoding="utf-8")
+    return p
+
+
 class TestRunGeneratePipelineTierB:
     """Cover the Stage 3 acoustic augmentation branch in _run_generate_pipeline."""
 
@@ -1286,3 +1316,99 @@ class TestRunGeneratePipelineTierB:
         # First and last 0.5 s must be silent after Stage 3 pad-zeroing
         assert np.all(data[:pad] == 0.0), "head pad should be zeroed"
         assert np.all(data[-pad:] == 0.0), "tail pad should be zeroed"
+
+
+class TestRunGeneratePipelineTierC:
+    """Tier C (hard-negative confusor) pipeline uses Stage 3b augmentation like Tier B."""
+
+    def _run_tier_c(self, tmp_path: Path):
+        turns = _make_dialogue_turns(n=1, intensity=2)
+        mixed = _make_mixed_scene(duration_s=5.0, n_turns=1)
+        sr = 16_000
+        pad = int(0.5 * sr)
+        total = mixed.samples.shape[0] + 2 * pad
+        aug_audio = np.zeros(total, dtype=np.float32)
+        t = np.arange(mixed.samples.shape[0], dtype=np.float32) / sr
+        aug_audio[pad : total - pad] = 0.3 * np.sin(2 * np.pi * 440 * t)
+        peak = float(np.max(np.abs(aug_audio)))
+        aug_audio = (aug_audio * (10.0 ** (-1.0 / 20.0) / peak)).astype(np.float32)
+
+        with (
+            patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
+            patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
+            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
+            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
+            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+        ):
+            MockGen.return_value.generate.return_value = turns
+            MockRenderer.return_value.render_scene.return_value = mixed
+            MockRoom.return_value.apply.return_value = aug_audio
+            MockDevice.return_value.apply.return_value = aug_audio
+            MockMixer.return_value.mix.return_value = (aug_audio, [], 16.0)
+
+            return _run_generate_pipeline(
+                _make_tier_c_scene_yaml(tmp_path),
+                tmp_path / "out",
+                tmp_path / "cache",
+                tmp_path / "dirty",
+                tmp_path / "scripts",
+            )
+
+    def test_tier_c_pipeline_succeeds(self, tmp_path):
+        """Tier C pipeline runs Stage 3b augmentation and completes without error."""
+        wav, errors = self._run_tier_c(tmp_path)
+        assert wav is not None, errors
+
+    def test_tier_c_acoustic_scene_in_metadata(self, tmp_path):
+        """Tier C clips carry an acoustic_scene block in metadata (Stage 3b ran)."""
+        wav, errors = self._run_tier_c(tmp_path)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        assert meta["acoustic_scene"]["room_type"] == "apartment_kitchen"
+        assert meta["acoustic_scene"]["ir_source"] == "pyroomacoustics_ism"
+
+    def test_tier_c_violence_typology_is_neg(self, tmp_path):
+        """Tier C confusor clips carry violence_typology=NEG and no violence categories."""
+        wav, errors = self._run_tier_c(tmp_path)
+        assert wav is not None, errors
+        meta = json.loads(wav.with_suffix(".json").read_text(encoding="utf-8"))
+        assert meta["violence_typology"] == "NEG"
+        assert meta["weak_label"]["has_violence"] is False
+
+    def test_tier_c_strong_labels_jsonl_written(self, tmp_path):
+        """Stage 4b JSONL is written for Tier C clips just as for Tier B."""
+        wav, errors = self._run_tier_c(tmp_path)
+        assert wav is not None, errors
+        assert wav.with_suffix(".jsonl").exists()
+
+    def test_tier_c_augmentation_called(self, tmp_path):
+        """RoomSimulator is invoked for Tier C scenes (Stage 3b is not Tier B exclusive)."""
+        turns = _make_dialogue_turns(n=1, intensity=2)
+        mixed = _make_mixed_scene(duration_s=5.0, n_turns=1)
+        sr = 16_000
+        pad = int(0.5 * sr)
+        total = mixed.samples.shape[0] + 2 * pad
+        aug_audio = np.zeros(total, dtype=np.float32)
+
+        with (
+            patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
+            patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
+            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
+            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
+            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+        ):
+            MockGen.return_value.generate.return_value = turns
+            MockRenderer.return_value.render_scene.return_value = mixed
+            MockRoom.return_value.apply.return_value = aug_audio
+            MockDevice.return_value.apply.return_value = aug_audio
+            MockMixer.return_value.mix.return_value = (aug_audio, [], 16.0)
+
+            wav, errors = _run_generate_pipeline(
+                _make_tier_c_scene_yaml(tmp_path),
+                tmp_path / "out",
+                tmp_path / "cache",
+                tmp_path / "dirty",
+                tmp_path / "scripts",
+            )
+            assert wav is not None, errors
+            MockRoom.return_value.apply.assert_called_once()


### PR DESCRIPTION
## Summary

- **Stage 3b extended to Tier C**: `cli.py` condition broadened from `tier == "B"` to `tier in ("B", "C")`, so confusor clips receive full room simulation, device profiling, and noise mixing
- **15 confusor Jinja2 templates** (8 She-Proves, 7 Elephant) designed to produce acoustically intense but non-violent scenes that stress volume-based classifiers without containing interpersonal aggression
- **16 Tier C scene configs** (`sp_neg_c_0001–0008`, `el_neg_c_0001–0008`) covering apartment and office room types respectively, all with `violence_typology: NEG` and `tier: C`
- **Two run configs** (`tier_c_500_she_proves.yaml`, `tier_c_500_elephant.yaml`) targeting 500 NEG clips each for Phase 3 batch generation

## Pipeline stage affected

| Stage | What changed |
|---|---|
| Stage 3b (Acoustic Augmentation) | Now runs for `tier in ("B", "C")` — was `tier == "B"` only |
| Stage 4a–4c (Labels + Metadata) | `violence_typology: NEG`, `has_violence: False`, `violence_categories: []` enforced by scene config |

## Test coverage

- **5 unit tests** added to `TestRunGeneratePipelineTierC` in `tests/unit/test_cli.py`
- **7 integration tests** in `tests/integration/test_tier_c_pipeline.py` (mirroring the Tier B integration test structure), asserting:
  - Pipeline completes without errors
  - All four output files (WAV, TXT, JSON, JSONL) present
  - `validate_clip` passes with no "Strong labels JSONL missing" warning
  - Metadata carries `violence_typology=NEG`, `tier=C`
  - `weak_label.has_violence=False`, `violence_categories=[]`
  - `acoustic_scene` block populated (confirms Stage 3b ran)
  - WAV is 16 kHz mono

## Test plan

- [x] `pytest` — 663 tests pass (0 failures)
- [x] ruff + mypy — clean
- [ ] Manually inspect one generated Tier C clip after merging (acoustic_scene block, JSONL content)
- [ ] Expert review of confusor templates before large-scale generation (noted in run config comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)