### PR TITLE
feat(m3): per-turn RMS gain in SceneMixer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,29 @@ All Phase 1 milestones are implemented and tested:
 
 The full pipeline is now wired end-to-end: `ScriptGenerator.generate()` → `TTSRenderer.render_scene()` → `preprocess()` → per-turn event labels → `ClipMetadata`. AI teams can use the Tier A dataset to start baseline model development.
 
+## Phase 3 IAA utilities (complete as of 2026-04-15)
+
+| Milestone | Module(s) | Status |
+|---|---|---|
+| 3.1 Per-turn RMS gain (M3) | `synthbanshee/tts/mixer.py`, `synthbanshee/config/speaker_config.py` | Done |
+| 3.2 Per-category kappa | `synthbanshee/labels/iaa.py` | Done |
+| 3.3 IAAReport | `synthbanshee/labels/iaa.py` | Done |
+| 3.4 iaa-report CLI | `synthbanshee/cli.py` | Done |
+
+### M3 — per-turn RMS gain
+
+Azure TTS normalizes WAV output, so `volume_delta_db` in SSML has no effect on amplitude.
+M3 fixes this by applying post-TTS RMS gain inside `SceneMixer.mix_sequential()`:
+
+- `StyleEntry` gains an optional `rms_target_dbfs: float | None` field (in `synthbanshee/config/speaker_config.py`).
+- `SceneMixer.mix_sequential()` now takes 4-tuples `(wav_bytes, pause_before_s, speaker_id, rms_target_dbfs)`. If `rms_target_dbfs` is not `None`, `_apply_rms_gain()` scales the decoded segment so its RMS matches the target before mixing.
+- `TTSRenderer.render_scene()` passes `style_entry.rms_target_dbfs` as the 4th element of each segment tuple.
+- Near-silent frames (RMS < −80 dBFS) are skipped to avoid noise-floor amplification.
+- The gain-adjusted signal is not clipped in the mixer; downstream peak-normalization in `preprocessing.py` handles clipping.
+
+AGG/BEN speaker YAMLs: `rms_target_dbfs` escalates −28 → −15 dBFS across I1–I5 (+13 dB, satisfying the ≥ 8 dB AGG escalation spec target).
+VIC/SW speaker YAMLs: `rms_target_dbfs` descends −26 → −30 dBFS across I1–I5 (victim's voice retreats under pressure).
+
 ## What NOT to do
 
 - Don't mix speaker personas across train/val/test splits (speaker-disjoint splits are required)

--- a/configs/examples/speaker_AGG_M_30-45_001.yaml
+++ b/configs/examples/speaker_AGG_M_30-45_001.yaml
@@ -33,26 +33,31 @@ style_map:
     rate_multiplier: 1.0
     pitch_delta_st: 0               # semitones
     volume_delta_db: 0
+    rms_target_dbfs: -28            # M3: quiet baseline
   2:                                # Moderate — slight edge, clipped responses
     style: "General"
     rate_multiplier: 1.05
     pitch_delta_st: 0               # M2a: AGG anger → faster + louder (M3), not higher pitch
     volume_delta_db: +2
+    rms_target_dbfs: -25            # M3: +3 dB
   3:                                # Active conflict — raised voice, contemptuous
     style: "angry"
     rate_multiplier: 1.15
     pitch_delta_st: 0               # M2a: stay flat; rate carries urgency
     volume_delta_db: +5
+    rms_target_dbfs: -22            # M3: +6 dB above I1
   4:                                # Escalated — aggressive, loud
     style: "angry"
     rate_multiplier: 1.20
     pitch_delta_st: +1              # M2a: minimal rise only at extreme ends
     volume_delta_db: +9
+    rms_target_dbfs: -19            # M3: +9 dB above I1
   5:                                # Extreme — shouting, near-clipping
     style: "angry"
     rate_multiplier: 1.25
-    pitch_delta_st: +1              # M2a: hard cap; RMS escalation via M3
+    pitch_delta_st: +1              # M2a: hard cap; loudness carried by M3
     volume_delta_db: +13
+    rms_target_dbfs: -15            # M3: +13 dB above I1 (satisfies ≥8 dB spec)
 
 # --- Disfluency profile ---
 # Probabilities for injecting realism markers into rendered speech.

--- a/configs/examples/speaker_BEN_M_40-55_003.yaml
+++ b/configs/examples/speaker_BEN_M_40-55_003.yaml
@@ -22,26 +22,31 @@ style_map:
     rate_multiplier: 1.0
     pitch_delta_st: 0
     volume_delta_db: 0
+    rms_target_dbfs: -28            # M3: quiet baseline
   2:                                # Frustrated — clipped, short answers
     style: "General"
     rate_multiplier: 1.05
     pitch_delta_st: 0               # M2a: anger → faster, not higher; M3 handles loudness
     volume_delta_db: +2
+    rms_target_dbfs: -25            # M3: +3 dB
   3:                                # Agitated — loud, accusatory, interrupting
     style: "angry"
     rate_multiplier: 1.15
     pitch_delta_st: 0               # M2a: stay flat; rate carries urgency
     volume_delta_db: +5
+    rms_target_dbfs: -22            # M3: +6 dB above I1
   4:                                # Pre-attack — threatening, pacing energy
     style: "angry"
     rate_multiplier: 1.20
     pitch_delta_st: +1              # M2a: minimal rise only at extreme ends
     volume_delta_db: +9
+    rms_target_dbfs: -19            # M3: +9 dB above I1
   5:                                # Attack — shouting, physical sounds added by augmenter
     style: "angry"
     rate_multiplier: 1.30
-    pitch_delta_st: +1              # M2a: hard cap; RMS escalation via M3
+    pitch_delta_st: +1              # M2a: hard cap; loudness carried by M3
     volume_delta_db: +13
+    rms_target_dbfs: -15            # M3: +13 dB above I1 (satisfies ≥8 dB spec)
 
 disfluency:
   filled_pause_prob: 0.05

--- a/configs/examples/speaker_SW_F_30-45_001.yaml
+++ b/configs/examples/speaker_SW_F_30-45_001.yaml
@@ -22,26 +22,31 @@ style_map:
     rate_multiplier: 1.0
     pitch_delta_st: -4              # M2a: lower baseline F0; prevents child-voice range at higher intensities
     volume_delta_db: 0
+    rms_target_dbfs: -26            # M3: professional baseline level
   2:                                # Slight tension — still professional, firmer tone
     style: "General"
     rate_multiplier: 1.0
     pitch_delta_st: -3
     volume_delta_db: +1
+    rms_target_dbfs: -27            # M3: slightly quieter (controlled de-escalation posture)
   3:                                # Conflict — de-escalation attempt, controlled stress
     style: "General"
     rate_multiplier: 0.95           # Slows down deliberately (de-escalation technique)
     pitch_delta_st: -3
     volume_delta_db: +2
+    rms_target_dbfs: -28            # M3: quieter still (deliberate lowering of voice)
   4:                                # Escalated — fear breaking through; pitch capped to avoid child-voice range
     style: "sad"
     rate_multiplier: 1.05
     pitch_delta_st: -2              # M2a: cap pitch escalation; additional distress via rate/timing
     volume_delta_db: +4
+    rms_target_dbfs: -29            # M3: fear suppresses volume further
   5:                                # Attack — panic, screaming for help
     style: "sad"
     rate_multiplier: 1.20
     pitch_delta_st: -1              # M2a: hard cap
     volume_delta_db: +5
+    rms_target_dbfs: -30            # M3: panic cry often perceived quieter than aggressor
 
 disfluency:
   filled_pause_prob: 0.03           # Low at baseline (professional); rises with intensity

--- a/configs/examples/speaker_VIC_F_25-40_002.yaml
+++ b/configs/examples/speaker_VIC_F_25-40_002.yaml
@@ -21,26 +21,31 @@ style_map:
     rate_multiplier: 1.0
     pitch_delta_st: -4              # M2a: lower baseline F0; prevents child-voice range at higher intensities
     volume_delta_db: 0
+    rms_target_dbfs: -26            # M3: baseline level (slightly quieter than AGG)
   2:                                # Tension — careful, watchful; slight vocal strain
     style: "General"
     rate_multiplier: 0.95
     pitch_delta_st: -3
     volume_delta_db: +1
+    rms_target_dbfs: -27            # M3: voice drops slightly (guarded/hushed)
   3:                                # Conflict — defensive, shaking voice
     style: "sad"                    # Azure "sad" approximates fear/distress for he-IL
     rate_multiplier: 0.90
     pitch_delta_st: -3
     volume_delta_db: +2
+    rms_target_dbfs: -28            # M3: still dropping (victim shrinks under pressure)
   4:                                # Escalated — pleading, distress; pitch capped to avoid child-voice range
     style: "sad"
     rate_multiplier: 0.88
     pitch_delta_st: -2              # M2a: cap pitch escalation; additional distress via rate/timing
     volume_delta_db: +4
+    rms_target_dbfs: -29            # M3: near-whisper pleading
   5:                                # Extreme — panic, screaming or sobbing
     style: "sad"
     rate_multiplier: 1.10           # Can speed up under panic
     pitch_delta_st: -1              # M2a: hard cap; distress from rate instability, not further pitch rise
     volume_delta_db: +5
+    rms_target_dbfs: -30            # M3: sobbing/panic often sounds quieter than shouting (mic overload avoided)
 
 disfluency:
   filled_pause_prob: 0.08           # Higher — victim is more hesitant, searches for words

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -201,7 +201,10 @@ def _run_generate_pipeline(
     try:
         with tempfile.TemporaryDirectory() as tmp:
             raw_wav = Path(tmp) / "raw.wav"
-            sf.write(str(raw_wav), mixed.samples, mixed.sample_rate, subtype="PCM_16")
+            # Write as 32-bit float WAV so out-of-range samples from M3 RMS
+            # gain are preserved exactly; preprocess() peak-normalizes and
+            # then writes the final PCM_16 output safely.
+            sf.write(str(raw_wav), mixed.samples, mixed.sample_rate, subtype="FLOAT")
             result = preprocess(raw_wav, clip_wav, dirty_dir=dirty_dir)
     except Exception as exc:
         return None, [f"Pipeline error: {exc}"]

--- a/synthbanshee/config/speaker_config.py
+++ b/synthbanshee/config/speaker_config.py
@@ -25,6 +25,8 @@ class StyleEntry(BaseModel):
     rate_multiplier: float = Field(gt=0, le=3.0, default=1.0)
     pitch_delta_st: float = Field(ge=-12.0, le=12.0, default=0.0)
     volume_delta_db: float = Field(ge=-20.0, le=20.0, default=0.0)
+    # M3: post-TTS RMS target applied by SceneMixer. None → no gain adjustment.
+    rms_target_dbfs: float | None = Field(default=None, ge=-60.0, le=0.0)
 
 
 class DisfluencyProfile(BaseModel):

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -1,9 +1,10 @@
 """SceneMixer: concatenate per-speaker TTS WAV segments into a single audio scene.
 
-Each segment is a (wav_bytes, pause_before_s, speaker_id) triple.  The mixer
-decodes WAV bytes using soundfile, resamples to 16 kHz if needed, prepends the
-requested silence gap, and concatenates all segments into a single float32 mono
-array while preserving speaker IDs in the mix metadata.
+Each segment is a (wav_bytes, pause_before_s, speaker_id, rms_target_dbfs) 4-tuple.
+The mixer decodes WAV bytes using soundfile, resamples to 16 kHz if needed, applies
+optional per-turn RMS gain (M3), prepends the requested silence gap, and concatenates
+all segments into a single float32 mono array while preserving speaker IDs in the mix
+metadata.
 
 The output MixedScene carries per-turn onset/offset times so the label generator
 can derive event timing from the mix log rather than re-estimating it from the
@@ -25,20 +26,47 @@ from synthbanshee.script.types import MixedScene
 _TARGET_SR = 16_000
 
 
+def _apply_rms_gain(mono: np.ndarray, rms_target_dbfs: float) -> np.ndarray:
+    """Scale *mono* so its RMS equals *rms_target_dbfs* dBFS.
+
+    Near-silent frames (RMS < −80 dBFS) are returned unchanged to avoid
+    amplifying noise floors to absurd levels.  The result is not clipped;
+    clipping is handled downstream by the preprocessing peak-normalizer.
+
+    Args:
+        mono: Float32 mono audio array (values in [−1, 1] range expected).
+        rms_target_dbfs: Desired RMS level in dBFS (negative float, e.g. −20.0).
+
+    Returns:
+        Gain-adjusted float32 array.
+    """
+    rms = float(np.sqrt(np.mean(mono**2)))
+    if rms < 1e-4:  # ~−80 dBFS — treat as silence, skip gain
+        return mono
+    current_dbfs = 20.0 * np.log10(rms)
+    gain_db = rms_target_dbfs - current_dbfs
+    gain_linear = 10.0 ** (gain_db / 20.0)
+    return (mono * gain_linear).astype(np.float32)
+
+
 class SceneMixer:
     """Mix a sequence of TTS segments into a single-track 16 kHz scene."""
 
     def mix_sequential(
         self,
-        segments: list[tuple[bytes, float, str]],
+        segments: list[tuple[bytes, float, str, float | None]],
     ) -> MixedScene:
         """Concatenate segments in order, separated by silence gaps.
 
         Args:
-            segments: List of (wav_bytes, pause_before_s, speaker_id) triples.
+            segments: List of (wav_bytes, pause_before_s, speaker_id,
+                      rms_target_dbfs) 4-tuples.
                       wav_bytes must be valid WAV data (any SR / channels).
                       pause_before_s is inserted *before* each segment.
                       speaker_id is stored in the MixedScene for labelling.
+                      rms_target_dbfs: if not None, the segment is gain-adjusted
+                      so its RMS matches this target (dBFS) after decoding and
+                      resampling.
 
         Returns:
             MixedScene with all segments concatenated at 16 kHz mono.
@@ -49,7 +77,7 @@ class SceneMixer:
         speaker_ids: list[str] = []
         current_pos_s: float = 0.0
 
-        for wav_bytes, pause_s, speaker_id in segments:
+        for wav_bytes, pause_s, speaker_id, rms_target_dbfs in segments:
             # --- Decode WAV ---
             with io.BytesIO(wav_bytes) as buf:
                 data, src_sr = sf.read(buf, dtype="float32", always_2d=True)
@@ -60,6 +88,10 @@ class SceneMixer:
             # Resample to 16 kHz if needed
             if src_sr != _TARGET_SR:
                 mono = _resample(mono, src_sr, _TARGET_SR)
+
+            # M3: apply per-turn RMS gain before mixing
+            if rms_target_dbfs is not None:
+                mono = _apply_rms_gain(mono, rms_target_dbfs)
 
             # Prepend silence gap
             if pause_s > 0.0:

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -187,7 +187,7 @@ class TTSRenderer:
         rng = random.Random(rng_seed)
         mixer = SceneMixer()
 
-        segments: list[tuple[bytes, float, str]] = []
+        segments: list[tuple[bytes, float, str, float | None]] = []
         for i, turn in enumerate(turns):
             speaker = speakers[turn.speaker_id]
             # Use text_spoken (post-gender-disambiguation) rather than the
@@ -199,6 +199,7 @@ class TTSRenderer:
                     prob=speaker.disfluency.filled_pause_prob,
                     rng_seed=rng.randint(0, 2**31),
                 )
+            style_entry = speaker.style_for_intensity(turn.intensity)
             wav_bytes, _, hit = self.render_utterance(
                 text,
                 speaker,
@@ -213,6 +214,8 @@ class TTSRenderer:
                     f" [{turn.speaker_id}] intensity={turn.intensity}"
                     f" → {status}[/dim]"
                 )
-            segments.append((wav_bytes, turn.pause_before_s, turn.speaker_id))
+            segments.append(
+                (wav_bytes, turn.pause_before_s, turn.speaker_id, style_entry.rms_target_dbfs)
+            )
 
         return mixer.mix_sequential(segments)

--- a/tests/unit/test_mixer.py
+++ b/tests/unit/test_mixer.py
@@ -8,7 +8,7 @@ import wave
 import numpy as np
 import pytest
 
-from synthbanshee.tts.mixer import _TARGET_SR, SceneMixer
+from synthbanshee.tts.mixer import _TARGET_SR, SceneMixer, _apply_rms_gain
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -67,7 +67,7 @@ class TestSceneMixer:
     def test_single_segment_no_pause(self):
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.0, "SPK_001")])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None)])
 
         assert result.sample_rate == _TARGET_SR
         assert len(result.turn_onsets_s) == 1
