### PR TITLE
feat(m3b): replace peak normalizer with peak limiter in preprocess()

### DIFF
--- a/docs/audio_generation_v3_design.md
+++ b/docs/audio_generation_v3_design.md
@@ -34,7 +34,7 @@ All P0–P2 work is tracked here. Milestones that span multiple PRs are listed o
 | **M1** | P0 | ✅ Done | Eliminates AGG→VIC gender errors | `hebrew_disambiguator.py` — niqqud lexicon + SSML `<phoneme>` for top tokens; `DialogueTurn.text_spoken` / `text_original` / `normalization_rules_triggered`; wired after `ScriptGenerator.generate()`; QA flag for unvocalized high-risk tokens in `text_spoken` | Small | No |
 | **M2a** | P0 | ✅ Done | Lowers VIC F0 to adult range; caps AGG pitch escalation | Update `style_map` in speaker YAMLs per §4.2a table — VIC pitch −4→−1 st, AGG pitch capped 0/0/0/+1/+1 across I2–I5 | Small | No |
 | **M3a** | P0 | ✅ Done | Preserves within-scene loudness trajectory | `rms_target_dbfs` on `StyleEntry`; `_apply_rms_gain()` helper in `SceneMixer`; 4-tuple segment API; AGG −28→−15 dBFS (I1→I5), VIC −26→−30 dBFS; FLOAT temp WAV write to avoid PCM_16 hard-clip | Small | No |
-| **M3b** | P0 | 🔲 Not started | Prevents peak-normalize from erasing inter-scene RMS contrast | Replace `_normalize_peak()` in `preprocess()` with sample-peak limiter (only clips above −1.0 dBFS, no forced scale-up); update `validate_audio()` to check peak ≤ −1.0 dBFS instead of == −1.0 dBFS; update `spec.md §3` | Small | Yes — spec.md §3 |
+| **M3b** | P0 | ✅ Done | Prevents peak-normalize from erasing inter-scene RMS contrast | Replace `_normalize_peak()` in `preprocess()` with sample-peak limiter (only clips above −1.0 dBFS, no forced scale-up); update `validate_audio()` to check peak ≤ −1.0 dBFS instead of == −1.0 dBFS; update `spec.md §3` | Small | Yes — spec.md §3 |
 | **M4** | P0 | 🔲 Not started | Fixes silent label corruption in strong-label JSONL | Audit `debug_run_1` emotional states; extend `taxonomy.yaml` `emotional_states` to cover all legitimate LLM outputs; replace `_normalize_emotion()` silent fallback with explicit mapping table + logged warning (hard fail for completely unknown states); add `WARN_EMOTION_DOWNGRADE` QA flag | Small | No |
 | **M5** | P1 | 🔲 Not started | Protects Tier A phonetic quality from over-denoising | `PreprocessingConfig` dataclass; update `preprocess()` to accept it (default unchanged); scene YAMLs gain optional `preprocessing` block; Wiener step skipped when `wiener_denoise=False`; unit tests verify Wiener skip | Small | No |
 | **M6** | P1 | 🔲 Not started | Replaces mechanical silence gaps with psychologically-motivated turn latencies | `TurnGapController` in `synthbanshee/tts/gap_controller.py`; project-specific gap tables (§4.5); wire into `TTSRenderer.render_scene()` replacing `turn.pause_before_s`; NEG/NEU confusor gap ranges; unit tests per context type and project | Small | No |
@@ -690,7 +690,7 @@ Before any dataset version is promoted from "restricted training" to "full train
 M1  (disambiguation)   ✅ ─────────────────────────────────────────── P0
 M2a (SSML params)      ✅ ─────────────────────────────────────────── P0
 M3a (per-turn gain)    ✅ requires M2a ──────────────────────────────── P0
-M3b (peak-limiter)        requires M3a ──────────────────────────────── P0
+M3b (peak-limiter)     ✅ requires M3a ──────────────────────────────── P0
 M4  (emotion metadata)    ─────────────────────────────────────────── P0
 
 M5  (preprocessing)       ──────────────────────────────── P1

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -97,7 +97,7 @@ Project codes: `SP` (She-Proves) · `EL` (Elephant in the Room)
 | Sample rate | 16,000 Hz | Resample before delivery; retain originals at native rate |
 | Bit depth | 16-bit PCM | |
 | Channels | Mono | Downmix to mono before delivery |
