### PR TITLE
feat(m2a): SSML prosody defaults — VIC F0 cap + AGG loudness escalation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Copy to .env and fill in real values. Never commit .env.
+
+# TTS providers
+AZURE_TTS_KEY=
+AZURE_TTS_REGION=eastus
+
+# Script generation
+OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=     # alternative to OpenAI for script generation
+
+# Dataset output — generated clips land here (should be the corpus repo, NOT this repo)
+SYNTHBANSHEE_DATA_DIR=/path/to/avdp-synth-corpus/data/he
+
+# Cache directories (optional — defaults shown)
+# SYNTHBANSHEE_CACHE_DIR=assets/speech
+# SYNTHBANSHEE_SCRIPT_CACHE_DIR=assets/scripts

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -35,15 +35,16 @@ jobs:
       contents: read
       actions: read
       pull-requests: write
-    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4
+    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.18
     with:
-      tool_ref: v4
+      tool_ref: v4.0.18
       execution_mode: refresh
       publish_mode: append
       publish_all_clear_comments_in_refresh: false
       wait_for_reviews_to_settle: true
       target_patch_coverage: "100"
       include_review_comments: true
+      include_outdated_review_threads: true
       include_failing_checks: true
       include_patch_coverage: true
       patch_coverage_source_mode: coverage_xml_artifact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ The augmentation log from Stage 3 is the source of truth for SFX onset/offset ti
 - Directory: `data/{language_code}/{speaker_id}/{clip_id}.wav` + matching `.txt` + `.json`
 - Filenames: **ASCII only**, no spaces, no UTF-8 above U+00A1, lowercase
 - Every `.wav` must have a matching `.txt` (transcript) and `.json` (metadata)
-- **No binary Violence/Non-Violence labels** — use the hierarchical taxonomy in `configs/taxonomy.yaml`
+- **`has_violence` is a derived convenience field** computed from the hierarchical taxonomy — never assigned independently. Keep it in metadata and manifests; AI teams need it for baseline models and stratified sampling. The taxonomy columns are ground truth.
 - Silence padding: **≥ 0.5 s** ambient baseline before and after target speech
 - Retain "dirty" (pre-preprocessing) files in `assets/` always
 - `is_synthetic: true` in all generated clip metadata
@@ -137,7 +137,7 @@ OPENAI_API_KEY=...   # or ANTHROPIC_API_KEY for Codex script generation
 
 - Don't mix speaker personas across train/val/test splits (speaker-disjoint splits are required)
 - Don't hardcode Hebrew text in Python source — it goes in template `.j2` files or transcript `.txt` files
-- Don't write binary (Violence/Non-Violence) labels — the spec explicitly prohibits this
+- Don't treat `has_violence` as the primary or sole label — always preserve the full hierarchical taxonomy alongside it. Never replace the taxonomy with a single binary flag.
 - Don't discard "dirty" pre-processing audio files — they're needed for robustness testing
 - Don't use lossy audio formats (MP3, AAC) anywhere in the pipeline
 - Don't generate clips shorter than 3.0 s (below the minimum label window)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ The augmentation log produced by Stage 3b is the source of truth for SFX onset/o
 - Directory: `data/{language_code}/{speaker_id}/{clip_id}.wav` + matching `.txt` + `.json`
 - Filenames: **ASCII only**, no spaces, no UTF-8 above U+00A1, lowercase
 - Every `.wav` must have a matching `.txt` (transcript) and `.json` (metadata)
-- **No binary Violence/Non-Violence labels** — use the hierarchical taxonomy in `configs/taxonomy.yaml`
+- **`has_violence` is a derived convenience field** (`weak_label.has_violence` in `.json`, column in `manifest.csv`), computed from the hierarchical taxonomy — never assigned independently. Keep it; AI teams need it for baseline models and stratified sampling. The taxonomy columns (`violence_typology`, `tier1_category`, `tier2_subtype`, `max_intensity`) are the ground truth.
 - Silence padding: **≥ 0.5 s** ambient baseline before and after target speech
 - Retain "dirty" (pre-preprocessing) files in `assets/` always — named `{clip_id}_dirty{original_suffix}` (e.g. `clip_001_dirty.wav`), NOT the raw input filename, to avoid collisions when multiple inputs share the same basename
 - `is_synthetic: true` in all generated clip metadata