@@ -80,7 +80,7 @@ class TestSceneMixer:
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         pause_s = 0.3
-        result = mixer.mix_sequential([(wav, pause_s, "SPK_001")])
+        result = mixer.mix_sequential([(wav, pause_s, "SPK_001", None)])
 
         assert result.turn_onsets_s[0] == pytest.approx(pause_s, abs=0.01)
         assert result.duration_s == pytest.approx(pause_s + 0.5, abs=0.05)
@@ -91,8 +91,8 @@ class TestSceneMixer:
         wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "SPK_A"),
-                (wav2, 0.2, "SPK_B"),
+                (wav1, 0.0, "SPK_A", None),
+                (wav2, 0.2, "SPK_B", None),
             ]
         )
 
@@ -105,9 +105,9 @@ class TestSceneMixer:
     def test_total_duration_matches_samples(self):
         mixer = SceneMixer()
         segments = [
-            (_sine_wav_bytes(duration_s=0.8, sample_rate=_TARGET_SR), 0.1, "S1"),
-            (_sine_wav_bytes(duration_s=0.6, sample_rate=_TARGET_SR), 0.2, "S2"),
-            (_sine_wav_bytes(duration_s=0.4, sample_rate=_TARGET_SR), 0.15, "S3"),
+            (_sine_wav_bytes(duration_s=0.8, sample_rate=_TARGET_SR), 0.1, "S1", None),
+            (_sine_wav_bytes(duration_s=0.6, sample_rate=_TARGET_SR), 0.2, "S2", None),
+            (_sine_wav_bytes(duration_s=0.4, sample_rate=_TARGET_SR), 0.15, "S3", None),
         ]
         result = mixer.mix_sequential(segments)
         computed_duration = len(result.samples) / result.sample_rate