-| Amplitude normalization | −1.0 dBFS peak | Applied after augmentation |
+| Amplitude normalization | Peak ≤ −1.0 dBFS (limiter, not normalizer) | Only attenuates; never scales up — preserves within-scene loudness trajectory |
 | Silence padding | ≥ 0.5 s of ambient baseline before and after target speech | |
 | SNR at acquisition | ≥ 15 dB (Tier A) | Tier B/C may degrade controllably below 15 dB; log actual SNR in metadata |
 | Max clip duration | 300 s (5 min) | Longer source scenes must be segmented |
@@ -111,7 +111,7 @@ All clips must pass through this pipeline before delivery. The "dirty" pre-pipel
 2. **Downmix** — stereo → mono (average channels)
 3. **Spectral filter** — low-pass at 7,500 Hz to remove irrelevant high-frequency noise from budget sensors (Butterworth order 4)
 4. **Denoising** — spectral subtraction (Wiener filtering) to remove electrical hum; parameterize noise profile from silent leading segment
-5. **Normalize** — peak normalization to −1.0 dBFS
+5. **Peak limit** — attenuate to ≤ −1.0 dBFS if the signal exceeds that ceiling; never scale up. This preserves the within-scene loudness trajectory established by per-turn RMS gain (M3a). A forced scale-up would collapse intensity-level amplitude differences.
 6. **Silence pad** — verify ≥ 0.5 s ambient baseline at head and tail; add if absent
 7. **Validate** — assert: sample rate == 16000, channels == 1, no NaN/Inf samples, no UTF-8 above U+00A1 in metadata strings
 

--- a/synthbanshee/augment/preprocessing.py
+++ b/synthbanshee/augment/preprocessing.py
@@ -51,13 +51,21 @@ def _to_dbfs(samples: np.ndarray) -> float:
     return 20.0 * math.log10(peak)
 
 
-def _normalize_peak(samples: np.ndarray, target_dbfs: float = _PEAK_DBFS) -> np.ndarray:
-    """Peak-normalize to target_dbfs (e.g. −1.0 dBFS)."""
+def _peak_limit(samples: np.ndarray, ceiling_dbfs: float = _PEAK_DBFS) -> np.ndarray:
+    """Attenuate samples so peak ≤ ceiling_dbfs; never scale up.
+
+    Unlike peak normalization, this only applies gain when the signal
+    exceeds the ceiling.  Quieter signals are returned unchanged so that
+    the within-scene loudness trajectory established by per-turn RMS gain
+    (M3a) is preserved across the full clip.
+    """
     peak = float(np.max(np.abs(samples)))
     if peak == 0.0:
         return samples
-    target_linear = 10.0 ** (target_dbfs / 20.0)
-    return (samples * (target_linear / peak)).astype(np.float32)
+    ceiling_linear = 10.0 ** (ceiling_dbfs / 20.0)
+    if peak <= ceiling_linear:
+        return samples  # already within limit — do not scale up
+    return (samples * (ceiling_linear / peak)).astype(np.float32)
 
 
 def _resample(samples: np.ndarray, src_sr: int, dst_sr: int) -> np.ndarray:
@@ -155,9 +163,9 @@ def preprocess(
     samples = _wiener_denoise(samples)
     steps.append("wiener_denoise")
 
-    # --- 5. Peak normalize to −1.0 dBFS --------------------------------------
-    samples = _normalize_peak(samples, _PEAK_DBFS)
-    steps.append(f"normalize_peak_{_PEAK_DBFS}dBFS")
+    # --- 5. Peak limit to −1.0 dBFS (never scale up) -------------------------
+    samples = _peak_limit(samples, _PEAK_DBFS)
+    steps.append(f"peak_limit_{_PEAK_DBFS}dBFS")
 
     # --- 6. Silence pad (≥ 0.5 s at head and tail) ---------------------------
     samples = _ensure_silence_pad(samples, sr, _SILENCE_PAD_S)
@@ -234,12 +242,11 @@ def validate_audio(path: Path | str) -> tuple[bool, list[str]]:
     if duration < _MIN_DURATION_S:
         errors.append(f"duration {duration:.2f} s < minimum {_MIN_DURATION_S} s")
 
-    # Peak normalization (within 0.5 dB of target)
+    # Peak limit — clip must not exceed ceiling (allow 0.5 dB tolerance for
+    # PCM_16 quantisation rounding); clips quieter than the ceiling are fine.
     peak_dbfs = _to_dbfs(samples)
-    if not math.isinf(peak_dbfs) and abs(peak_dbfs - _PEAK_DBFS) > 0.5:
-        errors.append(
-            f"peak {peak_dbfs:.2f} dBFS deviates more than 0.5 dB from target {_PEAK_DBFS} dBFS"
-        )
+    if not math.isinf(peak_dbfs) and peak_dbfs > _PEAK_DBFS + 0.5:
+        errors.append(f"peak {peak_dbfs:.2f} dBFS exceeds ceiling {_PEAK_DBFS} dBFS")
 
     # Silence padding: check first and last 0.5 s are below -40 dBFS
     pad_n = int(_SILENCE_PAD_S * sr)

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -12,6 +12,7 @@ from synthbanshee.augment.preprocessing import (
     _PEAK_DBFS,
     _SILENCE_PAD_S,
     _TARGET_SR,
+    _peak_limit,
     preprocess,
     validate_audio,
 )
@@ -72,12 +73,26 @@ class TestPreprocess:
         data, _ = sf.read(str(dst))
         assert data.ndim == 1
 
-    def test_peak_normalization(self, tmp_path):
-        src = _write_sine_wav(tmp_path / "src.wav", amplitude=0.1)
+    def test_peak_limiter_loud_clip_clamped(self, tmp_path):
+        """A clip whose peak exceeds the ceiling must be attenuated to ≤ ceiling."""
+        # amplitude=0.99 → peak ≈ −0.09 dBFS, above the −1.0 dBFS ceiling
+        src = _write_sine_wav(tmp_path / "src.wav", amplitude=0.99)
         dst = tmp_path / "out.wav"
         preprocess(src, dst)
         peak = _peak_dbfs(dst)
-        assert abs(peak - _PEAK_DBFS) < 0.5, f"Peak {peak:.2f} not near {_PEAK_DBFS} dBFS"
+        assert peak <= _PEAK_DBFS + 0.5, f"Peak {peak:.2f} dBFS exceeds ceiling {_PEAK_DBFS} dBFS"
+
+    def test_peak_limiter_quiet_clip_not_scaled_up(self, tmp_path):
+        """A clip already below the ceiling must NOT be scaled up."""
+        # amplitude=0.05 → peak ≈ −26 dBFS, well below the −1.0 dBFS ceiling
+        src = _write_sine_wav(tmp_path / "src.wav", amplitude=0.05, sample_rate=_TARGET_SR)
+        dst = tmp_path / "out.wav"
+        preprocess(src, dst)
+        peak = _peak_dbfs(dst)
+        # Must remain well below the ceiling — not normalized up to −1.0 dBFS
+        assert peak < _PEAK_DBFS - 5.0, (
+            f"Quiet clip was scaled up: peak {peak:.2f} dBFS (expected << {_PEAK_DBFS} dBFS)"
+        )
 
     def test_silence_padding_present(self, tmp_path):
         src = _write_sine_wav(tmp_path / "src.wav", duration_s=4.0)
@@ -109,7 +124,7 @@ class TestPreprocess:
         assert "resample" in steps_str
         # "mono" step only appears when source has >1 channels
         assert "lowpass" in steps_str
-        assert "normalize" in steps_str
+        assert "peak_limit" in steps_str
         assert "silence_pad" in steps_str
 
     def test_short_clip_warning(self, tmp_path):
@@ -163,3 +178,60 @@ class TestValidateAudio:
         # 1 s + 2*0.5 s padding = 2 s — still below 3 s minimum
         assert not ok
         assert any("duration" in e for e in errors)
+
+    def test_quiet_clip_passes_validator(self, tmp_path):
+        """A valid clip whose peak is well below −1.0 dBFS must pass validation.
+
+        With a limiter (not normalizer) preprocess() does not scale up quiet
+        clips.  validate_audio() must accept them — only clips that exceed the
+        ceiling should be rejected.
+        """
+        src = _write_sine_wav(
+            tmp_path / "src.wav", amplitude=0.05, duration_s=4.0, sample_rate=_TARGET_SR
+        )
+        dst = tmp_path / "quiet.wav"
+        preprocess(src, dst)
+        ok, errors = validate_audio(dst)
+        assert ok, f"Quiet clip incorrectly rejected: {errors}"
+
+    def test_over_ceiling_clip_fails_validator(self, tmp_path):
+        """A WAV written with peak above the ceiling must fail validation."""
+        # Write a loud clip directly (bypassing preprocess) so the peak is > ceiling
+        path = tmp_path / "loud.wav"
+        loud = np.ones(int(4.0 * _TARGET_SR), dtype=np.float32) * 0.99
+        sf.write(str(path), loud, _TARGET_SR, subtype="PCM_16")
+        # Reload to get the actual stored peak (PCM_16 quantisation)
+        data, _ = sf.read(str(path), dtype="float32")
+        # Manually check it is above ceiling before asserting validator catches it
+        assert float(np.max(np.abs(data))) > 10 ** (_PEAK_DBFS / 20.0) + 0.01
+        ok, errors = validate_audio(path)
+        assert not ok
+        assert any("exceeds ceiling" in e for e in errors)
+
+
+class TestPeakLimit:
+    """Unit tests for _peak_limit() helper (M3b)."""
+
+    def test_loud_signal_clamped_to_ceiling(self):
+        loud = np.ones(1000, dtype=np.float32) * 0.99  # peak ≈ −0.09 dBFS
+        ceiling_dbfs = -1.0
+        result = _peak_limit(loud, ceiling_dbfs)
+        peak = float(np.max(np.abs(result)))
+        assert peak <= 10 ** (ceiling_dbfs / 20.0) + 1e-6
+
+    def test_quiet_signal_unchanged(self):
+        quiet = np.ones(1000, dtype=np.float32) * 0.1  # peak ≈ −20 dBFS
+        original = quiet.copy()
+        result = _peak_limit(quiet, -1.0)
+        np.testing.assert_array_equal(result, original)
+
+    def test_silence_unchanged(self):
+        silence = np.zeros(500, dtype=np.float32)
+        result = _peak_limit(silence, -1.0)
+        np.testing.assert_array_equal(result, silence)
+
+    def test_exactly_at_ceiling_unchanged(self):
+        ceiling_linear = 10 ** (-1.0 / 20.0)
+        at_ceiling = np.full(500, ceiling_linear, dtype=np.float32)
+        result = _peak_limit(at_ceiling, -1.0)
+        np.testing.assert_array_almost_equal(result, at_ceiling)


### PR DESCRIPTION
## Summary

Peak normalization in `preprocess()` was scaling the entire mixed scene to exactly −1.0 dBFS, including scaling **up** quiet scenes. This erased the within-scene loudness trajectory established by M3a per-turn RMS gain — a quiet AGG I1 turn and a loud AGG I5 turn would be brought to the same absolute level relative to the scene peak.

A **peak limiter** only attenuates when the signal exceeds the ceiling (−1.0 dBFS). Scenes already below the ceiling are passed through unchanged, preserving the M3a trajectory.

## Changes

**`synthbanshee/augment/preprocessing.py`**
- `_normalize_peak()` → `_peak_limit()`: only applies gain when peak exceeds ceiling; returns signal unchanged otherwise
- `preprocess()`: step label changed from `normalize_peak_-1.0dBFS` → `peak_limit_-1.0dBFS`
- `validate_audio()`: peak check changed from `abs(peak − ceiling) > 0.5` to `peak > ceiling + 0.5` — clips quieter than −1.0 dBFS are now valid

**`docs/spec.md §3`**
- Step 5 updated from "peak normalization to −1.0 dBFS" to "peak limit at −1.0 dBFS" with rationale
- Amplitude spec table row updated to "Peak ≤ −1.0 dBFS (limiter, not normalizer)"

**`docs/audio_generation_v3_design.md`**
- M3b tracker row marked ✅ Done

## Tests (906 pass)

- `test_peak_limiter_loud_clip_clamped` — loud clip clamped to ≤ ceiling
- `test_peak_limiter_quiet_clip_not_scaled_up` — quiet clip stays quiet
- `test_quiet_clip_passes_validator` — quiet clip accepted by `validate_audio()`
- `test_over_ceiling_clip_fails_validator` — over-ceiling clip rejected
- `TestPeakLimit` (4 tests) — unit tests for `_peak_limit()` directly

## Test plan

- [x] 906 unit tests pass
- [ ] Wet test: generate a scene with M3a RMS targets; confirm quiet I1 turns are not scaled up to −1.0 dBFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)