### PR TITLE
feat(m1): Hebrew gender disambiguation — pipeline Stage 1b

### DIFF
--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -162,6 +162,15 @@ def _run_generate_pipeline(
 
     vlog(f"  [dim]script: {len(turns)} turns[/dim]")
 
+    # Stage 1b — Hebrew Gender Disambiguation
+    vlog("[bold]Stage 1b[/bold] — Hebrew gender disambiguation")
+    from synthbanshee.script.hebrew_disambiguator import disambiguate_turns
+
+    speaker_roles_map = {spk_ref.speaker_id: spk_ref.role for spk_ref in scene.speakers}
+    turns = disambiguate_turns(turns, speaker_roles_map)
+    n_modified = sum(1 for t in turns if t.normalization_rules_triggered)
+    vlog(f"  [dim]disambiguation: {n_modified}/{len(turns)} turns modified[/dim]")
+
     # Stage 2 — TTS Rendering
     # 4. Render multi-speaker scene
     vlog(f"[bold]Stage 2[/bold] — TTS rendering ({len(turns)} turns)")

--- a/synthbanshee/script/hebrew_disambiguator.py
+++ b/synthbanshee/script/hebrew_disambiguator.py
@@ -1,0 +1,276 @@
+"""Hebrew gender disambiguation for TTS text normalization (pipeline M1).
+
+Azure TTS defaults to masculine inflection for morphologically ambiguous
+unvocalized Hebrew second-person forms.  When the aggressor (AGG) addresses
+the victim (VIC) — the dominant address direction in the current scenes —
+this produces systematic gender errors that are audible to native speakers
+and confirmed by direct listening (Shay, debug_run_1).
+
+Strategy: rule-based lexicon substitution that inserts niqqud (Hebrew vowel
+diacritics) for the highest-risk tokens so that Azure TTS receives an
+unambiguous phonetic target and reads the correct feminine form.
+
+Only ``DialogueTurn.text_spoken`` is modified; the original LLM output
+(``DialogueTurn.text``) is preserved unchanged for auditing and caching.
+
+Reference: docs/audio_generation_v3_design.md §4.1, M1
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from synthbanshee.script.types import DialogueTurn
+
+
+class LexiconEntry(NamedTuple):
+    """One disambiguation rule mapping an ambiguous surface form to its vocalized feminine replacement."""
+
+    rule_id: str
+    surface: str  # unvocalized form to match in source text
+    feminine_spoken: str  # niqqud-vocalized form for TTS; forces feminine reading
+    description: str  # human-readable note (masc default → correct fem reading)
+
+
+# ---------------------------------------------------------------------------
+# Lexicon — high-risk second-person forms
+# ---------------------------------------------------------------------------
+#
+# Sources: Shay's direct listening feedback on debug_run_1 ("שלך always
+# pronounced 'shelkha' instead of 'shelakh', הלכת pronounced 'halakhta'
+# instead of 'halakht'"), Gemini review, Hebrew morphological reference.
+#
+# Each entry targets a form where:
+#   (a) the written unvocalized text is identical for masc and fem, and
+#   (b) Azure TTS (he-IL-AvriNeural) defaults to the masculine reading.
+#
+# The niqqud replacement is the *only* change — the surrounding text is
+# untouched.  IPA equivalents are in the description for verification.
+
+_LEXICON: tuple[LexiconEntry, ...] = (
+    # --- Possessive / object pronouns ---
+    LexiconEntry(
+        "POSS_SHEL",
+        "שלך",
+        "שֶׁלָּךְ",
+        "shelakh (f) ← shelkha (m default); 'yours'",
+    ),
+    LexiconEntry(
+        "PRON_OTKH",
+        "אותך",
+        "אוֹתָךְ",
+        "otakh (f) ← otkha (m default); 'you' (direct object)",
+    ),
+    LexiconEntry(
+        "PRON_ITZAKH",
+        "אתך",
+        "אִתָּךְ",
+        "itakh (f) ← itkha (m default); 'with you'",
+    ),
+    # --- Prepositional clitics ---
+    LexiconEntry(
+        "PREP_LAKH",
+        "לך",
+        "לָךְ",
+        "lakh (f) ← lekha (m default); 'to/for you'",
+    ),
+    LexiconEntry(
+        "PREP_BAKH",
+        "בך",
+        "בָּךְ",
+        "bakh (f) ← bekha (m default); 'in/at you'",
+    ),
+    LexiconEntry(
+        "PREP_MIMEKH",
+        "ממך",
+        "מִמֵּךְ",
+        "mimekh (f) ← mimkha (m default); 'from you'",
+    ),
+    LexiconEntry(
+        "PREP_ALAIKH",
+        "עליך",
+        "עָלַיִךְ",
+        "alaikh (f) ← alekha (m default); 'on/about you'",
+    ),
+    LexiconEntry(
+        "PREP_ELAIKH",
+        "אליך",
+        "אֵלַיִךְ",
+        "elaikh (f) ← elekha (m default); 'toward you'",
+    ),
+    # --- Past-tense 2sg verbs — fem ends /-t/ (תְּ), masc /-ta/ (תָּ) ---
+    LexiconEntry(
+        "VERB_PAST_HALAKHT",
+        "הלכת",
+        "הָלַכְתְּ",
+        "halakht (f) ← halakhta (m default); 'you went'",
+    ),
+    LexiconEntry(
+        "VERB_PAST_ASIT",
+        "עשית",
+        "עָשִׂיתְ",
+        "asit (f) ← asita (m default); 'you did/made'",
+    ),
+    LexiconEntry(
+        "VERB_PAST_KHASHAVT",
+        "חשבת",
+        "חָשַׁבְתְּ",
+        "khashavt (f) ← khashavta (m default); 'you thought'",
+    ),
+    LexiconEntry(
+        "VERB_PAST_DIBBART",
+        "דיברת",
+        "דִּיבַּרְתְּ",
+        "dibart (f) ← dibarta (m default); 'you spoke'",
+    ),
+    LexiconEntry(
+        "VERB_PAST_YADAT",
+        "ידעת",
+        "יָדַעְתְּ",
+        "yadat (f) ← yadata (m default); 'you knew'",
+    ),
+    LexiconEntry(
+        "VERB_PAST_HAYIT",
+        "היית",
+        "הָיִיתְ",
+        "hayit (f) ← hayita (m default); 'you were'",
+    ),
+    LexiconEntry(
+        "VERB_PAST_RATSIT",
+        "רצית",
+        "רָצִיתְ",
+        "ratsit (f) ← ratsita (m default); 'you wanted'",
+    ),
+)
+
+# Pre-compile one regex per lexicon entry.
+# Lookahead/lookbehind on Hebrew base letters (U+05D0–U+05EA) ensure we
+# match whole tokens, not substrings embedded inside longer words.
+_HEB_LETTER = r"[\u05D0-\u05EA]"
+
+_COMPILED: tuple[tuple[LexiconEntry, re.Pattern[str]], ...] = tuple(
+    (
+        entry,
+        re.compile(
+            r"(?<!" + _HEB_LETTER + r")" + re.escape(entry.surface) + r"(?!" + _HEB_LETTER + r")"
+        ),
+    )
+    for entry in _LEXICON
+)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NormalizationResult:
+    """Outcome of gender disambiguation for one utterance.
+
+    Attributes:
+        text_spoken: Modified text ready to send to TTS.  Identical to the
+            input when no rules fire.
+        normalization_rules_triggered: Ordered list of ``LexiconEntry.rule_id``
+            values for every substitution that was applied.  Empty when the
+            input required no changes.
+    """
+
+    text_spoken: str
+    normalization_rules_triggered: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def disambiguate_for_speaker(
+    text: str,
+    speaker_role: str,
+    addressee_role: str,
+) -> NormalizationResult:
+    """Apply feminine gender corrections when AGG addresses VIC.
+
+    Substitutions are only applied when *speaker_role* is ``"AGG"`` and
+    *addressee_role* is ``"VIC"`` — the dominant AGG→VIC direction in all
+    current scene configurations.  All other role pairs are returned
+    unchanged, preserving VIC self-references and VIC→AGG address forms.
+
+    Args:
+        text: UTF-8 Hebrew source text (``DialogueTurn.text``).
+        speaker_role: Role of the turn's speaker, e.g. ``"AGG"``.
+        addressee_role: Role of the primary addressee, e.g. ``"VIC"``.
+
+    Returns:
+        :class:`NormalizationResult` carrying the (possibly modified)
+        ``text_spoken`` and the list of rule IDs that fired.
+    """
+    if not (speaker_role == "AGG" and addressee_role == "VIC"):
+        return NormalizationResult(text_spoken=text)
+
+    result = text
+    triggered: list[str] = []
+    for entry, pattern in _COMPILED:
+        new_text, n = pattern.subn(entry.feminine_spoken, result)
+        if n:
+            result = new_text
+            triggered.append(entry.rule_id)
+
+    return NormalizationResult(
+        text_spoken=result,
+        normalization_rules_triggered=triggered,
+    )
+
+
+def disambiguate_turns(
+    turns: list[DialogueTurn],
+    speaker_roles: dict[str, str],
+) -> list[DialogueTurn]:
+    """Apply gender disambiguation to every turn in a scene.
+
+    For each turn the addressee role is inferred as the role of the first
+    other speaker in *speaker_roles* — correct for the standard two-speaker
+    AGG/VIC scene.  For scenes with more than two speaker roles the heuristic
+    may be inaccurate; it is still better than applying no disambiguation.
+
+    The original ``DialogueTurn`` objects are never mutated.  New instances
+    are returned with ``text_spoken`` and ``normalization_rules_triggered``
+    populated.
+
+    Args:
+        turns: Ordered list of turns from :class:`ScriptGenerator`.
+        speaker_roles: Mapping ``{speaker_id: role}`` for all speakers in
+            the scene (built from ``SceneConfig.speakers``).
+
+    Returns:
+        New list of :class:`DialogueTurn` with disambiguation applied.
+    """
+
+    def _addressee_role(speaker_id: str) -> str:
+        my_role = speaker_roles.get(speaker_id, "UNK")
+        for sid, role in speaker_roles.items():
+            if sid != speaker_id and role != my_role:
+                return role
+        return "UNK"
+
+    result: list[DialogueTurn] = []
+    for turn in turns:
+        addr_role = _addressee_role(turn.speaker_id)
+        norm = disambiguate_for_speaker(
+            turn.text,
+            speaker_roles.get(turn.speaker_id, "UNK"),
+            addr_role,
+        )
+        result.append(
+            dataclasses.replace(
+                turn,
+                text_spoken=norm.text_spoken,
+                normalization_rules_triggered=norm.normalization_rules_triggered,
+            )
+        )
+    return result

--- a/synthbanshee/script/hebrew_disambiguator.py
+++ b/synthbanshee/script/hebrew_disambiguator.py
@@ -148,15 +148,25 @@ _LEXICON: tuple[LexiconEntry, ...] = (
 )
 
 # Pre-compile one regex per lexicon entry.
-# Lookahead/lookbehind on Hebrew base letters (U+05D0–U+05EA) ensure we
-# match whole tokens, not substrings embedded inside longer words.
-_HEB_LETTER = r"[\u05D0-\u05EA]"
+# Lookahead/lookbehind on Hebrew token characters ensure we match whole
+# tokens, not substrings embedded inside longer words.  The guard covers
+# both Hebrew base letters (U+05D0–U+05EA) and Hebrew combining marks /
+# related marks (U+0591–U+05C7), so a partially-vocalized letter immediately
+# adjacent to the surface form does not create a false word boundary that
+# would allow an in-word match.
+_HEB_TOKEN_CHAR = r"[\u0591-\u05C7\u05D0-\u05EA]"
 
 _COMPILED: tuple[tuple[LexiconEntry, re.Pattern[str]], ...] = tuple(
     (
         entry,
         re.compile(
-            r"(?<!" + _HEB_LETTER + r")" + re.escape(entry.surface) + r"(?!" + _HEB_LETTER + r")"
+            r"(?<!"
+            + _HEB_TOKEN_CHAR
+            + r")"
+            + re.escape(entry.surface)
+            + r"(?!"
+            + _HEB_TOKEN_CHAR
+            + r")"
         ),
     )
     for entry in _LEXICON
@@ -251,8 +261,19 @@ def disambiguate_turns(
         New list of :class:`DialogueTurn` with disambiguation applied.
     """
 
+    # Priority order for addressee selection in multi-speaker scenes.
+    # AGG prefers VIC; VIC prefers AGG; BYS is always last resort.
+    _ROLE_PRIORITY = ["VIC", "AGG", "BYS"]
+
     def _addressee_role(speaker_id: str) -> str:
         my_role = speaker_roles.get(speaker_id, "UNK")
+        other_roles = {
+            role for sid, role in speaker_roles.items() if sid != speaker_id and role != my_role
+        }
+        for candidate in _ROLE_PRIORITY:
+            if candidate in other_roles:
+                return candidate
+        # Fall back to any other role not in the priority list.
         for sid, role in speaker_roles.items():
             if sid != speaker_id and role != my_role:
                 return role

--- a/synthbanshee/script/hebrew_disambiguator.py
+++ b/synthbanshee/script/hebrew_disambiguator.py
@@ -243,10 +243,15 @@ def disambiguate_turns(
 ) -> list[DialogueTurn]:
     """Apply gender disambiguation to every turn in a scene.
 
-    For each turn the addressee role is inferred as the role of the first
-    other speaker in *speaker_roles* — correct for the standard two-speaker
-    AGG/VIC scene.  For scenes with more than two speaker roles the heuristic
-    may be inaccurate; it is still better than applying no disambiguation.
+    For each turn the addressee role is inferred heuristically from the
+    other speakers in *speaker_roles*.  The function first looks for another
+    speaker whose role matches the priority order ``"VIC"``, ``"AGG"``,
+    ``"BYS"`` (excluding the current speaker's own ``speaker_id``).  If none
+    of those roles is present among the other speakers, it falls back to the
+    first other speaker role encountered.  This matches the standard
+    two-speaker AGG/VIC scene and provides a best-effort heuristic for
+    multi-speaker scenes, where the inferred addressee may still be
+    inaccurate.
 
     The original ``DialogueTurn`` objects are never mutated.  New instances
     are returned with ``text_spoken`` and ``normalization_rules_triggered``

--- a/synthbanshee/script/hebrew_disambiguator.py
+++ b/synthbanshee/script/hebrew_disambiguator.py
@@ -262,7 +262,7 @@ def disambiguate_turns(
     for turn in turns:
         addr_role = _addressee_role(turn.speaker_id)
         norm = disambiguate_for_speaker(
-            turn.text,
+            turn.text_spoken or turn.text,
             speaker_roles.get(turn.speaker_id, "UNK"),
             addr_role,
         )

--- a/synthbanshee/script/types.py
+++ b/synthbanshee/script/types.py
@@ -13,10 +13,18 @@ class DialogueTurn:
 
     Attributes:
         speaker_id: Matches a SpeakerConfig.speaker_id in the scene.
-        text: Hebrew UTF-8 utterance text. Never placed in filenames.
+        text: Original Hebrew UTF-8 text as produced by the LLM.  This is
+            the authoritative source of record and is never mutated after
+            creation.  Also accessible as ``text_original``.
         intensity: 1–5, drives SSML style selection in TTSRenderer.
         pause_before_s: Silence gap (seconds) inserted before this turn in the mix.
         emotional_state: LLM-generated hint; used as a secondary style cue.
+        text_spoken: Post-normalization text actually sent to TTS.  Populated
+            by the Hebrew gender-disambiguation step (M1); defaults to ``text``
+            when no normalization has been applied.
+        normalization_rules_triggered: Ordered list of disambiguation rule IDs
+            applied to produce ``text_spoken`` (e.g. ``["POSS_SHEL", "PREP_LAKH"]``).
+            Empty when ``text_spoken == text``.
     """
 
     speaker_id: str
@@ -24,6 +32,18 @@ class DialogueTurn:
     intensity: int
     pause_before_s: float = 0.3
     emotional_state: str = "neutral"
+    text_spoken: str = ""
+    normalization_rules_triggered: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # Default text_spoken to the original LLM text when not explicitly set.
+        if not self.text_spoken:
+            self.text_spoken = self.text
+
+    @property
+    def text_original(self) -> str:
+        """Alias for ``text``; the unmodified LLM output."""
+        return self.text
 
 
 @dataclass

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -190,7 +190,9 @@ class TTSRenderer:
         segments: list[tuple[bytes, float, str]] = []
         for i, turn in enumerate(turns):
             speaker = speakers[turn.speaker_id]
-            text = turn.text
+            # Use text_spoken (post-gender-disambiguation) rather than the
+            # raw LLM text so that niqqud corrections reach the TTS engine.
+            text = turn.text_spoken
             if disfluency:
                 text = inject_disfluency(
                     text,

--- a/tests/unit/test_hebrew_disambiguator.py
+++ b/tests/unit/test_hebrew_disambiguator.py
@@ -37,7 +37,8 @@ class TestDirectionGuard:
 
     def test_agg_vic_may_modify(self):
         result = disambiguate_for_speaker("שלך", "AGG", "VIC")
-        assert result.text_spoken != "שלך" or result.normalization_rules_triggered == []
+        assert result.text_spoken == "שֶׁלָּךְ"
+        assert result.normalization_rules_triggered == ["POSS_SHEL"]
 
     def test_vic_agg_no_change(self):
         result = disambiguate_for_speaker("שלך", "VIC", "AGG")
@@ -158,7 +159,7 @@ class TestMultipleSubstitutions:
     def test_rules_triggered_list_contains_each_rule_once(self):
         text = "הלכת לשם ועשית את זה"
         result = _agg_vic(text)
-        # Even though שלך might appear twice, each rule_id appears only once
+        # Each triggered rule_id should appear at most once in the result list
         seen = result.normalization_rules_triggered
         assert len(seen) == len(set(seen)), "Duplicate rule IDs in triggered list"
 

--- a/tests/unit/test_hebrew_disambiguator.py
+++ b/tests/unit/test_hebrew_disambiguator.py
@@ -1,0 +1,259 @@
+"""Unit tests for synthbanshee.script.hebrew_disambiguator (M1).
+
+Every lexicon entry is tested individually so that a bad niqqud character in
+the replacement string is caught immediately rather than silently producing
+wrong TTS output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from synthbanshee.script.hebrew_disambiguator import (
+    _LEXICON,
+    NormalizationResult,
+    disambiguate_for_speaker,
+    disambiguate_turns,
+)
+from synthbanshee.script.types import DialogueTurn
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _agg_vic(text: str) -> NormalizationResult:
+    """Convenience: disambiguate as AGG speaker addressing VIC."""
+    return disambiguate_for_speaker(text, speaker_role="AGG", addressee_role="VIC")
+
+
+# ---------------------------------------------------------------------------
+# disambiguate_for_speaker — direction guard
+# ---------------------------------------------------------------------------
+
+
+class TestDirectionGuard:
+    """Substitutions must only fire for AGG→VIC; all other pairs are no-ops."""
+
+    def test_agg_vic_may_modify(self):
+        result = disambiguate_for_speaker("שלך", "AGG", "VIC")
+        assert result.text_spoken != "שלך" or result.normalization_rules_triggered == []
+
+    def test_vic_agg_no_change(self):
+        result = disambiguate_for_speaker("שלך", "VIC", "AGG")
+        assert result.text_spoken == "שלך"
+        assert result.normalization_rules_triggered == []
+
+    def test_agg_agg_no_change(self):
+        result = disambiguate_for_speaker("הלכת", "AGG", "AGG")
+        assert result.text_spoken == "הלכת"
+        assert result.normalization_rules_triggered == []
+
+    def test_unk_speaker_no_change(self):
+        result = disambiguate_for_speaker("שלך", "UNK", "VIC")
+        assert result.text_spoken == "שלך"
+        assert result.normalization_rules_triggered == []
+
+    def test_vic_vic_no_change(self):
+        result = disambiguate_for_speaker("עשית", "VIC", "VIC")
+        assert result.text_spoken == "עשית"
+        assert result.normalization_rules_triggered == []
+
+
+# ---------------------------------------------------------------------------
+# disambiguate_for_speaker — pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestPassThrough:
+    def test_unlisted_word_unchanged(self):
+        text = "שלום, מה שלומך?"
+        result = _agg_vic(text)
+        assert result.text_spoken == text
+        assert result.normalization_rules_triggered == []
+
+    def test_empty_string(self):
+        result = _agg_vic("")
+        assert result.text_spoken == ""
+        assert result.normalization_rules_triggered == []
+
+    def test_already_vocalized_text_unchanged(self):
+        # Niqqud already present — surface form (unvocalized) won't match
+        text = "הָלַכְתְּ"
+        result = _agg_vic(text)
+        assert result.text_spoken == text
+        assert result.normalization_rules_triggered == []
+
+    def test_non_hebrew_text_unchanged(self):
+        text = "hello world"
+        result = _agg_vic(text)
+        assert result.text_spoken == text
+        assert result.normalization_rules_triggered == []
+
+
+# ---------------------------------------------------------------------------
+# disambiguate_for_speaker — individual lexicon entries
+# ---------------------------------------------------------------------------
+
+
+class TestLexiconEntries:
+    """One test per entry in _LEXICON ensuring the surface→feminine mapping is correct."""
+
+    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    def test_surface_replaced_by_feminine(self, entry):
+        """Each surface form surrounded by spaces must be replaced by its feminine variant."""
+        text = f"אמרתי {entry.surface} לאחרונה"
+        result = _agg_vic(text)
+        assert entry.surface not in result.text_spoken, (
+            f"Rule {entry.rule_id}: surface form still present after disambiguation"
+        )
+        assert entry.feminine_spoken in result.text_spoken, (
+            f"Rule {entry.rule_id}: feminine form not inserted"
+        )
+        assert entry.rule_id in result.normalization_rules_triggered
+
+    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    def test_surface_at_start_of_string(self, entry):
+        text = f"{entry.surface} הוא הדבר"
+        result = _agg_vic(text)
+        assert entry.feminine_spoken in result.text_spoken
+
+    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    def test_surface_at_end_of_string(self, entry):
+        text = f"רציתי לדבר {entry.surface}"
+        result = _agg_vic(text)
+        assert entry.feminine_spoken in result.text_spoken
+
+    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    def test_surface_not_matched_as_substring(self, entry):
+        """A longer Hebrew word that CONTAINS the surface form must not be corrupted."""
+        # Prepend and append a Hebrew letter to simulate embedding in a longer word.
+        # The lexicon entry should NOT match inside a longer word.
+        longer_word = "מ" + entry.surface + "ם"
+        result = _agg_vic(longer_word)
+        # The longer word is not a standalone match so text should be unchanged.
+        assert result.text_spoken == longer_word
+
+
+# ---------------------------------------------------------------------------
+# disambiguate_for_speaker — multiple substitutions
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleSubstitutions:
+    def test_two_tokens_in_one_turn(self):
+        text = "מה עשית עם שלך?"
+        result = _agg_vic(text)
+        assert "עָשִׂיתְ" in result.text_spoken
+        assert "שֶׁלָּךְ" in result.text_spoken
+        assert "VERB_PAST_ASIT" in result.normalization_rules_triggered
+        assert "POSS_SHEL" in result.normalization_rules_triggered
+
+    def test_same_token_twice(self):
+        text = "לך ואחרי זה לך שוב"
+        result = _agg_vic(text)
+        # Both occurrences of לך should be replaced
+        assert result.text_spoken.count("לָךְ") == 2
+
+    def test_rules_triggered_list_contains_each_rule_once(self):
+        text = "הלכת לשם ועשית את זה"
+        result = _agg_vic(text)
+        # Even though שלך might appear twice, each rule_id appears only once
+        seen = result.normalization_rules_triggered
+        assert len(seen) == len(set(seen)), "Duplicate rule IDs in triggered list"
+
+
+# ---------------------------------------------------------------------------
+# NormalizationResult
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizationResult:
+    def test_no_rules_gives_identical_text(self):
+        text = "בוקר טוב"
+        result = _agg_vic(text)
+        assert result.text_spoken == text
+        assert result.normalization_rules_triggered == []
+
+    def test_result_is_dataclass(self):
+        result = _agg_vic("שלך")
+        assert isinstance(result, NormalizationResult)
+
+
+# ---------------------------------------------------------------------------
+# DialogueTurn integration
+# ---------------------------------------------------------------------------
+
+
+class TestDialogueTurnDefaults:
+    def test_text_spoken_defaults_to_text(self):
+        turn = DialogueTurn(speaker_id="AGG_001", text="שלום", intensity=1)
+        assert turn.text_spoken == "שלום"
+
+    def test_text_original_property(self):
+        turn = DialogueTurn(speaker_id="AGG_001", text="שלום", intensity=1)
+        assert turn.text_original == "שלום"
+
+    def test_explicit_text_spoken_preserved(self):
+        turn = DialogueTurn(
+            speaker_id="AGG_001",
+            text="שלך",
+            intensity=1,
+            text_spoken="שֶׁלָּךְ",
+            normalization_rules_triggered=["POSS_SHEL"],
+        )
+        assert turn.text_spoken == "שֶׁלָּךְ"
+        assert turn.text == "שלך"
+
+    def test_normalization_rules_default_empty(self):
+        turn = DialogueTurn(speaker_id="AGG_001", text="שלום", intensity=1)
+        assert turn.normalization_rules_triggered == []
+
+
+# ---------------------------------------------------------------------------
+# disambiguate_turns
+# ---------------------------------------------------------------------------
+
+
+class TestDisambiguateTurns:
+    def _make_turns(self) -> list[DialogueTurn]:
+        return [
+            DialogueTurn(speaker_id="AGG_001", text="מה עשית?", intensity=2),
+            DialogueTurn(speaker_id="VIC_001", text="לא עשיתי כלום.", intensity=1),
+        ]
+
+    def _roles(self) -> dict[str, str]:
+        return {"AGG_001": "AGG", "VIC_001": "VIC"}
+
+    def test_agg_turn_modified(self):
+        turns = disambiguate_turns(self._make_turns(), self._roles())
+        agg_turn = next(t for t in turns if t.speaker_id == "AGG_001")
+        assert "עָשִׂיתְ" in agg_turn.text_spoken
+        assert "VERB_PAST_ASIT" in agg_turn.normalization_rules_triggered
+
+    def test_vic_turn_not_modified(self):
+        turns = disambiguate_turns(self._make_turns(), self._roles())
+        vic_turn = next(t for t in turns if t.speaker_id == "VIC_001")
+        # VIC→AGG direction: no feminine substitution applied
+        assert vic_turn.text_spoken == vic_turn.text
+        assert vic_turn.normalization_rules_triggered == []
+
+    def test_original_turns_not_mutated(self):
+        original = self._make_turns()
+        original_texts = [t.text for t in original]
+        disambiguate_turns(original, self._roles())
+        assert [t.text for t in original] == original_texts
+
+    def test_returns_same_length(self):
+        turns = self._make_turns()
+        result = disambiguate_turns(turns, self._roles())
+        assert len(result) == len(turns)
+
+    def test_empty_scene(self):
+        assert disambiguate_turns([], {}) == []
+
+    def test_single_speaker_scene_no_crash(self):
+        turns = [DialogueTurn(speaker_id="AGG_001", text="שלך", intensity=1)]
+        result = disambiguate_turns(turns, {"AGG_001": "AGG"})
+        # Only one speaker — addressee role is UNK; no modification
+        assert result[0].text_spoken == "שלך"

--- a/tests/unit/test_hebrew_disambiguator.py
+++ b/tests/unit/test_hebrew_disambiguator.py
@@ -135,6 +135,22 @@ class TestLexiconEntries:
         # The longer word is not a standalone match so text should be unchanged.
         assert result.text_spoken == longer_word
 
+    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    def test_surface_not_matched_after_vocalized_letter(self, entry):
+        """A surface form immediately following a niqqud-bearing letter must not match.
+
+        Regression guard for the U+0591–U+05C7 combining-mark boundary fix: before
+        the fix, a niqqud character after the preceding letter was not treated as a
+        token character, so the lookbehind saw a non-letter at that position and
+        allowed an in-word match.
+        """
+        # בָּ = bet (U+05D1) + dagesh (U+05BC) + patah (U+05B7): a vocalized letter
+        # immediately before the surface form simulates a partially-vocalized longer word.
+        adjacent = "בָּ" + entry.surface
+        result = _agg_vic(adjacent)
+        # Must not match: the surface form is not a standalone token here.
+        assert result.text_spoken == adjacent
+
 
 # ---------------------------------------------------------------------------
 # disambiguate_for_speaker — multiple substitutions
@@ -258,3 +274,22 @@ class TestDisambiguateTurns:
         result = disambiguate_turns(turns, {"AGG_001": "AGG"})
         # Only one speaker — addressee role is UNK; no modification
         assert result[0].text_spoken == "שלך"
+
+    def test_three_speaker_agg_prefers_vic_over_bys(self):
+        """In a 3-role scene (AGG, VIC, BYS) the AGG turn must be disambiguated
+        toward VIC, not BYS, regardless of dict insertion order."""
+        turns = [DialogueTurn(speaker_id="AGG_001", text="מה עשית?", intensity=2)]
+        # BYS is inserted first — without priority ordering this would be picked
+        roles = {"AGG_001": "AGG", "BYS_001": "BYS", "VIC_001": "VIC"}
+        result = disambiguate_turns(turns, roles)
+        agg_turn = result[0]
+        assert "עָשִׂיתְ" in agg_turn.text_spoken, "AGG turn should be disambiguated (addressee is VIC)"
+
+    def test_three_speaker_bys_gets_no_disambiguation(self):
+        """A BYS speaker addressing AGG must not receive feminine substitution."""
+        turns = [DialogueTurn(speaker_id="BYS_001", text="מה עשית?", intensity=1)]
+        roles = {"AGG_001": "AGG", "VIC_001": "VIC", "BYS_001": "BYS"}
+        result = disambiguate_turns(turns, roles)
+        bys_turn = result[0]
+        # BYS→AGG is not AGG→VIC, so no substitution should fire
+        assert bys_turn.text_spoken == bys_turn.text

--- a/tests/unit/test_hebrew_disambiguator.py
+++ b/tests/unit/test_hebrew_disambiguator.py
@@ -293,3 +293,13 @@ class TestDisambiguateTurns:
         bys_turn = result[0]
         # BYS→AGG is not AGG→VIC, so no substitution should fire
         assert bys_turn.text_spoken == bys_turn.text
+
+    def test_unknown_role_fallback_does_not_crash(self):
+        """A scene with only custom roles (not in the priority list) must still
+        return a stable addressee via the fallback path (lines 278-279)."""
+        turns = [DialogueTurn(speaker_id="A", text="שלך", intensity=1)]
+        # "WITNESS" is not in _ROLE_PRIORITY; the fallback loop must handle it.
+        roles = {"A": "CALLER", "B": "WITNESS"}
+        result = disambiguate_turns(turns, roles)
+        # CALLER→WITNESS is not AGG→VIC, so no substitution; just no crash.
+        assert result[0].text_spoken == "שלך"


### PR DESCRIPTION
## Summary

Implements **M1** from the V3.1 audio quality design plan (`docs/audio_generation_v3_design.md §4.1`).

Azure TTS (`he-IL-AvriNeural`) defaults to masculine inflection for morphologically ambiguous unvocalized Hebrew second-person forms. This produces systematic gender errors confirmed by direct listening (Shay, debug\_run\_1): *שלך* → "shelkha" instead of "shelakh", *הלכת* → "halakhta" instead of "halakht", and 13 other high-risk possessive, prepositional, and past-tense verb forms.

**New module** `synthbanshee/script/hebrew_disambiguator.py`:
- Lexicon of 15 second-person forms with niqqud-vocalized feminine replacements
- `disambiguate_for_speaker(text, speaker_role, addressee_role)` — applies corrections only for AGG→VIC direction; all other pairs are no-ops
- `disambiguate_turns(turns, speaker_roles)` — scene-level helper used by the pipeline; infers addressee role; never mutates input turns
- `NormalizationResult` carries `text_spoken` + `normalization_rules_triggered` rule IDs

**`DialogueTurn` extended** (`synthbanshee/script/types.py`):
- `text_spoken: str` — post-normalization text sent to TTS; defaults to `text` via `__post_init__`
- `normalization_rules_triggered: list[str]` — ordered list of rule IDs applied
- `text_original` property — alias for `text` (unmodified LLM output)

**Pipeline wired** as Stage 1b in `cli.py` between script generation and TTS rendering. `TTSRenderer.render_scene()` now reads `turn.text_spoken` instead of `turn.text`.

**84 unit tests** covering: every lexicon entry (surface replacement, string-start/end/embedded-substring boundary), direction guard, multi-token turns, `DialogueTurn` default behavior, `disambiguate_turns` integration.

## Test plan

- [x] `pytest tests/unit/test_hebrew_disambiguator.py` — 84 tests, all pass
- [x] `pytest tests/unit/` — 826 tests, all pass
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)