@@ -117,7 +117,7 @@ class TestSceneMixer:
         """Mixer should downsample 24 kHz input to 16 kHz output."""
         mixer = SceneMixer()
         wav_24k = _sine_wav_bytes(duration_s=0.5, sample_rate=24000)
-        result = mixer.mix_sequential([(wav_24k, 0.0, "SPK_001")])
+        result = mixer.mix_sequential([(wav_24k, 0.0, "SPK_001", None)])
 
         assert result.sample_rate == _TARGET_SR
         # Duration should still be approximately 0.5 s
@@ -126,7 +126,7 @@ class TestSceneMixer:
     def test_downmixes_stereo_to_mono(self):
         mixer = SceneMixer()
         stereo_wav = _stereo_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(stereo_wav, 0.0, "SPK_001")])
+        result = mixer.mix_sequential([(stereo_wav, 0.0, "SPK_001", None)])
 
         assert result.samples.ndim == 1
         assert result.duration_s == pytest.approx(1.0, abs=0.05)
@@ -134,15 +134,95 @@ class TestSceneMixer:
     def test_output_samples_are_float32(self):
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.0, "SPK_001")])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None)])
         assert result.samples.dtype == np.float32
 
     def test_offsets_greater_than_onsets(self):
         mixer = SceneMixer()
         segments = [
-            (_sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR), 0.1, "S1"),
-            (_sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR), 0.2, "S2"),
+            (_sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR), 0.1, "S1", None),
+            (_sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR), 0.2, "S2", None),
         ]
         result = mixer.mix_sequential(segments)
         for onset, offset in zip(result.turn_onsets_s, result.turn_offsets_s, strict=True):
             assert offset > onset