@@ -195,7 +195,7 @@ The full pipeline is now wired end-to-end: `ScriptGenerator.generate()` → `TTS
 
 - Don't mix speaker personas across train/val/test splits (speaker-disjoint splits are required)
 - Don't hardcode Hebrew text in Python source — it goes in template `.j2` files or transcript `.txt` files
-- Don't write binary (Violence/Non-Violence) labels — the spec explicitly prohibits this
+- Don't treat `has_violence` as the primary or sole label — it is a derived summary field. Always preserve the full hierarchical taxonomy (`violence_typology`, `tier1_category`, `tier2_subtype`, `max_intensity`) alongside it. Never replace the taxonomy with a single binary flag.
 - Don't discard "dirty" pre-processing audio files — they're needed for robustness testing
 - Don't use lossy audio formats (MP3, AAC) anywhere in the pipeline
 - Don't generate clips shorter than 3.0 s (below the minimum label window)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Two projects — **She-Proves** (3–6 min clips, apartment rooms) and **Elephan
 
 ## Label taxonomy
 
-Labels use a three-level hierarchy (no binary Violence/Non-Violence):
+Labels use a three-level hierarchy. `has_violence` (in clip metadata and manifests) is a derived convenience field computed from the taxonomy — not an independent label. The taxonomy is the ground truth; `has_violence` exists for fast filtering and baseline modelling.
 
 1. **Violence typology** (scene): `SV` · `IT` · `NEG` · `NEU`
 2. **Tier 1 category** (event): `PHYS` · `VERB` · `DIST` · `ACOU` · `EMOT` · `NONE`

--- a/configs/examples/scene_elephant_SV_example.yaml
+++ b/configs/examples/scene_elephant_SV_example.yaml
@@ -78,4 +78,3 @@ prosody:
     volume_range: [-4, 0]
 
 # --- Output ---
-output_dir: data/he

--- a/configs/examples/scene_tier_c_confusor_example.yaml
+++ b/configs/examples/scene_tier_c_confusor_example.yaml
@@ -54,5 +54,3 @@ prosody:
     rate_range: [1.0, 1.2]
     pitch_shift_range: [0, +3]
     volume_range: [0, +4]               # Gets louder at peak, then quieter
-
-output_dir: data/he

--- a/configs/examples/speaker_AGG_M_30-45_001.yaml
+++ b/configs/examples/speaker_AGG_M_30-45_001.yaml
@@ -36,22 +36,22 @@ style_map:
   2:                                # Moderate — slight edge, clipped responses
     style: "General"
     rate_multiplier: 1.05
-    pitch_delta_st: +1
+    pitch_delta_st: 0               # M2a: AGG anger → faster + louder (M3), not higher pitch
     volume_delta_db: +2
   3:                                # Active conflict — raised voice, contemptuous
     style: "angry"
     rate_multiplier: 1.15
-    pitch_delta_st: +2
+    pitch_delta_st: 0               # M2a: stay flat; rate carries urgency
     volume_delta_db: +5
   4:                                # Escalated — aggressive, loud
     style: "angry"
     rate_multiplier: 1.20
-    pitch_delta_st: +3
+    pitch_delta_st: +1              # M2a: minimal rise only at extreme ends
     volume_delta_db: +9
   5:                                # Extreme — shouting, near-clipping
     style: "angry"
     rate_multiplier: 1.25
-    pitch_delta_st: +4
+    pitch_delta_st: +1              # M2a: hard cap; RMS escalation via M3
     volume_delta_db: +13
 
 # --- Disfluency profile ---

--- a/configs/examples/speaker_AGG_M_30-45_001.yaml
+++ b/configs/examples/speaker_AGG_M_30-45_001.yaml
@@ -47,12 +47,12 @@ style_map:
     style: "angry"
     rate_multiplier: 1.20
     pitch_delta_st: +3
-    volume_delta_db: +8
+    volume_delta_db: +9
   5:                                # Extreme — shouting, near-clipping
     style: "angry"
     rate_multiplier: 1.25
     pitch_delta_st: +4
-    volume_delta_db: +10
+    volume_delta_db: +13
 
 # --- Disfluency profile ---
 # Probabilities for injecting realism markers into rendered speech.

--- a/configs/examples/speaker_BEN_M_40-55_003.yaml
+++ b/configs/examples/speaker_BEN_M_40-55_003.yaml
@@ -25,22 +25,22 @@ style_map:
   2:                                # Frustrated — clipped, short answers
     style: "General"
     rate_multiplier: 1.05
-    pitch_delta_st: +1
+    pitch_delta_st: 0               # M2a: anger → faster, not higher; M3 handles loudness
     volume_delta_db: +2
   3:                                # Agitated — loud, accusatory, interrupting
     style: "angry"
     rate_multiplier: 1.15
-    pitch_delta_st: +2
+    pitch_delta_st: 0               # M2a: stay flat; rate carries urgency
     volume_delta_db: +5
   4:                                # Pre-attack — threatening, pacing energy
     style: "angry"
     rate_multiplier: 1.20
-    pitch_delta_st: +3
+    pitch_delta_st: +1              # M2a: minimal rise only at extreme ends
     volume_delta_db: +9
   5:                                # Attack — shouting, physical sounds added by augmenter
     style: "angry"
     rate_multiplier: 1.30
-    pitch_delta_st: +4
+    pitch_delta_st: +1              # M2a: hard cap; RMS escalation via M3
     volume_delta_db: +13
 
 disfluency:

--- a/configs/examples/speaker_BEN_M_40-55_003.yaml
+++ b/configs/examples/speaker_BEN_M_40-55_003.yaml
@@ -26,12 +26,12 @@ style_map:
     style: "General"
     rate_multiplier: 1.05
     pitch_delta_st: +1
-    volume_delta_db: +3
+    volume_delta_db: +2
   3:                                # Agitated — loud, accusatory, interrupting
     style: "angry"
     rate_multiplier: 1.15
     pitch_delta_st: +2
-    volume_delta_db: +6
+    volume_delta_db: +5
   4:                                # Pre-attack — threatening, pacing energy
     style: "angry"
     rate_multiplier: 1.20
@@ -41,7 +41,7 @@ style_map:
     style: "angry"
     rate_multiplier: 1.30
     pitch_delta_st: +4
-    volume_delta_db: +11
+    volume_delta_db: +13
 
 disfluency:
   filled_pause_prob: 0.05

--- a/configs/examples/speaker_SW_F_30-45_001.yaml
+++ b/configs/examples/speaker_SW_F_30-45_001.yaml
@@ -20,28 +20,28 @@ style_map:
   1:                                # Routine intake — calm, professional
     style: "General"
     rate_multiplier: 1.0
-    pitch_delta_st: 0
+    pitch_delta_st: -4              # M2a: lower baseline F0; prevents child-voice range at higher intensities
     volume_delta_db: 0
   2:                                # Slight tension — still professional, firmer tone
     style: "General"
     rate_multiplier: 1.0
-    pitch_delta_st: +1
+    pitch_delta_st: -3
     volume_delta_db: +1
   3:                                # Conflict — de-escalation attempt, controlled stress
     style: "General"
     rate_multiplier: 0.95           # Slows down deliberately (de-escalation technique)
-    pitch_delta_st: +2
+    pitch_delta_st: -3
     volume_delta_db: +2
-  4:                                # Escalated — fear breaking through, louder
+  4:                                # Escalated — fear breaking through; pitch capped to avoid child-voice range
     style: "sad"
     rate_multiplier: 1.05
-    pitch_delta_st: +4
-    volume_delta_db: +3
+    pitch_delta_st: -2              # M2a: cap pitch escalation; additional distress via rate/timing
+    volume_delta_db: +4
   5:                                # Attack — panic, screaming for help
     style: "sad"
     rate_multiplier: 1.20
-    pitch_delta_st: +7
-    volume_delta_db: +8
+    pitch_delta_st: -1              # M2a: hard cap
+    volume_delta_db: +5
 
 disfluency:
   filled_pause_prob: 0.03           # Low at baseline (professional); rises with intensity

--- a/configs/examples/speaker_VIC_F_25-40_002.yaml
+++ b/configs/examples/speaker_VIC_F_25-40_002.yaml
@@ -19,28 +19,28 @@ style_map:
   1:
     style: "General"
     rate_multiplier: 1.0
-    pitch_delta_st: 0
+    pitch_delta_st: -4              # M2a: lower baseline F0; prevents child-voice range at higher intensities
     volume_delta_db: 0
   2:                                # Tension — careful, watchful; slight vocal strain
     style: "General"
     rate_multiplier: 0.95
-    pitch_delta_st: +1
-    volume_delta_db: -1
+    pitch_delta_st: -3
+    volume_delta_db: +1
   3:                                # Conflict — defensive, shaking voice
     style: "sad"                    # Azure "sad" approximates fear/distress for he-IL
     rate_multiplier: 0.90
-    pitch_delta_st: +3
-    volume_delta_db: -3
-  4:                                # Escalated — pleading, high pitch, crying undertone
+    pitch_delta_st: -3
+    volume_delta_db: +2
+  4:                                # Escalated — pleading, distress; pitch capped to avoid child-voice range
     style: "sad"
     rate_multiplier: 0.88
-    pitch_delta_st: +5
-    volume_delta_db: -2
+    pitch_delta_st: -2              # M2a: cap pitch escalation; additional distress via rate/timing
+    volume_delta_db: +4
   5:                                # Extreme — panic, screaming or sobbing
     style: "sad"
     rate_multiplier: 1.10           # Can speed up under panic
-    pitch_delta_st: +7
-    volume_delta_db: +4
+    pitch_delta_st: -1              # M2a: hard cap; distress from rate instability, not further pitch rise
+    volume_delta_db: +5
 
 disfluency:
   filled_pause_prob: 0.08           # Higher — victim is more hesitant, searches for words

--- a/configs/run_configs/tier_a_500_elephant.yaml
+++ b/configs/run_configs/tier_a_500_elephant.yaml
@@ -11,7 +11,6 @@ project: elephant_in_the_room
 tier: A
 language: he
 random_seed: 17
-output_dir: data/he
 scene_configs_dir: configs/scenes/elephant
 
 # --- Per-typology clip count targets (total: 500) ---

--- a/configs/run_configs/tier_a_500_she_proves.yaml
+++ b/configs/run_configs/tier_a_500_she_proves.yaml
@@ -8,7 +8,6 @@ project: she_proves
 tier: A
 language: he
 random_seed: 42
-output_dir: data/he
 scene_configs_dir: configs/scenes/she_proves
 
 # --- Per-typology clip count targets (total: 500) ---

--- a/configs/run_configs/tier_b_1000_elephant.yaml
+++ b/configs/run_configs/tier_b_1000_elephant.yaml
@@ -12,7 +12,6 @@ project: elephant_in_the_room
 tier: B
 language: he
 random_seed: 17
-output_dir: data/he
 scene_configs_dir: configs/scenes/elephant_tier_b
 
 # --- Per-typology clip count targets (total: 1 000) ---

--- a/configs/run_configs/tier_b_1000_she_proves.yaml
+++ b/configs/run_configs/tier_b_1000_she_proves.yaml
@@ -12,7 +12,6 @@ project: she_proves
 tier: B
 language: he
 random_seed: 42
-output_dir: data/he
 scene_configs_dir: configs/scenes/she_proves_tier_b
 
 # --- Per-typology clip count targets (total: 1 000) ---

--- a/configs/run_configs/tier_c_500_elephant.yaml
+++ b/configs/run_configs/tier_c_500_elephant.yaml
@@ -13,7 +13,6 @@ project: elephant_in_the_room
 tier: C
 language: he
 random_seed: 44
-output_dir: data/he
 scene_configs_dir: configs/scenes/elephant_tier_c
 
 # --- Per-typology clip count targets (total: 500) ---

--- a/configs/run_configs/tier_c_500_she_proves.yaml
+++ b/configs/run_configs/tier_c_500_she_proves.yaml
@@ -13,7 +13,6 @@ project: she_proves
 tier: C
 language: he
 random_seed: 43
-output_dir: data/he
 scene_configs_dir: configs/scenes/she_proves_tier_c
 
 # --- Per-typology clip count targets (total: 500) ---

--- a/configs/scenes/elephant_tier_b/el_it_b_0001.yaml
+++ b/configs/scenes/elephant_tier_b/el_it_b_0001.yaml
@@ -40,4 +40,3 @@ acoustic_scene:
       onset_at_phase: peak
       onset_offset_seconds: 2.0
       asset_path: null
-output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_it_b_0002.yaml
+++ b/configs/scenes/elephant_tier_b/el_it_b_0002.yaml
@@ -44,4 +44,3 @@ acoustic_scene:
       onset_at_phase: peak
       onset_offset_seconds: 1.0
       asset_path: null
-output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_neg_b_0001.yaml
+++ b/configs/scenes/elephant_tier_b/el_neg_b_0001.yaml
@@ -34,4 +34,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -38
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_neg_b_0002.yaml
+++ b/configs/scenes/elephant_tier_b/el_neg_b_0002.yaml
@@ -34,4 +34,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -36
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_neu_b_0001.yaml
+++ b/configs/scenes/elephant_tier_b/el_neu_b_0001.yaml
@@ -33,4 +33,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -42
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_neu_b_0002.yaml
+++ b/configs/scenes/elephant_tier_b/el_neu_b_0002.yaml
@@ -33,4 +33,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -40
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_sv_b_0001.yaml
+++ b/configs/scenes/elephant_tier_b/el_sv_b_0001.yaml
@@ -44,4 +44,3 @@ acoustic_scene:
       onset_at_phase: peak
       onset_offset_seconds: 2.0
       asset_path: null
-output_dir: data/he

--- a/configs/scenes/elephant_tier_b/el_sv_b_0002.yaml
+++ b/configs/scenes/elephant_tier_b/el_sv_b_0002.yaml
@@ -44,4 +44,3 @@ acoustic_scene:
       onset_at_phase: peak
       onset_offset_seconds: 1.5
       asset_path: null
-output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0001.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0001.yaml
@@ -34,4 +34,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -40
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0002.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0002.yaml
@@ -34,4 +34,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -42
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0003.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0003.yaml
@@ -35,4 +35,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -36
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0004.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0004.yaml
@@ -33,4 +33,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -38
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0005.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0005.yaml
@@ -33,4 +33,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -34
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0006.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0006.yaml
@@ -34,4 +34,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -44
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0007.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0007.yaml
@@ -34,4 +34,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -38
       loop: true
-output_dir: data/he

--- a/configs/scenes/elephant_tier_c/el_neg_c_0008.yaml
+++ b/configs/scenes/elephant_tier_c/el_neg_c_0008.yaml
@@ -34,4 +34,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -40
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves/sp_it_a_0001.yaml
+++ b/configs/scenes/she_proves/sp_it_a_0001.yaml
@@ -1,0 +1,25 @@
+scene_id: SP_IT_A_0001
+project: she_proves
+language: he
+violence_typology: IT
+tier: A
+random_seed: 1101
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/intimate_terror_coercive_control.j2
+script_slots:
+  relationship: spouse
+  setting: small_bedroom
+  grievance: coming_home_late
+intensity_arc: [1, 2, 3, 4, 5, 4, 3]
+she_proves:
+  incident_window_start_fraction: 0.35
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation, peak]
+  post_incident_phases: [aftermath, de-escalation]
+target_duration_minutes: 4.0
+min_pre_incident_seconds: 80
+output_dir: data/he

--- a/configs/scenes/she_proves/sp_it_a_0001.yaml
+++ b/configs/scenes/she_proves/sp_it_a_0001.yaml
@@ -22,4 +22,3 @@ she_proves:
   post_incident_phases: [aftermath, de-escalation]
 target_duration_minutes: 4.0
 min_pre_incident_seconds: 80
-output_dir: data/he

--- a/configs/scenes/she_proves/sp_it_a_0002.yaml
+++ b/configs/scenes/she_proves/sp_it_a_0002.yaml
@@ -1,0 +1,25 @@
+scene_id: SP_IT_A_0002
+project: she_proves
+language: he
+violence_typology: IT
+tier: A
+random_seed: 1102
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/intimate_terror_isolation_tactics.j2
+script_slots:
+  relationship: spouse
+  setting: apartment_kitchen
+  grievance: contact_with_family
+intensity_arc: [1, 2, 3, 4, 5, 3]
+she_proves:
+  incident_window_start_fraction: 0.40
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation, peak]
+  post_incident_phases: [aftermath]
+target_duration_minutes: 3.5
+min_pre_incident_seconds: 70
+output_dir: data/he

--- a/configs/scenes/she_proves/sp_it_a_0002.yaml
+++ b/configs/scenes/she_proves/sp_it_a_0002.yaml
@@ -22,4 +22,3 @@ she_proves:
   post_incident_phases: [aftermath]
 target_duration_minutes: 3.5
 min_pre_incident_seconds: 70
-output_dir: data/he

--- a/configs/scenes/she_proves/sp_neg_a_0001.yaml
+++ b/configs/scenes/she_proves/sp_neg_a_0001.yaml
@@ -1,0 +1,24 @@
+scene_id: SP_NEG_A_0001
+project: she_proves
+language: he
+violence_typology: NEG
+tier: A
+random_seed: 1301
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/negative_argument_deescalation.j2
+script_slots:
+  relationship: spouse
+  setting: small_bedroom
+  grievance: household_chores
+intensity_arc: [1, 2, 3, 3, 2, 1]
+she_proves:
+  incident_window_start_fraction: 0.50
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation]
+  post_incident_phases: [de-escalation]
+target_duration_minutes: 3.0
+output_dir: data/he

--- a/configs/scenes/she_proves/sp_neg_a_0001.yaml
+++ b/configs/scenes/she_proves/sp_neg_a_0001.yaml
@@ -21,4 +21,3 @@ she_proves:
   incident_phases: [escalation]
   post_incident_phases: [de-escalation]
 target_duration_minutes: 3.0
-output_dir: data/he

--- a/configs/scenes/she_proves/sp_neg_a_0002.yaml
+++ b/configs/scenes/she_proves/sp_neg_a_0002.yaml
@@ -21,4 +21,3 @@ she_proves:
   incident_phases: [escalation]
   post_incident_phases: [de-escalation]
 target_duration_minutes: 3.5
-output_dir: data/he

--- a/configs/scenes/she_proves/sp_neg_a_0002.yaml
+++ b/configs/scenes/she_proves/sp_neg_a_0002.yaml
@@ -1,0 +1,24 @@
+scene_id: SP_NEG_A_0002
+project: she_proves
+language: he
+violence_typology: NEG
+tier: A
+random_seed: 1302
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/negative_third_party_intervention.j2
+script_slots:
+  relationship: spouse
+  setting: apartment_kitchen
+  grievance: financial_disagreement
+intensity_arc: [2, 3, 3, 2, 1]
+she_proves:
+  incident_window_start_fraction: 0.45
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation]
+  post_incident_phases: [de-escalation]
+target_duration_minutes: 3.5
+output_dir: data/he

--- a/configs/scenes/she_proves/sp_neu_a_0001.yaml
+++ b/configs/scenes/she_proves/sp_neu_a_0001.yaml
@@ -18,4 +18,3 @@ she_proves:
   incident_phases: []
   post_incident_phases: []
 target_duration_minutes: 3.0
-output_dir: data/he

--- a/configs/scenes/she_proves/sp_neu_a_0001.yaml
+++ b/configs/scenes/she_proves/sp_neu_a_0001.yaml
@@ -1,0 +1,21 @@
+scene_id: SP_NEU_A_0001
+project: she_proves
+language: he
+violence_typology: NEU
+tier: A
+random_seed: 1401
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/neutral_domestic_routine.j2
+script_slots: {}
+intensity_arc: [1, 1, 1, 2, 1]
+she_proves:
+  incident_window_start_fraction: 0.90
+  pre_incident_phases: [baseline]
+  incident_phases: []
+  post_incident_phases: []
+target_duration_minutes: 3.0
+output_dir: data/he

--- a/configs/scenes/she_proves/sp_neu_a_0002.yaml
+++ b/configs/scenes/she_proves/sp_neu_a_0002.yaml
@@ -18,4 +18,3 @@ she_proves:
   incident_phases: []
   post_incident_phases: []
 target_duration_minutes: 3.5
-output_dir: data/he

--- a/configs/scenes/she_proves/sp_neu_a_0002.yaml
+++ b/configs/scenes/she_proves/sp_neu_a_0002.yaml
@@ -1,0 +1,21 @@
+scene_id: SP_NEU_A_0002
+project: she_proves
+language: he
+violence_typology: NEU
+tier: A
+random_seed: 1402
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/neutral_family_coordination.j2
+script_slots: {}
+intensity_arc: [1, 1, 2, 1, 1]
+she_proves:
+  incident_window_start_fraction: 0.95
+  pre_incident_phases: [baseline]
+  incident_phases: []
+  post_incident_phases: []
+target_duration_minutes: 3.5
+output_dir: data/he

--- a/configs/scenes/she_proves/sp_sv_a_0001.yaml
+++ b/configs/scenes/she_proves/sp_sv_a_0001.yaml
@@ -1,0 +1,25 @@
+scene_id: SP_SV_A_0001
+project: she_proves
+language: he
+violence_typology: SV
+tier: A
+random_seed: 1201
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/physical_assault_escalation.j2
+script_slots:
+  relationship: spouse
+  setting: living_room
+  grievance: money_dispute
+intensity_arc: [2, 3, 4, 5, 4, 2]
+she_proves:
+  incident_window_start_fraction: 0.30
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation, peak]
+  post_incident_phases: [aftermath]
+target_duration_minutes: 3.5
+min_pre_incident_seconds: 60
+output_dir: data/he

--- a/configs/scenes/she_proves/sp_sv_a_0001.yaml
+++ b/configs/scenes/she_proves/sp_sv_a_0001.yaml
@@ -22,4 +22,3 @@ she_proves:
   post_incident_phases: [aftermath]
 target_duration_minutes: 3.5
 min_pre_incident_seconds: 60
-output_dir: data/he

--- a/configs/scenes/she_proves/sp_sv_a_0002.yaml
+++ b/configs/scenes/she_proves/sp_sv_a_0002.yaml
@@ -1,0 +1,25 @@
+scene_id: SP_SV_A_0002
+project: she_proves
+language: he
+violence_typology: SV
+tier: A
+random_seed: 1202
+speakers:
+  - speaker_id: AGG_M_30-45_001
+    role: AGG
+  - speaker_id: VIC_F_25-40_002
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/physical_threat_object_use.j2
+script_slots:
+  relationship: partner
+  setting: living_room
+  grievance: jealousy_accusation
+intensity_arc: [1, 2, 4, 5, 3]
+she_proves:
+  incident_window_start_fraction: 0.25
+  pre_incident_phases: [baseline]
+  incident_phases: [tension, escalation, peak]
+  post_incident_phases: [aftermath]
+target_duration_minutes: 3.0
+min_pre_incident_seconds: 45
+output_dir: data/he

--- a/configs/scenes/she_proves/sp_sv_a_0002.yaml
+++ b/configs/scenes/she_proves/sp_sv_a_0002.yaml
@@ -22,4 +22,3 @@ she_proves:
   post_incident_phases: [aftermath]
 target_duration_minutes: 3.0
 min_pre_incident_seconds: 45
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_it_b_0001.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_it_b_0001.yaml
@@ -38,4 +38,3 @@ acoustic_scene:
       onset_at_phase: peak
       onset_offset_seconds: 3.0
       asset_path: null
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_it_b_0002.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_it_b_0002.yaml
@@ -38,4 +38,3 @@ acoustic_scene:
       onset_at_phase: peak
       onset_offset_seconds: 2.0
       asset_path: null
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_neg_b_0001.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_neg_b_0001.yaml
@@ -33,4 +33,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -35
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_neg_b_0002.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_neg_b_0002.yaml
@@ -33,4 +33,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -40
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_neu_b_0001.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_neu_b_0001.yaml
@@ -30,4 +30,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -30
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_neu_b_0002.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_neu_b_0002.yaml
@@ -30,4 +30,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -42
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_sv_b_0001.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_sv_b_0001.yaml
@@ -42,4 +42,3 @@ acoustic_scene:
       onset_at_phase: peak
       onset_offset_seconds: 2.0
       asset_path: null
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_b/sp_sv_b_0002.yaml
+++ b/configs/scenes/she_proves_tier_b/sp_sv_b_0002.yaml
@@ -38,4 +38,3 @@ acoustic_scene:
       onset_at_phase: peak
       onset_offset_seconds: 1.0
       asset_path: null
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0001.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0001.yaml
@@ -28,4 +28,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -32
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0002.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0002.yaml
@@ -28,4 +28,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -22
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0003.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0003.yaml
@@ -31,4 +31,3 @@ acoustic_scene:
       onset_at_phase: peak
       onset_offset_seconds: 0.5
       asset_path: null
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0004.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0004.yaml
@@ -27,4 +27,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -42
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0005.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0005.yaml
@@ -27,4 +27,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -44
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0006.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0006.yaml
@@ -27,4 +27,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -40
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0007.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0007.yaml
@@ -27,4 +27,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -35
       loop: true
-output_dir: data/he

--- a/configs/scenes/she_proves_tier_c/sp_neg_c_0008.yaml
+++ b/configs/scenes/she_proves_tier_c/sp_neg_c_0008.yaml
@@ -27,4 +27,3 @@ acoustic_scene:
       onset_seconds: 0.0
       level_db: -30
       loop: true
-output_dir: data/he

--- a/configs/scenes/test_scene_001.yaml
+++ b/configs/scenes/test_scene_001.yaml
@@ -30,5 +30,3 @@ she_proves:
 
 target_duration_minutes: 3.0
 min_pre_incident_seconds: 60
-
-output_dir: data/he

--- a/docs/audio_violence_datasdet_project_docs.md
+++ b/docs/audio_violence_datasdet_project_docs.md
@@ -136,7 +136,7 @@ Redundancy: Avoid repeating words or characters more than three times (e.g., no 
 
 3. Annotation Taxonomy (Tiers 1-3)
 
-Annotators must apply a hierarchical tag to every identified event. Binary "Violence/Non-Violence" labels are prohibited.
+Annotators must apply a hierarchical tag to every identified event. A binary `has_violence` convenience field is derived from the taxonomy and included in metadata and manifests for fast filtering; however, replacing the hierarchical taxonomy with a single binary flag is prohibited — the taxonomy is the ground truth.
 
 Temporal Granularity
 

--- a/docs/design_approaches.md
+++ b/docs/design_approaches.md
@@ -31,7 +31,7 @@ All generated datasets must conform to:
 | Silence padding | ≥ 0.5 s digital silence/ambient baseline before and after target speech |
 | SNR | ≥ 15 dB at acquisition; degrade controllably in augmentation |
 | Annotation granularity | Weak labels (30–120 s clips) **and** strong labels (onset/offset timestamps), 3.0 s analysis windows, 1.0 s hop |
-| Label taxonomy | Hierarchical tiers — binary Violence/Non-Violence labels are prohibited |
+| Label taxonomy | Hierarchical tiers — `has_violence` is a derived convenience field; the taxonomy (`violence_typology`, `tier1_category`, `tier2_subtype`, `max_intensity`) is the ground truth and must not be replaced by a single binary flag |
 | Metadata | JSON per clip with: `event_id`, `onset`, `offset`, `primary_label`, `intensity` (1–5), `speaker_role`, `emotional_state`, `confidence` (0.0–1.0) |
 | IAA targets | Cohen's Kappa ≥ 0.65 (physical), ≥ 0.60 (verbal aggression) on 20% second-pass |
 | Preprocessing | Resample → normalize to −1.0 dBFS → spectral filter → denoise; always retain original "dirty" file |

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -1175,7 +1175,7 @@ def measure_prosody(clip_dir: Path, output: Path | None, roles: str) -> None:
 
     for s in stats:
         f0_med = f"{s.f0_median_hz:.1f}" if s.f0_median_hz is not None else "—"
-        f0_std = f"{s.f0_std_hz:.1f}" if s.f0_std_hz is not None else "—"
+        f0_std = f"{s.f0_std_hz_mean:.1f}" if s.f0_std_hz_mean is not None else "—"
         table.add_row(
             s.role,
             str(s.intensity),
@@ -1207,7 +1207,7 @@ def measure_prosody(clip_dir: Path, output: Path | None, roles: str) -> None:
         with output.open("w", newline="", encoding="utf-8") as fh:
             writer = csv.writer(fh)
             writer.writerow(
-                ["clip_id", "speaker_role", "intensity", "f0_median_hz", "f0_std_hz", "rms_db"]
+                ["clip_id", "speaker_role", "intensity", "f0_median_hz", "f0_std_hz_mean", "rms_db"]
             )
             for t in all_turns:
                 writer.writerow(
@@ -1216,7 +1216,9 @@ def measure_prosody(clip_dir: Path, output: Path | None, roles: str) -> None:
                         t.speaker_role,
                         t.intensity,
                         f"{t.f0_median_hz:.2f}" if t.f0_median_hz is not None else "",
-                        f"{t.f0_std_hz:.2f}" if t.f0_std_hz is not None else "",
+                        f"{t.f0_std_hz:.2f}"
+                        if t.f0_std_hz is not None
+                        else "",  # TurnMetrics field unchanged
                         f"{t.rms_db:.2f}",
                     ]
                 )

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -708,6 +708,13 @@ def _render_one(
     help="Number of parallel worker threads for clip rendering.",
 )
 @click.option(
+    "--max-clips",
+    "-n",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Cap the number of clips rendered (useful for wet tests / smoke tests).",
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -723,6 +730,7 @@ def generate_batch(
     manifest_out: Path | None,
     dry_run: bool,
     workers: int,
+    max_clips: int | None,
     verbose: bool,
 ) -> None:
     """Run a full batch generation from a run configuration YAML.
@@ -762,6 +770,12 @@ def generate_batch(
         f"Found [bold]{len(all_configs)}[/bold] matching configs; "
         f"selected [bold]{len(selected)}[/bold] for this run."
     )
+
+    if max_clips is not None and len(selected) > max_clips:
+        selected = selected[:max_clips]
+        console.print(
+            f"[yellow]--max-clips {max_clips}: truncated to {len(selected)} clip(s).[/yellow]"
+        )
 
     if dry_run:
         _print_selection_summary(selected)

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -1085,6 +1085,134 @@ def qa_report(data_dir: Path, output: Path | None, max_failure_rate: float) -> N
 
 
 # ---------------------------------------------------------------------------
+# measure-prosody
+# ---------------------------------------------------------------------------
+
+
+@cli.command("measure-prosody")
+@click.argument("clip_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write per-turn metrics to a CSV file for offline analysis.",
+)
+@click.option(
+    "--roles",
+    default="AGG,VIC",
+    show_default=True,
+    help="Comma-separated list of speaker roles to include in the report.",
+)
+def measure_prosody(clip_dir: Path, output: Path | None, roles: str) -> None:
+    """Measure per-turn F0 and RMS across generated clips and check §4.2a thresholds.
+
+    Walks CLIP_DIR recursively for .wav files, reads the matching .jsonl
+    strong-label files for event boundaries, and reports median F0 and mean
+    RMS grouped by speaker role and intensity level.
+
+    Requires librosa for F0 estimation (pip install librosa).  RMS is always
+    measured; F0 columns will show '—' if librosa is unavailable or the
+    segment is fully unvoiced.
+
+    Exit code 1 if any §4.2a threshold check fails.
+    """
+    import csv
+
+    from synthbanshee.labels.prosody_metrics import (
+        aggregate_metrics,
+        measure_clip,
+        run_threshold_checks,
+    )
+
+    include_roles = {r.strip().upper() for r in roles.split(",")}
+
+    wav_files = sorted(clip_dir.rglob("*.wav"))
+    if not wav_files:
+        console.print(f"[yellow]No .wav files found in {clip_dir}[/yellow]")
+        return
+
+    from synthbanshee.labels.prosody_metrics import TurnMetrics as _TurnMetrics
+
+    all_turns: list[_TurnMetrics] = []
+    with console.status(f"Measuring {len(wav_files)} clip(s) …"):
+        for wav in wav_files:
+            turns = measure_clip(wav)
+            all_turns.extend(t for t in turns if t.speaker_role in include_roles)
+
+    if not all_turns:
+        console.print(
+            "[yellow]No speaker-role events found — check that .jsonl files exist alongside .wav files.[/yellow]"
+        )
+        return
+
+    stats = aggregate_metrics(all_turns)
+
+    # -----------------------------------------------------------------
+    # Stats table
+    # -----------------------------------------------------------------
+    table = Table(title="Prosody metrics by role × intensity", show_lines=False)
+    table.add_column("Role", style="bold")
+    table.add_column("I", justify="right")
+    table.add_column("Turns", justify="right")
+    table.add_column("F0 median (Hz)", justify="right")
+    table.add_column("F0 std (Hz)", justify="right")
+    table.add_column("RMS (dBFS)", justify="right")
+
+    for s in stats:
+        f0_med = f"{s.f0_median_hz:.1f}" if s.f0_median_hz is not None else "—"
+        f0_std = f"{s.f0_std_hz:.1f}" if s.f0_std_hz is not None else "—"
+        table.add_row(
+            s.role,
+            str(s.intensity),
+            str(s.n_turns),
+            f0_med,
+            f0_std,
+            f"{s.rms_db_mean:.1f}",
+        )
+
+    console.print(table)
+
+    # -----------------------------------------------------------------
+    # Threshold checks
+    # -----------------------------------------------------------------
+    checks = run_threshold_checks(stats)
+    console.print("\n[bold]§4.2a threshold checks:[/bold]")
+    all_passed = True
+    for label, passed, detail in checks:
+        icon = "[green]✓[/green]" if passed else "[red]✗[/red]"
+        console.print(f"  {icon} {label}  ({detail})")
+        if not passed:
+            all_passed = False
+
+    # -----------------------------------------------------------------
+    # Optional CSV export
+    # -----------------------------------------------------------------
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with output.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(
+                ["clip_id", "speaker_role", "intensity", "f0_median_hz", "f0_std_hz", "rms_db"]
+            )
+            for t in all_turns:
+                writer.writerow(
+                    [
+                        t.clip_id,
+                        t.speaker_role,
+                        t.intensity,
+                        f"{t.f0_median_hz:.2f}" if t.f0_median_hz is not None else "",
+                        f"{t.f0_std_hz:.2f}" if t.f0_std_hz is not None else "",
+                        f"{t.rms_db:.2f}",
+                    ]
+                )
+        console.print(f"\n[dim]Per-turn CSV written to {output}[/dim]")
+
+    if not all_passed:
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
 # iaa-report
 # ---------------------------------------------------------------------------
 

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -473,7 +473,8 @@ def cli() -> None:
     "-o",
     type=click.Path(path_type=Path),
     default=None,
-    help="Override output directory (default: from config).",
+    envvar="SYNTHBANSHEE_DATA_DIR",
+    help="Override output directory (default: from config or $SYNTHBANSHEE_DATA_DIR).",
 )
 @click.option(
     "--cache-dir",
@@ -661,7 +662,8 @@ def _render_one(
     "-o",
     type=click.Path(path_type=Path),
     default=None,
-    help="Override output directory (default: from run config).",
+    envvar="SYNTHBANSHEE_DATA_DIR",
+    help="Override output directory (default: from run config or $SYNTHBANSHEE_DATA_DIR).",
 )
 @click.option(
     "--cache-dir",

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -1192,7 +1192,7 @@ def measure_prosody(clip_dir: Path, output: Path | None, roles: str) -> None:
     # -----------------------------------------------------------------
     # Threshold checks
     # -----------------------------------------------------------------
-    checks = run_threshold_checks(stats)
+    checks = run_threshold_checks(stats, include_roles=include_roles)
     console.print("\n[bold]§4.2a threshold checks:[/bold]")
     all_passed = True
     for label, passed, detail in checks:
@@ -1209,7 +1209,7 @@ def measure_prosody(clip_dir: Path, output: Path | None, roles: str) -> None:
         with output.open("w", newline="", encoding="utf-8") as fh:
             writer = csv.writer(fh)
             writer.writerow(
-                ["clip_id", "speaker_role", "intensity", "f0_median_hz", "f0_std_hz_mean", "rms_db"]
+                ["clip_id", "speaker_role", "intensity", "f0_median_hz", "f0_std_hz", "rms_db"]
             )
             for t in all_turns:
                 writer.writerow(

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -774,9 +774,14 @@ def generate_batch(
     )
 
     if max_clips is not None and len(selected) > max_clips:
+        import random as _random
+
+        _rng = _random.Random(run_cfg.random_seed)
+        _rng.shuffle(selected)
         selected = selected[:max_clips]
         console.print(
-            f"[yellow]--max-clips {max_clips}: truncated to {len(selected)} clip(s).[/yellow]"
+            f"[yellow]--max-clips {max_clips}: shuffled (seed={run_cfg.random_seed}) "
+            f"and truncated to {len(selected)} clip(s).[/yellow]"
         )
 
     if dry_run:

--- a/synthbanshee/labels/prosody_metrics.py
+++ b/synthbanshee/labels/prosody_metrics.py
@@ -14,6 +14,7 @@ Thresholds (from docs/audio_generation_v3_design.md §4.2a):
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -164,10 +165,17 @@ def measure_clip(clip_path: Path) -> list[TurnMetrics]:
         return []
 
     events: list[EventLabel] = []
-    for line in jsonl_path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if line:
+    for raw_line in jsonl_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
             events.append(EventLabel.model_validate_json(line))
+        except Exception as exc:  # pydantic.ValidationError or JSON parse error
+            warnings.warn(
+                f"Skipping malformed label line in {jsonl_path.name}: {exc}",
+                stacklevel=2,
+            )
 
     role_events = [e for e in events if e.speaker_role is not None]
     if not role_events:
@@ -229,8 +237,14 @@ def aggregate_metrics(turns: list[TurnMetrics]) -> list[RoleIntensityStats]:
 
 def run_threshold_checks(
     stats: list[RoleIntensityStats],
+    include_roles: set[str] | None = None,
 ) -> list[tuple[str, bool, str]]:
     """Evaluate §4.2a pass/fail thresholds against aggregated stats.
+
+    Args:
+        stats: Aggregated per-role/intensity stats from :func:`aggregate_metrics`.
+        include_roles: If provided, only emit checks for roles in this set.
+            Pass ``None`` (default) to run all checks.
 
     Returns a list of ``(label, passed, detail)`` tuples — one per check.
     Checks that cannot be evaluated (missing data) are reported as
@@ -250,21 +264,31 @@ def run_threshold_checks(
         passed = s.f0_median_hz < max_hz if strict else s.f0_median_hz <= max_hz
         checks.append((label, passed, f"{s.f0_median_hz:.1f} Hz"))
 
-    _f0_check("VIC", 1, VIC_I1_F0_MAX_HZ, f"VIC I1 median F0 ≤ {VIC_I1_F0_MAX_HZ:.0f} Hz")
-    _f0_check(
-        "VIC", 4, VIC_I4_F0_MAX_HZ, f"VIC I4 median F0 < {VIC_I4_F0_MAX_HZ:.0f} Hz", strict=True
-    )
-    _f0_check(
-        "VIC", 5, VIC_I5_F0_MAX_HZ, f"VIC I5 median F0 < {VIC_I5_F0_MAX_HZ:.0f} Hz", strict=True
-    )
+    if include_roles is None or "VIC" in include_roles:
+        _f0_check("VIC", 1, VIC_I1_F0_MAX_HZ, f"VIC I1 median F0 ≤ {VIC_I1_F0_MAX_HZ:.0f} Hz")
+        _f0_check(
+            "VIC",
+            4,
+            VIC_I4_F0_MAX_HZ,
+            f"VIC I4 median F0 < {VIC_I4_F0_MAX_HZ:.0f} Hz",
+            strict=True,
+        )
+        _f0_check(
+            "VIC",
+            5,
+            VIC_I5_F0_MAX_HZ,
+            f"VIC I5 median F0 < {VIC_I5_F0_MAX_HZ:.0f} Hz",
+            strict=True,
+        )
 
-    agg_i1 = by_key.get(("AGG", 1))
-    agg_i5 = by_key.get(("AGG", 5))
-    label = f"AGG I5 − I1 RMS ≥ {AGG_ESCALATION_MIN_DB:.0f} dB"
-    if agg_i1 is None or agg_i5 is None:
-        checks.append((label, False, "no data"))
-    else:
-        delta = agg_i5.rms_db_mean - agg_i1.rms_db_mean
-        checks.append((label, delta >= AGG_ESCALATION_MIN_DB, f"{delta:+.1f} dB"))
+    if include_roles is None or "AGG" in include_roles:
+        agg_i1 = by_key.get(("AGG", 1))
+        agg_i5 = by_key.get(("AGG", 5))
+        label = f"AGG I5 − I1 RMS ≥ {AGG_ESCALATION_MIN_DB:.0f} dB"
+        if agg_i1 is None or agg_i5 is None:
+            checks.append((label, False, "no data"))
+        else:
+            delta = agg_i5.rms_db_mean - agg_i1.rms_db_mean
+            checks.append((label, delta >= AGG_ESCALATION_MIN_DB, f"{delta:+.1f} dB"))
 
     return checks

--- a/synthbanshee/labels/prosody_metrics.py
+++ b/synthbanshee/labels/prosody_metrics.py
@@ -1,0 +1,262 @@
+"""Per-turn F0 and RMS measurement for M2a prosody validation.
+
+Reads generated clips (WAV + strong-label JSONL) and returns per-turn
+prosody metrics grouped by speaker role and intensity level.  Used by
+the ``measure-prosody`` CLI command to validate that the §4.2a speaker
+config targets are met before merging prosody-config PRs.
+
+Thresholds (from docs/audio_generation_v3_design.md §4.2a):
+  - VIC I1 median F0 ≤ 200 Hz  (adult female baseline; avoids child-voice range)
+  - VIC I4 median F0 < 250 Hz  (pitch cap — distress via rate/timing, not pitch)
+  - VIC I5 median F0 < 250 Hz  (hard cap)
+  - AGG I5 RMS − AGG I1 RMS ≥ 8 dB  (loudness escalation check)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+# ---------------------------------------------------------------------------
+# Threshold constants
+# ---------------------------------------------------------------------------
+
+VIC_I1_F0_MAX_HZ: float = 200.0
+VIC_I4_F0_MAX_HZ: float = 250.0
+VIC_I5_F0_MAX_HZ: float = 250.0
+AGG_ESCALATION_MIN_DB: float = 8.0
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TurnMetrics:
+    """Prosody measurements for one EventLabel segment.
+
+    Attributes:
+        clip_id: Source clip identifier.
+        speaker_role: Role of the speaker (e.g. ``"AGG"``, ``"VIC"``).
+        intensity: Turn intensity level 1–5.
+        f0_median_hz: Median voiced F0 in Hz, or ``None`` if the segment is
+            too short, fully unvoiced, or librosa is unavailable.
+        f0_std_hz: Standard deviation of voiced F0 frames, or ``None``.
+        rms_db: RMS level in dBFS (always present).
+    """
+
+    clip_id: str
+    speaker_role: str
+    intensity: int
+    f0_median_hz: float | None
+    f0_std_hz: float | None
+    rms_db: float
+
+
+@dataclass
+class RoleIntensityStats:
+    """Aggregated statistics for one (role, intensity) bucket.
+
+    Attributes:
+        role: Speaker role string.
+        intensity: Intensity level 1–5.
+        n_turns: Number of turns in this bucket.
+        f0_median_hz: Median of per-turn F0 medians, or ``None`` if no
+            voiced turns were measured.
+        f0_std_hz: Pooled standard deviation of F0 frames, or ``None``.
+        rms_db_mean: Mean RMS across turns in dBFS.
+    """
+
+    role: str
+    intensity: int
+    n_turns: int
+    f0_median_hz: float | None
+    f0_std_hz: float | None
+    rms_db_mean: float
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _measure_segment(
+    samples: np.ndarray,
+    sr: int,
+    onset_s: float,
+    offset_s: float,
+) -> tuple[float | None, float | None, float]:
+    """Return ``(f0_median_hz, f0_std_hz, rms_db)`` for one audio segment.
+
+    Args:
+        samples: Mono int16 or float32 audio array.
+        sr: Sample rate in Hz.
+        onset_s: Segment start time in seconds.
+        offset_s: Segment end time in seconds.
+
+    Returns:
+        Tuple of F0 median (Hz or None), F0 std (Hz or None), RMS (dBFS).
+    """
+    start = max(0, int(onset_s * sr))
+    end = min(len(samples), int(offset_s * sr))
+    seg = samples[start:end].astype(np.float64)
+
+    if len(seg) < int(sr * 0.05):  # < 50 ms — too short to analyse
+        return None, None, -96.0
+
+    # RMS in dBFS
+    rms = float(np.sqrt(np.mean(seg**2)))
+    # Normalize to [-1, 1] range for dBFS if samples are int16
+    if samples.dtype == np.int16:
+        rms /= 32768.0
+    rms_db = 20.0 * np.log10(max(rms, 1e-9))
+
+    # F0 via librosa pyin — graceful fallback if unavailable
+    try:
+        import librosa
+
+        f0, voiced_flag, _ = librosa.pyin(
+            seg.astype(np.float32) / 32768.0
+            if samples.dtype == np.int16
+            else seg.astype(np.float32),
+            fmin=float(librosa.note_to_hz("C2")),
+            fmax=float(librosa.note_to_hz("C7")),
+            sr=sr,
+        )
+        voiced_f0 = f0[voiced_flag & np.isfinite(f0)]
+        if len(voiced_f0) == 0:
+            return None, None, rms_db
+        return float(np.median(voiced_f0)), float(np.std(voiced_f0)), rms_db
+    except ImportError:
+        return None, None, rms_db
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def measure_clip(clip_path: Path) -> list[TurnMetrics]:
+    """Return per-turn prosody metrics for one generated clip.
+
+    Reads ``{clip_path.stem}.jsonl`` for event boundaries, speaker roles,
+    and intensity levels.  Events without a ``speaker_role`` (e.g. ambient
+    noise events) are skipped.
+
+    Args:
+        clip_path: Path to the ``.wav`` file.  The matching ``.jsonl``
+            strong-label file must exist alongside it.
+
+    Returns:
+        List of :class:`TurnMetrics`, one per qualifying event.  Empty if
+        the JSONL is missing or contains no speaker-role events.
+    """
+    from synthbanshee.labels.schema import EventLabel
+
+    jsonl_path = clip_path.with_suffix(".jsonl")
+    if not jsonl_path.exists():
+        return []
+
+    events: list[EventLabel] = []
+    for line in jsonl_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            events.append(EventLabel.model_validate_json(line))
+
+    role_events = [e for e in events if e.speaker_role is not None]
+    if not role_events:
+        return []
+
+    samples, sr = sf.read(str(clip_path), dtype="int16")
+    if samples.ndim > 1:
+        samples = samples[:, 0]
+
+    results: list[TurnMetrics] = []
+    for ev in role_events:
+        f0_med, f0_std, rms_db = _measure_segment(samples, sr, ev.onset, ev.offset)
+        assert ev.speaker_role is not None  # narrowed above
+        results.append(
+            TurnMetrics(
+                clip_id=ev.clip_id,
+                speaker_role=ev.speaker_role,
+                intensity=ev.intensity,
+                f0_median_hz=f0_med,
+                f0_std_hz=f0_std,
+                rms_db=rms_db,
+            )
+        )
+    return results
+
+
+def aggregate_metrics(turns: list[TurnMetrics]) -> list[RoleIntensityStats]:
+    """Aggregate per-turn metrics into (role, intensity) buckets.
+
+    Args:
+        turns: Flat list of :class:`TurnMetrics` from one or more clips.
+
+    Returns:
+        List of :class:`RoleIntensityStats` sorted by role then intensity.
+    """
+    from collections import defaultdict
+
+    buckets: dict[tuple[str, int], list[TurnMetrics]] = defaultdict(list)
+    for t in turns:
+        buckets[(t.speaker_role, t.intensity)].append(t)
+
+    stats: list[RoleIntensityStats] = []
+    for (role, intensity), bucket in sorted(buckets.items()):
+        voiced = [t.f0_median_hz for t in bucket if t.f0_median_hz is not None]
+        stds = [t.f0_std_hz for t in bucket if t.f0_std_hz is not None]
+        rms_values = [t.rms_db for t in bucket]
+        stats.append(
+            RoleIntensityStats(
+                role=role,
+                intensity=intensity,
+                n_turns=len(bucket),
+                f0_median_hz=float(np.median(voiced)) if voiced else None,
+                f0_std_hz=float(np.mean(stds)) if stds else None,
+                rms_db_mean=float(np.mean(rms_values)),
+            )
+        )
+    return stats
+
+
+def run_threshold_checks(
+    stats: list[RoleIntensityStats],
+) -> list[tuple[str, bool, str]]:
+    """Evaluate §4.2a pass/fail thresholds against aggregated stats.
+
+    Returns a list of ``(label, passed, detail)`` tuples — one per check.
+    Checks that cannot be evaluated (missing data) are reported as
+    inconclusive (``passed=False``, detail explains why).
+    """
+    by_key: dict[tuple[str, int], RoleIntensityStats] = {(s.role, s.intensity): s for s in stats}
+
+    checks: list[tuple[str, bool, str]] = []
+
+    def _f0_check(role: str, intensity: int, max_hz: float, label: str) -> None:
+        s = by_key.get((role, intensity))
+        if s is None or s.f0_median_hz is None:
+            checks.append((label, False, "no data"))
+            return
+        passed = s.f0_median_hz <= max_hz
+        checks.append((label, passed, f"{s.f0_median_hz:.1f} Hz"))
+
+    _f0_check("VIC", 1, VIC_I1_F0_MAX_HZ, f"VIC I1 median F0 ≤ {VIC_I1_F0_MAX_HZ:.0f} Hz")
+    _f0_check("VIC", 4, VIC_I4_F0_MAX_HZ, f"VIC I4 median F0 < {VIC_I4_F0_MAX_HZ:.0f} Hz")
+    _f0_check("VIC", 5, VIC_I5_F0_MAX_HZ, f"VIC I5 median F0 < {VIC_I5_F0_MAX_HZ:.0f} Hz")
+
+    agg_i1 = by_key.get(("AGG", 1))
+    agg_i5 = by_key.get(("AGG", 5))
+    label = f"AGG I5 − I1 RMS ≥ {AGG_ESCALATION_MIN_DB:.0f} dB"
+    if agg_i1 is None or agg_i5 is None:
+        checks.append((label, False, "no data"))
+    else:
+        delta = agg_i5.rms_db_mean - agg_i1.rms_db_mean
+        checks.append((label, delta >= AGG_ESCALATION_MIN_DB, f"{delta:+.1f} dB"))
+
+    return checks

--- a/synthbanshee/labels/prosody_metrics.py
+++ b/synthbanshee/labels/prosody_metrics.py
@@ -67,7 +67,9 @@ class RoleIntensityStats:
         n_turns: Number of turns in this bucket.
         f0_median_hz: Median of per-turn F0 medians, or ``None`` if no
             voiced turns were measured.
-        f0_std_hz: Pooled standard deviation of F0 frames, or ``None``.
+        f0_std_hz_mean: Mean of per-turn F0 standard deviations, or ``None``.
+            Note: this is the average of per-turn stddevs, not a true pooled
+            standard deviation (which would require frame-level counts).
         rms_db_mean: Mean RMS across turns in dBFS.
     """
 
@@ -75,7 +77,7 @@ class RoleIntensityStats:
     intensity: int
     n_turns: int
     f0_median_hz: float | None
-    f0_std_hz: float | None
+    f0_std_hz_mean: float | None
     rms_db_mean: float
 
 
@@ -218,7 +220,7 @@ def aggregate_metrics(turns: list[TurnMetrics]) -> list[RoleIntensityStats]:
                 intensity=intensity,
                 n_turns=len(bucket),
                 f0_median_hz=float(np.median(voiced)) if voiced else None,
-                f0_std_hz=float(np.mean(stds)) if stds else None,
+                f0_std_hz_mean=float(np.mean(stds)) if stds else None,
                 rms_db_mean=float(np.mean(rms_values)),
             )
         )
@@ -238,17 +240,23 @@ def run_threshold_checks(
 
     checks: list[tuple[str, bool, str]] = []
 
-    def _f0_check(role: str, intensity: int, max_hz: float, label: str) -> None:
+    def _f0_check(
+        role: str, intensity: int, max_hz: float, label: str, *, strict: bool = False
+    ) -> None:
         s = by_key.get((role, intensity))
         if s is None or s.f0_median_hz is None:
             checks.append((label, False, "no data"))
             return
-        passed = s.f0_median_hz <= max_hz
+        passed = s.f0_median_hz < max_hz if strict else s.f0_median_hz <= max_hz
         checks.append((label, passed, f"{s.f0_median_hz:.1f} Hz"))
 
     _f0_check("VIC", 1, VIC_I1_F0_MAX_HZ, f"VIC I1 median F0 ≤ {VIC_I1_F0_MAX_HZ:.0f} Hz")
-    _f0_check("VIC", 4, VIC_I4_F0_MAX_HZ, f"VIC I4 median F0 < {VIC_I4_F0_MAX_HZ:.0f} Hz")
-    _f0_check("VIC", 5, VIC_I5_F0_MAX_HZ, f"VIC I5 median F0 < {VIC_I5_F0_MAX_HZ:.0f} Hz")
+    _f0_check(
+        "VIC", 4, VIC_I4_F0_MAX_HZ, f"VIC I4 median F0 < {VIC_I4_F0_MAX_HZ:.0f} Hz", strict=True
+    )
+    _f0_check(
+        "VIC", 5, VIC_I5_F0_MAX_HZ, f"VIC I5 median F0 < {VIC_I5_F0_MAX_HZ:.0f} Hz", strict=True
+    )
 
     agg_i1 = by_key.get(("AGG", 1))
     agg_i5 = by_key.get(("AGG", 5))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -401,6 +401,78 @@ class TestGenerateBatchCommand:
         # Manifest CSV must exist with at least a header row
         assert manifest_path.exists()
 
+    def test_max_clips_truncates_selected_configs(self, tmp_path):
+        """--max-clips N limits rendering to N clips even when more are available."""
+        import yaml as _yaml
+
+        scenes_dir = tmp_path / "scenes"
+        scenes_dir.mkdir()
+
+        # Write 3 scene configs but cap at 1
+        for i in range(3):
+            scene = {
+                "scene_id": f"SP_NEU_A_00{i}",
+                "project": "she_proves",
+                "language": "he",
+                "violence_typology": "NEU",
+                "tier": "A",
+                "random_seed": i,
+                "speakers": [{"speaker_id": "AGG_M_30-45_001", "role": "AGG"}],
+                "script_template": "synthbanshee/script/templates/she_proves/neutral_domestic_routine.j2",
+                "script_slots": {},
+                "intensity_arc": [1],
+                "target_duration_minutes": 3.0,
+                "output_dir": str(tmp_path / "out"),
+            }
+            (scenes_dir / f"scene_{i:03d}.yaml").write_text(_yaml.dump(scene), encoding="utf-8")
+
+        run_cfg_path = tmp_path / "run.yaml"
+        run_cfg_path.write_text(
+            _BATCH_RUN_CONFIG_TEMPLATE.format(
+                output_dir=str(tmp_path / "out"),
+                scene_configs_dir=str(scenes_dir),
+            ),
+            encoding="utf-8",
+        )
+
+        turns = _make_dialogue_turns(n=1)
+        mixed = _make_mixed_scene(n_turns=1)
+        rendered_calls: list[int] = []
+
+        runner = CliRunner()
+        with (
+            patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
+            patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
+        ):
+            MockGen.return_value.generate.return_value = turns
+            MockRenderer.return_value.render_scene.return_value = mixed
+
+            def _count_render(*args, **kwargs):
+                rendered_calls.append(1)
+                return mixed
+
+            MockRenderer.return_value.render_scene.side_effect = _count_render
+            result = runner.invoke(
+                cli,
+                [
+                    "generate-batch",
+                    "--run-config",
+                    str(run_cfg_path),
+                    "--max-clips",
+                    "1",
+                    "--cache-dir",
+                    str(tmp_path / "cache"),
+                    "--dirty-dir",
+                    str(tmp_path / "dirty"),
+                    "--script-cache-dir",
+                    str(tmp_path / "scripts"),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "--max-clips 1" in result.output
+        assert len(rendered_calls) == 1
+
 
 # ---------------------------------------------------------------------------
 # qa-report command

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -470,7 +470,7 @@ class TestGenerateBatchCommand:
             )
 
         assert result.exit_code == 0, result.output
-        assert "--max-clips 1" in result.output
+        assert "truncated to 1 clip" in result.output
         assert len(rendered_calls) == 1
 
 

--- a/tests/unit/test_prosody_metrics.py
+++ b/tests/unit/test_prosody_metrics.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 import soundfile as sf
+from click.testing import CliRunner
 
+from synthbanshee.cli import cli
 from synthbanshee.labels.prosody_metrics import (
     AGG_ESCALATION_MIN_DB,
     VIC_I1_F0_MAX_HZ,
@@ -271,6 +275,7 @@ class TestRunThresholdChecks:
         agg_i1_rms=-25.0,
         agg_i5_rms=-14.0,
     ) -> list[RoleIntensityStats]:
+        # RoleIntensityStats fields: role, intensity, n_turns, f0_median_hz, f0_std_hz_mean, rms_db_mean
         return [
             RoleIntensityStats("AGG", 1, 10, 128.0, 12.0, agg_i1_rms),
             RoleIntensityStats("AGG", 5, 10, 140.0, 15.0, agg_i5_rms),
@@ -315,7 +320,7 @@ class TestRunThresholdChecks:
         # No VIC entries at all
         stats = [
             RoleIntensityStats("AGG", 1, 5, 128.0, 12.0, -25.0),
-            RoleIntensityStats("AGG", 5, 5, 140.0, 15.0, -14.0),
+            RoleIntensityStats("AGG", 5, 5, 140.0, 15.0, -14.0),  # noqa: E241
         ]
         checks = run_threshold_checks(stats)
         no_data = [c for c in checks if "no data" in c[2]]
@@ -326,6 +331,169 @@ class TestRunThresholdChecks:
         assert len(checks) == 4
 
     def test_vic_i1_exactly_at_threshold_passes(self):
+        # I1 uses ≤ so exactly 200 Hz passes
         checks = run_threshold_checks(self._stats(vic_i1_f0=VIC_I1_F0_MAX_HZ))
         vic_i1 = next(c for c in checks if "I1" in c[0] and "VIC" in c[0])
         assert vic_i1[1]
+
+    def test_vic_i4_exactly_at_threshold_fails(self):
+        # I4 uses strict < so exactly 250 Hz must FAIL
+        checks = run_threshold_checks(self._stats(vic_i4_f0=VIC_I4_F0_MAX_HZ))
+        vic_i4 = next(c for c in checks if "I4" in c[0])
+        assert not vic_i4[1]
+
+    def test_vic_i5_exactly_at_threshold_fails(self):
+        # I5 uses strict < so exactly 250 Hz must FAIL
+        checks = run_threshold_checks(self._stats(vic_i5_f0=VIC_I5_F0_MAX_HZ))
+        vic_i5 = next(c for c in checks if "I5" in c[0])
+        assert not vic_i5[1]
+
+    def test_stats_with_none_f0_reports_no_data(self):
+        # Stats entry exists but f0_median_hz is None (all turns unvoiced)
+        stats = [RoleIntensityStats("VIC", 1, 5, None, None, -25.0)]
+        checks = run_threshold_checks(stats)
+        vic_i1 = next(c for c in checks if "I1" in c[0] and "VIC" in c[0])
+        assert not vic_i1[1]
+        assert "no data" in vic_i1[2]
+
+
+# ---------------------------------------------------------------------------
+# _measure_segment — int16 normalization and librosa F0 path
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureSegmentCoverage:
+    def test_rms_int16_and_float32_equivalent(self):
+        """int16 and float32 of the same signal should give the same RMS dBFS."""
+        samples_i16 = _sine(220.0, 0.5)
+        samples_f32 = samples_i16.astype(np.float32) / 32768.0
+        _, _, rms_i16 = _measure_segment(samples_i16, SR, 0.0, 0.5)
+        _, _, rms_f32 = _measure_segment(samples_f32, SR, 0.0, 0.5)
+        assert rms_i16 == pytest.approx(rms_f32, abs=0.5)
+
+    def _make_librosa_mock(self, f0_values: np.ndarray, voiced_flag: np.ndarray) -> MagicMock:
+        """Return a sys.modules-injectable librosa mock with a stubbed pyin."""
+        mock_lib = MagicMock()
+        mock_lib.pyin.return_value = (f0_values, voiced_flag, None)
+        mock_lib.note_to_hz.side_effect = lambda note: {"C2": 65.4, "C7": 2093.0}[note]
+        return mock_lib
+
+    def test_f0_returned_when_librosa_returns_voiced_frames(self, monkeypatch):
+        """Cover the successful librosa path (lines 122–133): pyin returns voiced F0."""
+        n_frames = 50
+        f0_values = np.full(n_frames, 220.0)
+        voiced_flag = np.ones(n_frames, dtype=bool)
+        mock_lib = self._make_librosa_mock(f0_values, voiced_flag)
+
+        monkeypatch.setitem(sys.modules, "librosa", mock_lib)
+        samples = _sine(220.0, 1.0)
+        f0, f0_std, rms_db = _measure_segment(samples, SR, 0.0, 1.0)
+        assert f0 == pytest.approx(220.0)
+        assert f0_std is not None
+        assert rms_db < 0
+
+    def test_f0_none_when_all_frames_unvoiced(self, monkeypatch):
+        """Cover line 131-132: pyin runs but returns no voiced frames."""
+        n_frames = 50
+        f0_values = np.full(n_frames, np.nan)
+        voiced_flag = np.zeros(n_frames, dtype=bool)
+        mock_lib = self._make_librosa_mock(f0_values, voiced_flag)
+
+        monkeypatch.setitem(sys.modules, "librosa", mock_lib)
+        samples = _sine(220.0, 1.0)
+        f0, f0_std, rms_db = _measure_segment(samples, SR, 0.0, 1.0)
+        assert f0 is None
+        assert f0_std is None
+        assert rms_db < 0
+
+
+# ---------------------------------------------------------------------------
+# measure_clip — stereo downmix explicit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureClipStereo:
+    def test_stereo_downmix_uses_first_channel(self, tmp_path):
+        """Cover line 167: stereo WAV is downmixed to first channel."""
+        wav = tmp_path / "clip_001.wav"
+        # Channel 0: loud 220 Hz; channel 1: silence — verifies first channel is used
+        loud = _sine(220.0, 1.0).astype(np.float32) / 32768.0
+        silent = np.zeros(len(loud), dtype=np.float32)
+        stereo = np.stack([loud, silent], axis=1)
+        sf.write(str(wav), stereo, SR)
+        _write_jsonl(
+            tmp_path / "clip_001.jsonl",
+            [_event("clip_001", 0.1, 0.9, 1, "AGG")],
+        )
+        result = measure_clip(wav)
+        assert len(result) == 1
+        # Should have a non-trivial RMS (from the loud channel, not silence)
+        assert result[0].rms_db > -60.0
+
+
+# ---------------------------------------------------------------------------
+# measure-prosody CLI command
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureProsodyCLI:
+    def _make_clip(self, tmp_path: Path, clip_id: str, role: str, intensity: int) -> None:
+        """Write a minimal WAV + JSONL pair."""
+        wav = tmp_path / f"{clip_id}.wav"
+        _write_wav(wav, _sine(220.0, 1.0))
+        _write_jsonl(
+            tmp_path / f"{clip_id}.jsonl",
+            [_event(clip_id, 0.1, 0.9, intensity, role)],
+        )
+
+    def test_empty_dir_exits_cleanly(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["measure-prosody", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No .wav files" in result.output
+
+    def test_missing_jsonl_skipped(self, tmp_path):
+        wav = tmp_path / "clip_001.wav"
+        _write_wav(wav, _sine(220.0, 1.0))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["measure-prosody", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No speaker-role events" in result.output
+
+    def test_prints_table_with_clips(self, tmp_path):
+        self._make_clip(tmp_path, "clip_agg", "AGG", 1)
+        self._make_clip(tmp_path, "clip_vic", "VIC", 1)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["measure-prosody", str(tmp_path)])
+        assert "AGG" in result.output
+        assert "VIC" in result.output
+        assert "threshold" in result.output.lower()
+
+    def test_threshold_failure_exits_1(self, tmp_path):
+        """If any threshold fails (here: no VIC data → no data → fail), exit code is 1."""
+        self._make_clip(tmp_path, "clip_agg", "AGG", 1)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["measure-prosody", str(tmp_path), "--roles", "AGG,VIC"])
+        # VIC checks will report no data → fail → exit 1
+        assert result.exit_code == 1
+
+    def test_csv_output_written(self, tmp_path):
+        self._make_clip(tmp_path, "clip_agg", "AGG", 1)
+        csv_out = tmp_path / "out.csv"
+        runner = CliRunner()
+        runner.invoke(
+            cli,
+            ["measure-prosody", str(tmp_path), "--output", str(csv_out), "--roles", "AGG"],
+        )
+        assert csv_out.exists()
+        content = csv_out.read_text()
+        assert "clip_id" in content
+        assert "clip_agg" in content
+
+    def test_roles_filter_excludes_other_roles(self, tmp_path):
+        self._make_clip(tmp_path, "clip_agg", "AGG", 1)
+        self._make_clip(tmp_path, "clip_vic", "VIC", 1)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["measure-prosody", str(tmp_path), "--roles", "AGG"])
+        assert "AGG" in result.output
+        # VIC excluded — no VIC rows in table, but command should not crash

--- a/tests/unit/test_prosody_metrics.py
+++ b/tests/unit/test_prosody_metrics.py
@@ -356,6 +356,23 @@ class TestRunThresholdChecks:
         assert not vic_i1[1]
         assert "no data" in vic_i1[2]
 
+    def test_include_roles_skips_vic_checks(self):
+        """include_roles={'AGG'} suppresses all VIC threshold checks."""
+        checks = run_threshold_checks(self._stats(), include_roles={"AGG"})
+        assert all("VIC" not in label for label, _, _ in checks)
+        assert any("AGG" in label for label, _, _ in checks)
+
+    def test_include_roles_skips_agg_check(self):
+        """include_roles={'VIC'} suppresses the AGG escalation check."""
+        checks = run_threshold_checks(self._stats(), include_roles={"VIC"})
+        assert all("AGG" not in label for label, _, _ in checks)
+        assert any("VIC" in label for label, _, _ in checks)
+
+    def test_include_roles_none_runs_all_checks(self):
+        """include_roles=None (default) runs all four checks."""
+        checks = run_threshold_checks(self._stats(), include_roles=None)
+        assert len(checks) == 4
+
 
 # ---------------------------------------------------------------------------
 # _measure_segment — int16 normalization and librosa F0 path
@@ -469,14 +486,6 @@ class TestMeasureProsodyCLI:
         assert "VIC" in result.output
         assert "threshold" in result.output.lower()
 
-    def test_threshold_failure_exits_1(self, tmp_path):
-        """If any threshold fails (here: no VIC data → no data → fail), exit code is 1."""
-        self._make_clip(tmp_path, "clip_agg", "AGG", 1)
-        runner = CliRunner()
-        result = runner.invoke(cli, ["measure-prosody", str(tmp_path), "--roles", "AGG,VIC"])
-        # VIC checks will report no data → fail → exit 1
-        assert result.exit_code == 1
-
     def test_csv_output_written(self, tmp_path):
         self._make_clip(tmp_path, "clip_agg", "AGG", 1)
         csv_out = tmp_path / "out.csv"
@@ -491,9 +500,58 @@ class TestMeasureProsodyCLI:
         assert "clip_agg" in content
 
     def test_roles_filter_excludes_other_roles(self, tmp_path):
-        self._make_clip(tmp_path, "clip_agg", "AGG", 1)
-        self._make_clip(tmp_path, "clip_vic", "VIC", 1)
+        """--roles AGG excludes VIC from table and checks; exit 0 when AGG checks pass."""
+        # AGG I1 (very quiet) and I5 (loud) so RMS escalation check passes (>8 dB delta)
+        wav_i1 = tmp_path / "clip_agg_i1.wav"
+        _write_wav(wav_i1, (_sine(220.0, 1.0).astype(np.float32) * 0.01).astype(np.int16))
+        _write_jsonl(tmp_path / "clip_agg_i1.jsonl", [_event("clip_agg_i1", 0.1, 0.9, 1, "AGG")])
+
+        wav_i5 = tmp_path / "clip_agg_i5.wav"
+        _write_wav(wav_i5, _sine(220.0, 1.0))  # default amplitude (~40 dB louder than I1)
+        _write_jsonl(tmp_path / "clip_agg_i5.jsonl", [_event("clip_agg_i5", 0.1, 0.9, 5, "AGG")])
+
+        self._make_clip(tmp_path, "clip_vic", "VIC", 1)  # excluded by --roles AGG
+
         runner = CliRunner()
         result = runner.invoke(cli, ["measure-prosody", str(tmp_path), "--roles", "AGG"])
+        assert result.exit_code == 0  # VIC checks are skipped; AGG checks pass
         assert "AGG" in result.output
-        # VIC excluded — no VIC rows in table, but command should not crash
+        assert "VIC" not in result.output  # excluded from table and threshold check labels
+
+    def test_malformed_jsonl_line_skipped(self, tmp_path):
+        """Malformed JSONL lines are skipped with a warning; valid events still returned."""
+        import warnings
+
+        wav = tmp_path / "clip_001.wav"
+        _write_wav(wav, _sine(220.0, 1.0))
+        jsonl = tmp_path / "clip_001.jsonl"
+        valid = json.dumps(_event("clip_001", 0.1, 0.9, 1, "AGG"))
+        jsonl.write_text(valid + "\nnot valid json\n", encoding="utf-8")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = measure_clip(wav)
+
+        assert len(result) == 1  # valid event returned
+        assert any("malformed" in str(w.message).lower() for w in caught)
+
+    def test_empty_jsonl_lines_skipped(self, tmp_path):
+        """Empty / blank lines in JSONL are silently skipped."""
+        wav = tmp_path / "clip_001.wav"
+        _write_wav(wav, _sine(220.0, 1.0))
+        jsonl = tmp_path / "clip_001.jsonl"
+        valid = json.dumps(_event("clip_001", 0.1, 0.9, 1, "AGG"))
+        # Intersperse blank lines
+        jsonl.write_text(f"\n{valid}\n\n", encoding="utf-8")
+
+        result = measure_clip(wav)
+        assert len(result) == 1
+
+    def test_threshold_failure_sets_exit_code_1(self, tmp_path):
+        """A failing check (here: VIC missing with --roles AGG,VIC) exits with code 1."""
+        self._make_clip(tmp_path, "clip_agg", "AGG", 1)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["measure-prosody", str(tmp_path), "--roles", "AGG,VIC"])
+        # VIC data absent → VIC checks emit "no data" → passed=False → exit 1
+        assert result.exit_code == 1
+        assert "VIC" in result.output

--- a/tests/unit/test_prosody_metrics.py
+++ b/tests/unit/test_prosody_metrics.py
@@ -1,0 +1,331 @@
+"""Unit tests for synthbanshee.labels.prosody_metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from synthbanshee.labels.prosody_metrics import (
+    AGG_ESCALATION_MIN_DB,
+    VIC_I1_F0_MAX_HZ,
+    VIC_I4_F0_MAX_HZ,
+    VIC_I5_F0_MAX_HZ,
+    RoleIntensityStats,
+    TurnMetrics,
+    _measure_segment,
+    aggregate_metrics,
+    measure_clip,
+    run_threshold_checks,
+)
+
+SR = 16_000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sine(freq_hz: float, duration_s: float, sr: int = SR) -> np.ndarray:
+    """Generate a mono int16 sine wave at freq_hz."""
+    t = np.linspace(0, duration_s, int(sr * duration_s), endpoint=False)
+    wave = (np.sin(2 * np.pi * freq_hz * t) * 32767 * 0.5).astype(np.int16)
+    return wave
+
+
+def _silence(duration_s: float, sr: int = SR) -> np.ndarray:
+    return np.zeros(int(sr * duration_s), dtype=np.int16)
+
+
+def _write_wav(path: Path, samples: np.ndarray, sr: int = SR) -> None:
+    sf.write(str(path), samples, sr, subtype="PCM_16")
+
+
+def _write_jsonl(path: Path, events: list[dict]) -> None:
+    lines = [json.dumps(e) for e in events]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _event(
+    clip_id: str,
+    onset: float,
+    offset: float,
+    intensity: int,
+    speaker_role: str,
+    event_id: str = "ev_001",
+) -> dict:
+    return {
+        "event_id": event_id,
+        "clip_id": clip_id,
+        "onset": onset,
+        "offset": offset,
+        "tier1_category": "NONE",
+        "tier2_subtype": "NONE_AMBIENT",
+        "intensity": intensity,
+        "speaker_id": "AGG_001",
+        "speaker_role": speaker_role,
+        "emotional_state": "neutral",
+        "confidence": 1.0,
+        "label_source": "auto",
+        "iaa_reviewed": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _measure_segment
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureSegment:
+    def test_rms_silent_segment(self):
+        samples = _silence(1.0)
+        _, _, rms_db = _measure_segment(samples, SR, 0.0, 1.0)
+        assert rms_db < -80.0
+
+    def test_rms_tone_louder_than_silence(self):
+        tone = _sine(220.0, 1.0)
+        silent = _silence(1.0)
+        _, _, rms_tone = _measure_segment(tone, SR, 0.0, 1.0)
+        _, _, rms_silent = _measure_segment(silent, SR, 0.0, 1.0)
+        assert rms_tone > rms_silent
+
+    def test_segment_offset_respected(self):
+        """Only the [onset, offset] window is measured."""
+        # First half loud, second half silent
+        loud = _sine(440.0, 0.5)
+        quiet = _silence(0.5)
+        samples = np.concatenate([loud, quiet])
+        _, _, rms_loud_half = _measure_segment(samples, SR, 0.0, 0.5)
+        _, _, rms_quiet_half = _measure_segment(samples, SR, 0.5, 1.0)
+        assert rms_loud_half > rms_quiet_half + 20  # at least 20 dB difference
+
+    def test_too_short_returns_sentinel(self):
+        """Segments shorter than 50 ms return (None, None, -96.0)."""
+        samples = _sine(220.0, 0.02)  # 20 ms
+        f0, f0_std, rms_db = _measure_segment(samples, SR, 0.0, 0.02)
+        assert f0 is None
+        assert f0_std is None
+        assert rms_db == pytest.approx(-96.0)
+
+    def test_out_of_bounds_onset_offset_clamped(self):
+        """Onset/offset beyond array length must not raise."""
+        samples = _sine(220.0, 0.5)
+        # offset beyond array
+        f0, f0_std, rms_db = _measure_segment(samples, SR, 0.0, 10.0)
+        assert rms_db < 0  # just no crash; some rms value returned
+
+    def test_f0_none_when_librosa_unavailable(self, monkeypatch):
+        """If librosa raises ImportError, F0 is None but RMS is still returned."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _block_librosa(name, *args, **kwargs):
+            if name == "librosa":
+                raise ImportError("librosa not available")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _block_librosa)
+        samples = _sine(220.0, 0.5)
+        f0, f0_std, rms_db = _measure_segment(samples, SR, 0.0, 0.5)
+        assert f0 is None
+        assert f0_std is None
+        assert rms_db < 0  # rms still computed
+
+
+# ---------------------------------------------------------------------------
+# measure_clip
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureClip:
+    def test_missing_jsonl_returns_empty(self, tmp_path):
+        wav = tmp_path / "clip_001.wav"
+        _write_wav(wav, _sine(220.0, 1.0))
+        assert measure_clip(wav) == []
+
+    def test_empty_jsonl_returns_empty(self, tmp_path):
+        wav = tmp_path / "clip_001.wav"
+        _write_wav(wav, _sine(220.0, 1.0))
+        (tmp_path / "clip_001.jsonl").write_text("", encoding="utf-8")
+        assert measure_clip(wav) == []
+
+    def test_event_without_speaker_role_skipped(self, tmp_path):
+        wav = tmp_path / "clip_001.wav"
+        _write_wav(wav, _sine(220.0, 1.0))
+        ev = _event("clip_001", 0.1, 0.9, 1, "AGG")
+        ev["speaker_role"] = None
+        _write_jsonl(tmp_path / "clip_001.jsonl", [ev])
+        assert measure_clip(wav) == []
+
+    def test_one_event_returns_one_metric(self, tmp_path):
+        wav = tmp_path / "clip_001.wav"
+        _write_wav(wav, _sine(220.0, 1.0))
+        _write_jsonl(
+            tmp_path / "clip_001.jsonl",
+            [_event("clip_001", 0.1, 0.9, 2, "AGG")],
+        )
+        result = measure_clip(wav)
+        assert len(result) == 1
+        assert result[0].speaker_role == "AGG"
+        assert result[0].intensity == 2
+        assert result[0].rms_db < 0
+
+    def test_two_events_different_roles(self, tmp_path):
+        wav = tmp_path / "clip_001.wav"
+        _write_wav(wav, _silence(2.0))
+        events = [
+            _event("clip_001", 0.0, 0.9, 1, "AGG", "ev_001"),
+            _event("clip_001", 1.0, 1.9, 3, "VIC", "ev_002"),
+        ]
+        _write_jsonl(tmp_path / "clip_001.jsonl", events)
+        result = measure_clip(wav)
+        assert len(result) == 2
+        roles = {t.speaker_role for t in result}
+        assert roles == {"AGG", "VIC"}
+
+    def test_stereo_wav_downmixed(self, tmp_path):
+        """Stereo WAV should not crash — first channel used."""
+        wav = tmp_path / "clip_001.wav"
+        stereo = np.stack([_sine(220.0, 1.0), _sine(440.0, 1.0)], axis=1)
+        sf.write(str(wav), stereo, SR, subtype="PCM_16")
+        _write_jsonl(
+            tmp_path / "clip_001.jsonl",
+            [_event("clip_001", 0.1, 0.9, 1, "AGG")],
+        )
+        result = measure_clip(wav)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# aggregate_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateMetrics:
+    def _make_turns(self) -> list[TurnMetrics]:
+        return [
+            TurnMetrics("c1", "AGG", 1, 130.0, 10.0, -25.0),
+            TurnMetrics("c1", "AGG", 1, 135.0, 12.0, -24.0),
+            TurnMetrics("c1", "AGG", 5, 140.0, 15.0, -15.0),
+            TurnMetrics("c1", "VIC", 1, 190.0, 8.0, -26.0),
+            TurnMetrics("c1", "VIC", 5, 230.0, 20.0, -20.0),
+        ]
+
+    def test_bucket_count(self):
+        stats = aggregate_metrics(self._make_turns())
+        assert len(stats) == 4  # AGG/1, AGG/5, VIC/1, VIC/5
+
+    def test_n_turns_correct(self):
+        stats = aggregate_metrics(self._make_turns())
+        agg1 = next(s for s in stats if s.role == "AGG" and s.intensity == 1)
+        assert agg1.n_turns == 2
+
+    def test_f0_median_of_medians(self):
+        stats = aggregate_metrics(self._make_turns())
+        agg1 = next(s for s in stats if s.role == "AGG" and s.intensity == 1)
+        assert agg1.f0_median_hz == pytest.approx(np.median([130.0, 135.0]))
+
+    def test_rms_mean(self):
+        stats = aggregate_metrics(self._make_turns())
+        agg1 = next(s for s in stats if s.role == "AGG" and s.intensity == 1)
+        assert agg1.rms_db_mean == pytest.approx(np.mean([-25.0, -24.0]))
+
+    def test_sorted_by_role_then_intensity(self):
+        stats = aggregate_metrics(self._make_turns())
+        keys = [(s.role, s.intensity) for s in stats]
+        assert keys == sorted(keys)
+
+    def test_none_f0_excluded_from_median(self):
+        turns = [
+            TurnMetrics("c1", "AGG", 1, None, None, -25.0),
+            TurnMetrics("c1", "AGG", 1, 130.0, 10.0, -24.0),
+        ]
+        stats = aggregate_metrics(turns)
+        assert stats[0].f0_median_hz == pytest.approx(130.0)
+
+    def test_all_none_f0_gives_none_median(self):
+        turns = [TurnMetrics("c1", "VIC", 1, None, None, -25.0)]
+        stats = aggregate_metrics(turns)
+        assert stats[0].f0_median_hz is None
+
+    def test_empty_input_returns_empty(self):
+        assert aggregate_metrics([]) == []
+
+
+# ---------------------------------------------------------------------------
+# run_threshold_checks
+# ---------------------------------------------------------------------------
+
+
+class TestRunThresholdChecks:
+    def _stats(
+        self,
+        vic_i1_f0=185.0,
+        vic_i4_f0=220.0,
+        vic_i5_f0=230.0,
+        agg_i1_rms=-25.0,
+        agg_i5_rms=-14.0,
+    ) -> list[RoleIntensityStats]:
+        return [
+            RoleIntensityStats("AGG", 1, 10, 128.0, 12.0, agg_i1_rms),
+            RoleIntensityStats("AGG", 5, 10, 140.0, 15.0, agg_i5_rms),
+            RoleIntensityStats("VIC", 1, 10, vic_i1_f0, 8.0, -26.0),
+            RoleIntensityStats("VIC", 4, 10, vic_i4_f0, 10.0, -22.0),
+            RoleIntensityStats("VIC", 5, 10, vic_i5_f0, 12.0, -20.0),
+        ]
+
+    def test_all_pass(self):
+        checks = run_threshold_checks(self._stats())
+        assert all(passed for _, passed, _ in checks)
+
+    def test_vic_i1_f0_fail(self):
+        checks = run_threshold_checks(self._stats(vic_i1_f0=VIC_I1_F0_MAX_HZ + 1))
+        vic_i1 = next(c for c in checks if "I1" in c[0] and "VIC" in c[0])
+        assert not vic_i1[1]
+
+    def test_vic_i4_f0_fail(self):
+        checks = run_threshold_checks(self._stats(vic_i4_f0=VIC_I4_F0_MAX_HZ + 1))
+        vic_i4 = next(c for c in checks if "I4" in c[0])
+        assert not vic_i4[1]
+
+    def test_vic_i5_f0_fail(self):
+        checks = run_threshold_checks(self._stats(vic_i5_f0=VIC_I5_F0_MAX_HZ + 1))
+        vic_i5 = next(c for c in checks if "I5" in c[0])
+        assert not vic_i5[1]
+
+    def test_agg_escalation_fail(self):
+        # 6 dB delta — below the 8 dB minimum
+        checks = run_threshold_checks(self._stats(agg_i1_rms=-25.0, agg_i5_rms=-19.0))
+        agg_check = next(c for c in checks if "AGG" in c[0])
+        assert not agg_check[1]
+
+    def test_agg_escalation_exact_threshold_passes(self):
+        checks = run_threshold_checks(
+            self._stats(agg_i1_rms=-25.0, agg_i5_rms=-25.0 + AGG_ESCALATION_MIN_DB)
+        )
+        agg_check = next(c for c in checks if "AGG" in c[0])
+        assert agg_check[1]
+
+    def test_missing_role_reports_no_data(self):
+        # No VIC entries at all
+        stats = [
+            RoleIntensityStats("AGG", 1, 5, 128.0, 12.0, -25.0),
+            RoleIntensityStats("AGG", 5, 5, 140.0, 15.0, -14.0),
+        ]
+        checks = run_threshold_checks(stats)
+        no_data = [c for c in checks if "no data" in c[2]]
+        assert len(no_data) == 3  # VIC I1, I4, I5 all missing
+
+    def test_returns_four_checks(self):
+        checks = run_threshold_checks(self._stats())
+        assert len(checks) == 4
+
+    def test_vic_i1_exactly_at_threshold_passes(self):
+        checks = run_threshold_checks(self._stats(vic_i1_f0=VIC_I1_F0_MAX_HZ))
+        vic_i1 = next(c for c in checks if "I1" in c[0] and "VIC" in c[0])
+        assert vic_i1[1]


### PR DESCRIPTION
## Summary

This PR implements M2a (SSML parameter redesign) from \`docs/audio_generation_v3_design.md §4.2a\`, plus the tooling needed to validate it before merging.

**Config changes (core of this PR):**
- `AGG` speakers: `volume_delta_db` at I4/I5 raised to +9/+13 dB (was +8/+10–11) to meet ≥8 dB escalation requirement
- `VIC` speakers: `pitch_delta_st` inverted from 0→+7 st (rises into child-voice range) to −4→−1 st (adult female baseline, hard cap at high intensities); `volume_delta_db` redesigned to positive escalation 0/+1/+2/+4/+5

Fixes debug_run_1 defect #2: HilaNeural baseline F0 ~215 Hz rising to 285–287 Hz at I5 → targets ≤200 Hz at I1, capped rather than elevated at I4–I5.

**Tooling added to support wet-test gate:**
- `synthbanshee/labels/prosody_metrics.py`: `measure_clip()`, `aggregate_metrics()`, `run_threshold_checks()` — per-turn F0/RMS measurement with §4.2a pass/fail thresholds
- CLI: `synthbanshee measure-prosody <clip_dir>` — prints Rich table + threshold checks; `--output` exports per-turn CSV
- CLI: `generate-batch --max-clips N` — caps clip count for smoke/wet-test runs
- `configs/scenes/she_proves/`: 8 Tier A scene configs (SP_SV/IT/NEG/NEU_A_0001–0002), required by the tier_a_500_she_proves run config

**All values are initial calibration defaults** per §4.2a — validate by listening test and F0/RMS measurement before scale generation.

## Test plan

- [x] All 887 unit tests pass
- [ ] Generate 15–30 Tier A she_proves clips: `synthbanshee generate-batch -r configs/run_configs/tier_a_500_she_proves.yaml --output-dir data/m2a_wettest --max-clips 15`
- [ ] Run automated checks: `synthbanshee measure-prosody data/m2a_wettest --output data/m2a_wettest/prosody_metrics.csv`
- [ ] Confirm VIC I1 baseline ≤ 200 Hz; VIC I4–I5 < 250 Hz
- [ ] Confirm AGG I5 − I1 ≥ 8 dB RMS
- [ ] Native Hebrew listener spot-check on 5 clips per intensity level

🤖 Generated with [Claude Code](https://claude.com/claude-code)