+
+
+class TestApplyRmsGain:
+    """Tests for _apply_rms_gain (M3 per-turn gain helper)."""
+
+    def _rms_dbfs(self, arr: np.ndarray) -> float:
+        rms = float(np.sqrt(np.mean(arr**2)))
+        return 20.0 * np.log10(rms)
+
+    def test_gain_reaches_target(self):
+        """Output RMS should match the requested target within 0.5 dB."""
+        n = 16000
+        t = np.linspace(0, 1.0, n, endpoint=False)
+        mono = (0.05 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        target_dbfs = -20.0
+        result = _apply_rms_gain(mono, target_dbfs)
+        assert self._rms_dbfs(result) == pytest.approx(target_dbfs, abs=0.5)
+
+    def test_louder_target_amplifies(self):
+        """Requesting a higher RMS target produces higher amplitude."""
+        n = 8000
+        t = np.linspace(0, 0.5, n, endpoint=False)
+        mono = (0.02 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        quiet = _apply_rms_gain(mono, -30.0)
+        loud = _apply_rms_gain(mono, -15.0)
+        assert self._rms_dbfs(loud) > self._rms_dbfs(quiet) + 10.0
+
+    def test_silence_returned_unchanged(self):
+        """Near-silent frames (RMS < 1e-4) must not be amplified."""
+        silence = np.zeros(8000, dtype=np.float32)
+        result = _apply_rms_gain(silence, -20.0)
+        assert np.all(result == 0.0)
+
+    def test_output_is_float32(self):
+        mono = (0.1 * np.ones(4000)).astype(np.float32)
+        result = _apply_rms_gain(mono, -25.0)
+        assert result.dtype == np.float32
+
+
+class TestRmsGainInMixer:
+    """Integration: rms_target_dbfs wired through mix_sequential."""
+
+    def _rms_dbfs(self, arr: np.ndarray) -> float:
+        rms = float(np.sqrt(np.mean(arr**2)))
+        return 20.0 * np.log10(rms)
+
+    def test_none_target_leaves_level_unchanged(self):
+        """Passing None for rms_target_dbfs must not alter the signal level."""
+        wav = _sine_wav_bytes(amplitude=0.1, duration_s=1.0, sample_rate=_TARGET_SR)
+        mixer = SceneMixer()
+        result = mixer.mix_sequential([(wav, 0.0, "SPK", None)])
+        # RMS of 0.1-amplitude sine = 0.1/sqrt(2) ≈ −23 dBFS; allow ±2 dB
+        assert self._rms_dbfs(result.samples) == pytest.approx(-23.0, abs=2.0)
+
+    def test_rms_target_applied(self):
+        """Segment with rms_target_dbfs should reach the requested level."""
+        wav = _sine_wav_bytes(amplitude=0.02, duration_s=1.0, sample_rate=_TARGET_SR)
+        mixer = SceneMixer()
+        target = -20.0
+        result = mixer.mix_sequential([(wav, 0.0, "SPK", target)])
+        assert self._rms_dbfs(result.samples) == pytest.approx(target, abs=0.5)
+
+    def test_escalation_across_two_segments(self):
+        """Louder RMS target on second segment produces measurably higher RMS."""
+        wav_quiet = _sine_wav_bytes(amplitude=0.02, duration_s=0.5, sample_rate=_TARGET_SR)
+        wav_loud = _sine_wav_bytes(amplitude=0.02, duration_s=0.5, sample_rate=_TARGET_SR)
+        mixer = SceneMixer()
+        result = mixer.mix_sequential(
+            [
+                (wav_quiet, 0.0, "AGG", -28.0),
+                (wav_loud, 0.0, "AGG", -15.0),
+            ]
+        )
+        # Verify combined duration is correct
+        assert result.duration_s == pytest.approx(1.0, abs=0.05)
+        # Extract the two halves and check RMS ordering
+        half = len(result.samples) // 2
+        rms_q = self._rms_dbfs(result.samples[:half])
+        rms_l = self._rms_dbfs(result.samples[half:])
+        assert rms_l > rms_q + 8.0  # ≥ 8 dB gap matches the M3 spec target


### PR DESCRIPTION
## Summary

- Azure TTS normalizes WAV output so `volume_delta_db` in SSML has no effect on amplitude — AGG speech was flat across intensity levels (I5−I1 ≈ 0.4 dB, far below the ≥ 8 dB spec target)
- M3 fixes this with a post-TTS per-turn RMS gain step applied inside `SceneMixer` before segments are concatenated

## Changes

**Core**
- `StyleEntry` (`synthbanshee/config/speaker_config.py`): new optional `rms_target_dbfs: float | None` field
- `SceneMixer.mix_sequential()` (`synthbanshee/tts/mixer.py`): signature extended to 4-tuples `(wav_bytes, pause_before_s, speaker_id, rms_target_dbfs)`; new `_apply_rms_gain()` helper scales each segment to the target RMS before mix. Near-silent frames (RMS < −80 dBFS) are skipped. No clipping — downstream `preprocess()` peak-normalizer handles that.
- `TTSRenderer.render_scene()` (`synthbanshee/tts/renderer.py`): passes `style_entry.rms_target_dbfs` as 4th element of each segment tuple

**Speaker configs**
- AGG / BEN: `rms_target_dbfs` escalates −28 → −15 dBFS across I1–I5 (+13 dB; satisfies ≥ 8 dB spec)
- VIC / SW: `rms_target_dbfs` descends −26 → −30 dBFS across I1–I5 (victim's voice retreats under pressure)

**Tests**
- All existing `TestSceneMixer` tests updated to 4-tuple signature (`None` for `rms_target_dbfs`)
- 4 new `TestApplyRmsGain` tests: target accuracy, amplification direction, silence skip, dtype
- 3 new `TestRmsGainInMixer` tests: `None` passthrough, target applied, escalation gap ≥ 8 dB

**Docs**: `CLAUDE.md` Phase 3 section added describing M3 design

## Test plan

- [x] All 899 unit tests pass (`pytest tests/unit/ -q`)
- [ ] Wet test: `synthbanshee generate-batch` with M3 YAMLs; confirm `measure-prosody --roles AGG` shows AGG I5−I1 ≥ 8 dB

🤖 Generated with [Claude Code](https://claude.com/claude-code)