### PR TITLE
feat(m8a): overlap audio mixing — MixMode, buffer mixer, three-timeline MixedScene

### DIFF
--- a/synthbanshee/script/types.py
+++ b/synthbanshee/script/types.py
@@ -83,12 +83,14 @@ class MixedScene:
         script_offsets_s: Sequential-world offset (script_onset + TTS duration).
         rendered_onsets_s: Actual onset in the output buffer, accounting for
             overlap/barge-in positioning.
-        rendered_offsets_s: Actual offset in the output buffer (rendered_onset +
-            TTS duration, before any barge-in truncation).
-        audible_onsets_s: Same as rendered_onsets_s for all turns.
-        audible_ends_s: End of the audible portion.  For turns interrupted by a
-            BARGE_IN, this is earlier than ``rendered_offsets_s`` (the tail is
-            truncated); for all other turns it equals ``rendered_offsets_s``.
+        rendered_offsets_s: Actual offset in the output buffer after any
+            barge-in truncation has been applied.  For uninterrupted turns this
+            is ``rendered_onset + TTS duration``; for turns interrupted by a
+            BARGE_IN it is the truncation point in the final mixed output.
+        audible_onsets_s: Same as ``rendered_onsets_s`` for all turns.
+        audible_ends_s: End of the audible portion.  Matches
+            ``rendered_offsets_s`` for all turns, including BARGE_IN-interrupted
+            turns where both fields reflect the truncation point.
     """
 
     samples: np.ndarray

--- a/synthbanshee/script/types.py
+++ b/synthbanshee/script/types.py
@@ -70,10 +70,23 @@ class MixedScene:
     Attributes:
         samples: Float32 numpy array, mono, 16 kHz.
         sample_rate: Always 16000.
-        turn_onsets_s: Per-turn onset time in seconds (after silence pad).
-        turn_offsets_s: Per-turn offset time in seconds.
+        turn_onsets_s: Per-turn rendered onset in seconds (backward-compat alias
+            for ``rendered_onsets_s``).
+        turn_offsets_s: Per-turn rendered offset in seconds (backward-compat alias
+            for ``rendered_offsets_s``).
         duration_s: Total scene duration in seconds.
         speaker_ids: Speaker ID for each turn (parallel with onsets/offsets).
+        script_onsets_s: Sequential-world onset — where the turn would start if
+            no overlap were applied (§4.6).
+        script_offsets_s: Sequential-world offset (script_onset + TTS duration).
+        rendered_onsets_s: Actual onset in the output buffer, accounting for
+            overlap/barge-in positioning.
+        rendered_offsets_s: Actual offset in the output buffer (rendered_onset +
+            TTS duration, before any barge-in truncation).
+        audible_onsets_s: Same as rendered_onsets_s for all turns.
+        audible_ends_s: End of the audible portion.  For turns interrupted by a
+            BARGE_IN, this is earlier than ``rendered_offsets_s`` (the tail is
+            truncated); for all other turns it equals ``rendered_offsets_s``.
     """
 
     samples: np.ndarray
@@ -82,3 +95,10 @@ class MixedScene:
     turn_offsets_s: list[float]
     duration_s: float
     speaker_ids: list[str] = field(default_factory=list)
+    # M8a: three-timeline timestamps (§4.6).
+    script_onsets_s: list[float] = field(default_factory=list)
+    script_offsets_s: list[float] = field(default_factory=list)
+    rendered_onsets_s: list[float] = field(default_factory=list)
+    rendered_offsets_s: list[float] = field(default_factory=list)
+    audible_onsets_s: list[float] = field(default_factory=list)
+    audible_ends_s: list[float] = field(default_factory=list)

--- a/synthbanshee/script/types.py
+++ b/synthbanshee/script/types.py
@@ -70,10 +70,12 @@ class MixedScene:
     Attributes:
         samples: Float32 numpy array, mono, 16 kHz.
         sample_rate: Always 16000.
-        turn_onsets_s: Per-turn rendered onset in seconds (backward-compat alias
-            for ``rendered_onsets_s``).
-        turn_offsets_s: Per-turn rendered offset in seconds (backward-compat alias
-            for ``rendered_offsets_s``).
+        turn_onsets_s: Per-turn audible onset in seconds (backward-compat alias
+            for ``audible_onsets_s``; safe for all consumers since values are
+            always within the final waveform duration).
+        turn_offsets_s: Per-turn audible end in seconds (backward-compat alias
+            for ``audible_ends_s``; for BARGE_IN-interrupted turns this is the
+            truncation point, not the original TTS end).
         duration_s: Total scene duration in seconds.
         speaker_ids: Speaker ID for each turn (parallel with onsets/offsets).
         script_onsets_s: Sequential-world onset — where the turn would start if

--- a/synthbanshee/tts/gap_controller.py
+++ b/synthbanshee/tts/gap_controller.py
@@ -4,7 +4,14 @@ Replaces fixed ``pause_before_s`` values with context-sensitive silence duration
 drawn from project-specific tables (spec §4.5).  All draws are reproducible via
 a caller-supplied ``random.Random`` instance seeded from the scene's ``random_seed``.
 
+At I3–I5 intensities, the controller also decides whether the current turn
+*overlaps* or *barges in* on the previous turn, according to the asymmetric
+probability tables in §4.6.  When overlap/barge-in is selected, the returned
+amount is drawn from a fixed range representing the depth of the interruption
+rather than a silence gap.
+
 Gap table reference: docs/audio_generation_v3_design.md §4.5
+Overlap probability table: docs/audio_generation_v3_design.md §4.6
 """
 
 from __future__ import annotations
@@ -14,6 +21,7 @@ from dataclasses import dataclass
 from typing import NamedTuple
 
 from synthbanshee.script.types import DialogueTurn
+from synthbanshee.tts.mixer import MixMode
 
 
 class _GapRange(NamedTuple):
@@ -81,10 +89,32 @@ _PROJECT_TABLES: dict[str, dict[str, _GapRange]] = {
 # rather than an immediate cutting-in response.
 _AGG_PAUSE_PROB = 0.30
 
+# ---------------------------------------------------------------------------
+# Overlap probability tables (§4.6)
+# Maps (current_role, current_intensity) → (barge_in_prob, overlap_prob).
+# AGG at I3–I5 may cut off VIC; VIC at any I may (rarely) cut off AGG.
+# ---------------------------------------------------------------------------
+
+_OVERLAP_PROBS: dict[tuple[str, int], tuple[float, float]] = {
+    # (current_role, current_intensity) → (barge_in_prob, overlap_prob)
+    ("AGG", 3): (0.10, 0.15),
+    ("AGG", 4): (0.25, 0.20),
+    ("AGG", 5): (0.40, 0.15),
+    ("VIC", 1): (0.05, 0.10),
+    ("VIC", 2): (0.05, 0.10),
+    ("VIC", 3): (0.05, 0.10),
+    ("VIC", 4): (0.05, 0.10),
+    ("VIC", 5): (0.05, 0.10),
+}
+
+# Depth ranges (seconds) drawn when an overlap/barge-in mode is selected.
+_OVERLAP_DEPTH_RANGE = _GapRange(0.10, 0.35)  # how far into prev turn OVERLAP starts
+_BARGE_IN_DEPTH_RANGE = _GapRange(0.20, 0.50)  # how far into prev turn BARGE_IN starts
+
 
 @dataclass
 class TurnGapController:
-    """Return psychologically-motivated inter-turn silence durations.
+    """Return psychologically-motivated inter-turn silence durations and mix modes.
 
     Args:
         project: Scene project identifier (``"she_proves"`` or
@@ -104,13 +134,18 @@ class TurnGapController:
         prev_turn: DialogueTurn | None,
         rng: random.Random,
         current_role: str,
-    ) -> float:
-        """Return a gap duration (in seconds) to insert before *current_turn*.
+    ) -> tuple[float, MixMode]:
+        """Return an (amount, MixMode) pair for the transition to *current_turn*.
+
+        For ``MixMode.SEQUENTIAL``, *amount* is a silence gap in seconds inserted
+        before the turn.  For ``MixMode.OVERLAP`` and ``MixMode.BARGE_IN``,
+        *amount* is the overlap depth in seconds — how far back into the previous
+        turn the current turn starts.
 
         Args:
             current_turn: The turn about to be spoken.
             prev_turn: The immediately preceding turn, or ``None`` for the
-                first turn in a scene (returns a short default gap).
+                first turn in a scene (returns a short default gap, SEQUENTIAL).
             rng: Seeded ``random.Random`` instance for reproducible draws.
             current_role: Semantic role of the current speaker (``"AGG"`` or
                 ``"VIC"``), taken from ``SpeakerConfig.role``.  Must not be
@@ -118,16 +153,29 @@ class TurnGapController:
                 prefixes (``BEN_``, ``SW_``) rather than role prefixes.
 
         Returns:
-            Gap duration in seconds (≥ 0.0).
+            ``(amount_s, MixMode)`` tuple.
         """
         if prev_turn is None:
             # First turn: use a brief ambient lead-in from the low range.
             r = self._table["agg_low"]
-            return rng.uniform(r.lo, r.hi)
+            return rng.uniform(r.lo, r.hi), MixMode.SEQUENTIAL
 
         intensity = current_turn.intensity
-        prev_intensity = prev_turn.intensity
 
+        # --- Overlap / barge-in decision (§4.6) ---
+        probs = _OVERLAP_PROBS.get((current_role, intensity))
+        if probs is not None:
+            barge_in_p, overlap_p = probs
+            roll = rng.random()
+            if roll < barge_in_p:
+                depth = rng.uniform(_BARGE_IN_DEPTH_RANGE.lo, _BARGE_IN_DEPTH_RANGE.hi)
+                return depth, MixMode.BARGE_IN
+            if roll < barge_in_p + overlap_p:
+                depth = rng.uniform(_OVERLAP_DEPTH_RANGE.lo, _OVERLAP_DEPTH_RANGE.hi)
+                return depth, MixMode.OVERLAP
+
+        # --- SEQUENTIAL path ---
+        prev_intensity = prev_turn.intensity
         if current_role == "VIC":
             context_key = self._vic_context(prev_intensity)
         elif current_role == "AGG":
@@ -137,7 +185,7 @@ class TurnGapController:
             context_key = "agg_low"
 
         r = self._table[context_key]
-        return rng.uniform(r.lo, r.hi)
+        return rng.uniform(r.lo, r.hi), MixMode.SEQUENTIAL
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/synthbanshee/tts/gap_controller.py
+++ b/synthbanshee/tts/gap_controller.py
@@ -91,20 +91,22 @@ _AGG_PAUSE_PROB = 0.30
 
 # ---------------------------------------------------------------------------
 # Overlap probability tables (§4.6)
-# Maps (current_role, current_intensity) → (barge_in_prob, overlap_prob).
-# AGG at I3–I5 may cut off VIC; VIC at any I may (rarely) cut off AGG.
+# Maps (prev_role, current_role, current_intensity) → (barge_in_prob, overlap_prob).
+# Keyed on the *transition* (who is cutting off whom) to prevent same-role
+# self-interruption, which has no psychological basis in the spec.
 # ---------------------------------------------------------------------------
 
-_OVERLAP_PROBS: dict[tuple[str, int], tuple[float, float]] = {
-    # (current_role, current_intensity) → (barge_in_prob, overlap_prob)
-    ("AGG", 3): (0.10, 0.15),
-    ("AGG", 4): (0.25, 0.20),
-    ("AGG", 5): (0.40, 0.15),
-    ("VIC", 1): (0.05, 0.10),
-    ("VIC", 2): (0.05, 0.10),
-    ("VIC", 3): (0.05, 0.10),
-    ("VIC", 4): (0.05, 0.10),
-    ("VIC", 5): (0.05, 0.10),
+_OVERLAP_PROBS: dict[tuple[str, str, int], tuple[float, float]] = {
+    # AGG cuts off VIC at I3–I5 (spec §4.6 table rows 1–3)
+    ("VIC", "AGG", 3): (0.10, 0.15),
+    ("VIC", "AGG", 4): (0.25, 0.20),
+    ("VIC", "AGG", 5): (0.40, 0.15),
+    # VIC cuts off AGG at any intensity (spec §4.6 table row 4)
+    ("AGG", "VIC", 1): (0.05, 0.10),
+    ("AGG", "VIC", 2): (0.05, 0.10),
+    ("AGG", "VIC", 3): (0.05, 0.10),
+    ("AGG", "VIC", 4): (0.05, 0.10),
+    ("AGG", "VIC", 5): (0.05, 0.10),
 }
 
 # Depth ranges (seconds) drawn when an overlap/barge-in mode is selected.
@@ -134,6 +136,7 @@ class TurnGapController:
         prev_turn: DialogueTurn | None,
         rng: random.Random,
         current_role: str,
+        prev_role: str | None = None,
     ) -> tuple[float, MixMode]:
         """Return an (amount, MixMode) pair for the transition to *current_turn*.
 
@@ -151,6 +154,10 @@ class TurnGapController:
                 ``"VIC"``), taken from ``SpeakerConfig.role``.  Must not be
                 inferred from ``speaker_id`` because Elephant scenes use persona
                 prefixes (``BEN_``, ``SW_``) rather than role prefixes.
+            prev_role: Semantic role of the *previous* speaker.  ``None`` when
+                ``prev_turn`` is ``None`` (first turn).  Overlap/barge-in is only
+                considered when both roles are known and differ, matching the
+                spec §4.6 transition table.
 
         Returns:
             ``(amount_s, MixMode)`` tuple.
@@ -163,16 +170,19 @@ class TurnGapController:
         intensity = current_turn.intensity
 
         # --- Overlap / barge-in decision (§4.6) ---
-        probs = _OVERLAP_PROBS.get((current_role, intensity))
-        if probs is not None:
-            barge_in_p, overlap_p = probs
-            roll = rng.random()
-            if roll < barge_in_p:
-                depth = rng.uniform(_BARGE_IN_DEPTH_RANGE.lo, _BARGE_IN_DEPTH_RANGE.hi)
-                return depth, MixMode.BARGE_IN
-            if roll < barge_in_p + overlap_p:
-                depth = rng.uniform(_OVERLAP_DEPTH_RANGE.lo, _OVERLAP_DEPTH_RANGE.hi)
-                return depth, MixMode.OVERLAP
+        # Only consider overlap when both roles are known; prevents same-role
+        # self-interruption (e.g. AGG→AGG) which has no spec support.
+        if prev_role is not None:
+            probs = _OVERLAP_PROBS.get((prev_role, current_role, intensity))
+            if probs is not None:
+                barge_in_p, overlap_p = probs
+                roll = rng.random()
+                if roll < barge_in_p:
+                    depth = rng.uniform(_BARGE_IN_DEPTH_RANGE.lo, _BARGE_IN_DEPTH_RANGE.hi)
+                    return depth, MixMode.BARGE_IN
+                if roll < barge_in_p + overlap_p:
+                    depth = rng.uniform(_OVERLAP_DEPTH_RANGE.lo, _OVERLAP_DEPTH_RANGE.hi)
+                    return depth, MixMode.OVERLAP
 
         # --- SEQUENTIAL path ---
         prev_intensity = prev_turn.intensity

--- a/synthbanshee/tts/gap_controller.py
+++ b/synthbanshee/tts/gap_controller.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from typing import NamedTuple
 
 from synthbanshee.script.types import DialogueTurn
-from synthbanshee.tts.mixer import MixMode
+from synthbanshee.tts.mix_mode import MixMode
 
 
 class _GapRange(NamedTuple):

--- a/synthbanshee/tts/mix_mode.py
+++ b/synthbanshee/tts/mix_mode.py
@@ -1,0 +1,17 @@
+"""MixMode enum — how a turn is positioned relative to the previous turn.
+
+Kept in a lightweight module (no audio deps) so that gap_controller and any
+other timing-only code can import it without pulling in the full mixer stack.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class MixMode(Enum):
+    """Placement strategy for a turn in the output buffer."""
+
+    SEQUENTIAL = "sequential"  # silence gap before this turn (default)
+    OVERLAP = "overlap"  # start before prev ends; both turns audible
+    BARGE_IN = "barge_in"  # start before prev ends; prev is cut off

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -13,13 +13,18 @@ to its MixMode:
 
 The output MixedScene carries per-turn timing metadata on three timelines (§4.6):
 
-  script_onsets_s / script_offsets_s  — sequential-world positions (no overlap applied).
-  rendered_onsets_s / rendered_offsets_s — actual onset/offset in the output buffer.
-  audible_onsets_s / audible_ends_s   — what is audible (= rendered, except the
-                                        *interrupted* turn's audible_end_s is truncated
-                                        at the barge-in point for BARGE_IN turns).
+  script_onsets_s / script_offsets_s    — sequential-world positions (no overlap applied);
+                                          script_offsets_s retains the original TTS duration
+                                          even for BARGE_IN-truncated turns.
+  rendered_onsets_s / rendered_offsets_s — actual onset/offset in the output buffer;
+                                          for BARGE_IN-interrupted turns, rendered_offsets_s
+                                          is updated to the truncation point.
+  audible_onsets_s / audible_ends_s     — what is audible (same as rendered; both are
+                                          at the truncation point for interrupted turns).
 
-For backward compatibility, turn_onsets_s and turn_offsets_s mirror the rendered lists.
+For backward compatibility, turn_onsets_s and turn_offsets_s mirror the *audible* timeline
+(audible_onsets_s and audible_ends_s respectively) so that all offsets stay within the
+final waveform duration.
 
 Spec reference: docs/audio_generation_v3_design.md §4.6
 """
@@ -137,9 +142,17 @@ class SceneMixer:
                 script_onset_s = script_cursor_s + gap_s
                 script_cursor_s = script_onset_s + seg_duration_s
             else:
-                # OVERLAP / BARGE_IN: go back *amount_s* into the previous turn.
-                overlap_s = amount_s
-                onset_s = max(0.0, render_cursor_s - overlap_s)
+                # OVERLAP / BARGE_IN: go back *amount_s* into the previous turn,
+                # but never before that turn's actual rendered onset (COPILOT-5).
+                if placed:
+                    prev_mono, prev_onset_sample = placed[-1]
+                    prev_onset_s = prev_onset_sample / _TARGET_SR
+                    prev_duration_s = len(prev_mono) / _TARGET_SR
+                    prev_offset_s = prev_onset_s + prev_duration_s
+                    overlap_s = min(amount_s, prev_duration_s)
+                    onset_s = max(prev_onset_s, prev_offset_s - overlap_s)
+                else:
+                    onset_s = max(0.0, render_cursor_s - amount_s)
                 # In script space the turn still follows the previous one (no gap).
                 script_onset_s = script_cursor_s
                 script_cursor_s = script_onset_s + seg_duration_s
@@ -153,7 +166,10 @@ class SceneMixer:
                 max_samples = onset_sample - prev_onset_sample
                 if 0 < max_samples < len(prev_mono):
                     placed[-1] = (prev_mono[:max_samples], prev_onset_sample)
-                    audible_ends[-1] = onset_s  # interrupted turn's audible end
+                    # Update both rendered and audible ends of the interrupted turn
+                    # so all offsets stay within the final waveform duration (COPILOT-6).
+                    rendered_offsets[-1] = onset_s
+                    audible_ends[-1] = onset_s
 
             placed.append((mono, onset_sample))
 
@@ -176,11 +192,13 @@ class SceneMixer:
         else:
             combined = np.zeros(0, dtype=np.float32)
 
+        # turn_onsets_s / turn_offsets_s mirror the audible timeline so that all
+        # offset values stay within the waveform duration (backward-compat, COPILOT-2).
         return MixedScene(
             samples=combined,
             sample_rate=_TARGET_SR,
-            turn_onsets_s=rendered_onsets,
-            turn_offsets_s=rendered_offsets,
+            turn_onsets_s=audible_onsets,
+            turn_offsets_s=audible_ends,
             duration_s=float(len(combined)) / _TARGET_SR,
             speaker_ids=speaker_ids,
             script_onsets_s=script_onsets,

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -1,21 +1,33 @@
 """SceneMixer: concatenate per-speaker TTS WAV segments into a single audio scene.
 
-Each segment is a (wav_bytes, pause_before_s, speaker_id, rms_target_dbfs) 4-tuple.
+Each segment is a (wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode) 5-tuple.
 The mixer decodes WAV bytes using soundfile, resamples to 16 kHz if needed, applies
-optional per-turn RMS gain (M3), prepends the requested silence gap, and concatenates
-all segments into a single float32 mono array while preserving speaker IDs in the mix
-metadata.
+optional per-turn RMS gain (M3), then places each turn in the output buffer according
+to its MixMode:
 
-The output MixedScene carries per-turn onset/offset times so the label generator
-can derive event timing from the mix log rather than re-estimating it from the
-final waveform.
+  SEQUENTIAL  — insert a silence gap of *amount_s* before this turn (existing behaviour).
+  OVERLAP     — start *amount_s* seconds before the previous turn ends; both turns are
+                audible in the overlap region.
+  BARGE_IN    — same positioning as OVERLAP but the previous turn's audio is truncated
+                at the point where the current turn begins.
 
-Spec reference: docs/spec.md §3.1
+The output MixedScene carries per-turn timing metadata on three timelines (§4.6):
+
+  script_onsets_s / script_offsets_s  — sequential-world positions (no overlap applied).
+  rendered_onsets_s / rendered_offsets_s — actual onset/offset in the output buffer.
+  audible_onsets_s / audible_ends_s   — what is audible (= rendered, except the
+                                        *interrupted* turn's audible_end_s is truncated
+                                        at the barge-in point for BARGE_IN turns).
+
+For backward compatibility, turn_onsets_s and turn_offsets_s mirror the rendered lists.
+
+Spec reference: docs/audio_generation_v3_design.md §4.6
 """
 
 from __future__ import annotations
 
 import io
+from enum import Enum
 
 import numpy as np
 import soundfile as sf
@@ -24,6 +36,14 @@ from synthbanshee.augment.preprocessing import _resample
 from synthbanshee.script.types import MixedScene
 
 _TARGET_SR = 16_000
+
+
+class MixMode(Enum):
+    """How the current turn is placed relative to the previous turn in the mix."""
+
+    SEQUENTIAL = "sequential"  # current behaviour: silence gap before this turn
+    OVERLAP = "overlap"  # start before prev ends; both turns audible
+    BARGE_IN = "barge_in"  # start before prev ends; prev is cut off
 
 
 def _apply_rms_gain(mono: np.ndarray, rms_target_dbfs: float) -> np.ndarray:
@@ -54,30 +74,44 @@ class SceneMixer:
 
     def mix_sequential(
         self,
-        segments: list[tuple[bytes, float, str, float | None]],
+        segments: list[tuple[bytes, float, str, float | None, MixMode]],
     ) -> MixedScene:
-        """Concatenate segments in order, separated by silence gaps.
+        """Place segments in the output buffer according to their MixMode.
 
         Args:
-            segments: List of (wav_bytes, pause_before_s, speaker_id,
-                      rms_target_dbfs) 4-tuples.
-                      wav_bytes must be valid WAV data (any SR / channels).
-                      pause_before_s is inserted *before* each segment.
-                      speaker_id is stored in the MixedScene for labelling.
-                      rms_target_dbfs: if not None, the segment is gain-adjusted
-                      so its RMS matches this target (dBFS) after decoding and
-                      resampling.
+            segments: List of (wav_bytes, amount_s, speaker_id,
+                      rms_target_dbfs, mix_mode) 5-tuples.
+                      wav_bytes — valid WAV data (any SR / channels).
+                      amount_s — silence gap for SEQUENTIAL; overlap depth for
+                        OVERLAP / BARGE_IN (how far back into the previous turn
+                        the current turn starts).
+                      speaker_id — stored in the MixedScene for labelling.
+                      rms_target_dbfs — if not None, the segment is gain-adjusted
+                        so its RMS matches this target (dBFS).
+                      mix_mode — placement strategy (MixMode enum).
 
         Returns:
-            MixedScene with all segments concatenated at 16 kHz mono.
+            MixedScene with all segments mixed at 16 kHz mono, carrying three
+            sets of per-turn timing timestamps (script / rendered / audible).
         """
-        all_samples: list[np.ndarray] = []
-        turn_onsets: list[float] = []
-        turn_offsets: list[float] = []
-        speaker_ids: list[str] = []
-        current_pos_s: float = 0.0
+        # Decoded and gain-adjusted mono arrays paired with their onset sample.
+        placed: list[tuple[np.ndarray, int]] = []  # (mono, onset_sample_idx)
 
-        for wav_bytes, pause_s, speaker_id, rms_target_dbfs in segments:
+        # Three-timeline metadata (§4.6).
+        script_onsets: list[float] = []
+        script_offsets: list[float] = []
+        rendered_onsets: list[float] = []
+        rendered_offsets: list[float] = []
+        audible_onsets: list[float] = []
+        audible_ends: list[float] = []
+        speaker_ids: list[str] = []
+
+        # render_cursor_s tracks the end of the last placed segment in buffer time.
+        # script_cursor_s advances sequentially (overlap is not subtracted).
+        render_cursor_s: float = 0.0
+        script_cursor_s: float = 0.0
+
+        for wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode in segments:
             # --- Decode WAV ---
             with io.BytesIO(wav_bytes) as buf:
                 data, src_sr = sf.read(buf, dtype="float32", always_2d=True)
@@ -93,29 +127,66 @@ class SceneMixer:
             if rms_target_dbfs is not None:
                 mono = _apply_rms_gain(mono, rms_target_dbfs)
 
-            # Prepend silence gap
-            if pause_s > 0.0:
-                silence = np.zeros(int(pause_s * _TARGET_SR), dtype=np.float32)
-                all_samples.append(silence)
-                current_pos_s += pause_s
-
-            onset_s = current_pos_s
-            turn_onsets.append(onset_s)
-
-            all_samples.append(mono.astype(np.float32))
+            mono = mono.astype(np.float32)
             seg_duration_s = len(mono) / _TARGET_SR
-            current_pos_s += seg_duration_s
 
-            turn_offsets.append(current_pos_s)
+            # --- Determine onset position ---
+            if mix_mode == MixMode.SEQUENTIAL:
+                gap_s = amount_s
+                onset_s = render_cursor_s + gap_s
+                script_onset_s = script_cursor_s + gap_s
+                script_cursor_s = script_onset_s + seg_duration_s
+            else:
+                # OVERLAP / BARGE_IN: go back *amount_s* into the previous turn.
+                overlap_s = amount_s
+                onset_s = max(0.0, render_cursor_s - overlap_s)
+                # In script space the turn still follows the previous one (no gap).
+                script_onset_s = script_cursor_s
+                script_cursor_s = script_onset_s + seg_duration_s
+
+            onset_sample = int(onset_s * _TARGET_SR)
+            offset_s = onset_s + seg_duration_s
+
+            # --- BARGE_IN: truncate the previous segment at the barge-in point ---
+            if mix_mode == MixMode.BARGE_IN and placed:
+                prev_mono, prev_onset_sample = placed[-1]
+                max_samples = onset_sample - prev_onset_sample
+                if 0 < max_samples < len(prev_mono):
+                    placed[-1] = (prev_mono[:max_samples], prev_onset_sample)
+                    audible_ends[-1] = onset_s  # interrupted turn's audible end
+
+            placed.append((mono, onset_sample))
+
+            render_cursor_s = offset_s
+
+            script_onsets.append(script_onset_s)
+            script_offsets.append(script_onset_s + seg_duration_s)
+            rendered_onsets.append(onset_s)
+            rendered_offsets.append(offset_s)
+            audible_onsets.append(onset_s)
+            audible_ends.append(offset_s)
             speaker_ids.append(speaker_id)
 
-        combined = np.concatenate(all_samples) if all_samples else np.zeros(0, dtype=np.float32)
+        # --- Build output buffer ---
+        if placed:
+            total_samples = max(onset + len(mono) for mono, onset in placed)
+            combined = np.zeros(total_samples, dtype=np.float32)
+            for mono, onset in placed:
+                combined[onset : onset + len(mono)] += mono
+        else:
+            combined = np.zeros(0, dtype=np.float32)
 
         return MixedScene(
             samples=combined,
             sample_rate=_TARGET_SR,
-            turn_onsets_s=turn_onsets,
-            turn_offsets_s=turn_offsets,
+            turn_onsets_s=rendered_onsets,
+            turn_offsets_s=rendered_offsets,
             duration_s=float(len(combined)) / _TARGET_SR,
             speaker_ids=speaker_ids,
+            script_onsets_s=script_onsets,
+            script_offsets_s=script_offsets,
+            rendered_onsets_s=rendered_onsets,
+            rendered_offsets_s=rendered_offsets,
+            audible_onsets_s=audible_onsets,
+            audible_ends_s=audible_ends,
         )

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -154,7 +154,10 @@ class SceneMixer:
                 script_cursor_s = script_onset_s + seg_duration_s
 
             onset_sample = int(onset_s * _TARGET_SR)
-            offset_s = onset_s + seg_duration_s
+            # Quantise onset/offset to the actual sample boundaries used for buffer
+            # placement so all timeline metadata stays exactly sample-aligned.
+            onset_s = float(onset_sample) / _TARGET_SR
+            offset_s = float(onset_sample + len(mono)) / _TARGET_SR
 
             # --- BARGE_IN: truncate the previous segment at the barge-in point ---
             if mix_mode == MixMode.BARGE_IN and placed:
@@ -162,24 +165,23 @@ class SceneMixer:
                 max_samples = onset_sample - prev_onset_sample
                 if max_samples <= 0:
                     # Full-depth barge-in: new turn starts at or before the previous
-                    # turn's onset — replace it with an empty array (COPILOT-3).
+                    # turn's onset — replace it with an empty array.
                     placed[-1] = (np.zeros(0, dtype=np.float32), prev_onset_sample)
                     prev_onset_s_f = float(prev_onset_sample) / _TARGET_SR
                     rendered_offsets[-1] = prev_onset_s_f
                     audible_ends[-1] = prev_onset_s_f
                 elif max_samples < len(prev_mono):
                     placed[-1] = (prev_mono[:max_samples], prev_onset_sample)
-                    # Use the quantised sample boundary rather than onset_s to keep
-                    # metadata timestamps exactly aligned with the audio buffer.
-                    quantised_onset_s = float(onset_sample) / _TARGET_SR
-                    rendered_offsets[-1] = quantised_onset_s
-                    audible_ends[-1] = quantised_onset_s
+                    # onset_s is already quantised to the sample boundary above.
+                    rendered_offsets[-1] = onset_s
+                    audible_ends[-1] = onset_s
 
             placed.append((mono, onset_sample))
 
-            # Never let the cursor move backward — short OVERLAP turns must not
-            # pull render_cursor_s behind where it already is (COPILOT-2).
-            render_cursor_s = max(render_cursor_s, offset_s)
+            # Recompute cursor from the actual max end-sample across all placed
+            # segments so BARGE_IN truncation can move it earlier and OVERLAP
+            # never overstates the true audio extent.
+            render_cursor_s = max(onset + len(m) for m, onset in placed) / _TARGET_SR
 
             script_onsets.append(script_onset_s)
             script_offsets.append(script_onset_s + seg_duration_s)

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -32,23 +32,15 @@ Spec reference: docs/audio_generation_v3_design.md §4.6
 from __future__ import annotations
 
 import io
-from enum import Enum
 
 import numpy as np
 import soundfile as sf
 
 from synthbanshee.augment.preprocessing import _resample
 from synthbanshee.script.types import MixedScene
+from synthbanshee.tts.mix_mode import MixMode
 
 _TARGET_SR = 16_000
-
-
-class MixMode(Enum):
-    """How the current turn is placed relative to the previous turn in the mix."""
-
-    SEQUENTIAL = "sequential"  # current behaviour: silence gap before this turn
-    OVERLAP = "overlap"  # start before prev ends; both turns audible
-    BARGE_IN = "barge_in"  # start before prev ends; prev is cut off
 
 
 def _apply_rms_gain(mono: np.ndarray, rms_target_dbfs: float) -> np.ndarray:
@@ -117,6 +109,10 @@ class SceneMixer:
         script_cursor_s: float = 0.0
 
         for wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode in segments:
+            # Clamp amount_s: negative values are nonsensical for all mix modes
+            # (gap for SEQUENTIAL; overlap depth for OVERLAP / BARGE_IN).
+            amount_s = max(0.0, amount_s)
+
             # --- Decode WAV ---
             with io.BytesIO(wav_bytes) as buf:
                 data, src_sr = sf.read(buf, dtype="float32", always_2d=True)
@@ -173,10 +169,11 @@ class SceneMixer:
                     audible_ends[-1] = prev_onset_s_f
                 elif max_samples < len(prev_mono):
                     placed[-1] = (prev_mono[:max_samples], prev_onset_sample)
-                    # Update both rendered and audible ends of the interrupted turn
-                    # so all offsets stay within the final waveform duration (COPILOT-6).
-                    rendered_offsets[-1] = onset_s
-                    audible_ends[-1] = onset_s
+                    # Use the quantised sample boundary rather than onset_s to keep
+                    # metadata timestamps exactly aligned with the audio buffer.
+                    quantised_onset_s = float(onset_sample) / _TARGET_SR
+                    rendered_offsets[-1] = quantised_onset_s
+                    audible_ends[-1] = quantised_onset_s
 
             placed.append((mono, onset_sample))
 

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -164,7 +164,14 @@ class SceneMixer:
             if mix_mode == MixMode.BARGE_IN and placed:
                 prev_mono, prev_onset_sample = placed[-1]
                 max_samples = onset_sample - prev_onset_sample
-                if 0 < max_samples < len(prev_mono):
+                if max_samples <= 0:
+                    # Full-depth barge-in: new turn starts at or before the previous
+                    # turn's onset — replace it with an empty array (COPILOT-3).
+                    placed[-1] = (np.zeros(0, dtype=np.float32), prev_onset_sample)
+                    prev_onset_s_f = float(prev_onset_sample) / _TARGET_SR
+                    rendered_offsets[-1] = prev_onset_s_f
+                    audible_ends[-1] = prev_onset_s_f
+                elif max_samples < len(prev_mono):
                     placed[-1] = (prev_mono[:max_samples], prev_onset_sample)
                     # Update both rendered and audible ends of the interrupted turn
                     # so all offsets stay within the final waveform duration (COPILOT-6).
@@ -173,7 +180,9 @@ class SceneMixer:
 
             placed.append((mono, onset_sample))
 
-            render_cursor_s = offset_s
+            # Never let the cursor move backward — short OVERLAP turns must not
+            # pull render_cursor_s behind where it already is (COPILOT-2).
+            render_cursor_s = max(render_cursor_s, offset_s)
 
             script_onsets.append(script_onset_s)
             script_offsets.append(script_onset_s + seg_duration_s)

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -260,7 +260,10 @@ class TTSRenderer:
                     f" [{turn.speaker_id}] intensity={turn.intensity}"
                     f" → {status}[/dim]"
                 )
-            gap_s, mix_mode = gap_ctrl.gap_seconds(turn, prev_turn, gap_rng, speaker.role)
+            prev_role = speakers[prev_turn.speaker_id].role if prev_turn is not None else None
+            gap_s, mix_mode = gap_ctrl.gap_seconds(
+                turn, prev_turn, gap_rng, speaker.role, prev_role
+            )
             segments.append(
                 (
                     wav_bytes,

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from synthbanshee.config.speaker_config import SpeakerConfig
 from synthbanshee.script.types import DialogueTurn, MixedScene
 from synthbanshee.tts.azure_provider import AzureProvider
+from synthbanshee.tts.mixer import MixMode
 from synthbanshee.tts.speaker_state import SpeakerState
 from synthbanshee.tts.ssml_builder import SSMLBuilder
 from synthbanshee.tts.ssml_types import PhraseProsody, collect_phrase_prosody, rebase_phrase_prosody
@@ -215,7 +216,7 @@ class TTSRenderer:
         # M7: one SpeakerState per speaker; starts neutral, updated after each turn.
         states: dict[str, SpeakerState] = {sid: SpeakerState() for sid in speakers}
 
-        segments: list[tuple[bytes, float, str, float | None]] = []
+        segments: list[tuple[bytes, float, str, float | None, MixMode]] = []
         prev_turn: DialogueTurn | None = None
         for i, turn in enumerate(turns):
             speaker = speakers[turn.speaker_id]
@@ -259,13 +260,14 @@ class TTSRenderer:
                     f" [{turn.speaker_id}] intensity={turn.intensity}"
                     f" → {status}[/dim]"
                 )
-            gap_s = gap_ctrl.gap_seconds(turn, prev_turn, gap_rng, speaker.role)
+            gap_s, mix_mode = gap_ctrl.gap_seconds(turn, prev_turn, gap_rng, speaker.role)
             segments.append(
                 (
                     wav_bytes,
                     gap_s,
                     turn.speaker_id,
                     speaker.style_for_intensity(turn.intensity).rms_target_dbfs,
+                    mix_mode,
                 )
             )
             prev_turn = turn

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from synthbanshee.config.speaker_config import SpeakerConfig
 from synthbanshee.script.types import DialogueTurn, MixedScene
 from synthbanshee.tts.azure_provider import AzureProvider
-from synthbanshee.tts.mixer import MixMode
+from synthbanshee.tts.mix_mode import MixMode
 from synthbanshee.tts.speaker_state import SpeakerState
 from synthbanshee.tts.ssml_builder import SSMLBuilder
 from synthbanshee.tts.ssml_types import PhraseProsody, collect_phrase_prosody, rebase_phrase_prosody

--- a/tests/integration/test_multi_speaker.py
+++ b/tests/integration/test_multi_speaker.py
@@ -147,9 +147,10 @@ class TestRenderScene:
         assert lo <= scene.turn_onsets_s[0] <= hi
 
     def test_second_turn_onset_after_first_offset(self, renderer, speakers, dialogue_turns):
-        """Second turn onset must be strictly after the first turn's offset."""
+        """With M8a overlap mixing, turns can start before the previous turn ends.
+        The invariant that always holds is that audible onsets are non-decreasing."""
         scene = renderer.render_scene(dialogue_turns, speakers)
-        assert scene.turn_onsets_s[1] > scene.turn_offsets_s[0]
+        assert scene.turn_onsets_s[1] >= scene.turn_onsets_s[0]
 
     def test_unknown_speaker_raises(self, renderer, dialogue_turns):
         """render_scene should raise KeyError for unknown speaker_id."""

--- a/tests/unit/test_gap_controller.py
+++ b/tests/unit/test_gap_controller.py
@@ -8,11 +8,14 @@ import pytest
 
 from synthbanshee.script.types import DialogueTurn
 from synthbanshee.tts.gap_controller import (
+    _BARGE_IN_DEPTH_RANGE,
     _DEFAULT_GAPS,
     _ELEPHANT_GAPS,
+    _OVERLAP_DEPTH_RANGE,
     _SHE_PROVES_GAPS,
     TurnGapController,
 )
+from synthbanshee.tts.mixer import MixMode
 
 
 def _turn(speaker_id: str, intensity: int) -> DialogueTurn:
@@ -38,9 +41,19 @@ def _draw_many(
     prev: DialogueTurn | None,
     current_role: str,
     n: int = 200,
-) -> list[float]:
+) -> list[tuple[float, MixMode]]:
     rng = random.Random(42)
     return [ctrl.gap_seconds(current, prev, rng, current_role) for _ in range(n)]
+
+
+def _gaps_only(draws: list[tuple[float, MixMode]]) -> list[float]:
+    """Extract just the amount values from gap_seconds() results."""
+    return [amount for amount, _ in draws]
+
+
+def _modes_only(draws: list[tuple[float, MixMode]]) -> list[MixMode]:
+    """Extract just the MixMode values from gap_seconds() results."""
+    return [mode for _, mode in draws]
 
 
 # ---------------------------------------------------------------------------
@@ -70,9 +83,14 @@ class TestProjectTableSelection:
 class TestFirstTurn:
     def test_first_turn_gap_in_range(self) -> None:
         ctrl = TurnGapController(project="she_proves")
-        gaps = _draw_many(ctrl, _turn("AGG_M_30-45_001", 1), None, "AGG")
+        draws = _draw_many(ctrl, _turn("AGG_M_30-45_001", 1), None, "AGG")
         lo, hi = _SHE_PROVES_GAPS["agg_low"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(_gaps_only(draws), lo, hi)
+
+    def test_first_turn_always_sequential(self) -> None:
+        ctrl = TurnGapController(project="she_proves")
+        draws = _draw_many(ctrl, _turn("AGG_M_30-45_001", 5), None, "AGG")
+        assert all(m == MixMode.SEQUENTIAL for m in _modes_only(draws))
 
 
 # ---------------------------------------------------------------------------
@@ -87,33 +105,38 @@ class TestVICSheProves:
 
     def test_vic_after_agg_i1(self) -> None:
         prev = _turn("AGG_M_30-45_001", 1)
-        gaps = _draw_many(self.ctrl, self.vic, prev, "VIC")
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_low"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_agg_i2(self) -> None:
         prev = _turn("AGG_M_30-45_001", 2)
-        gaps = _draw_many(self.ctrl, self.vic, prev, "VIC")
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_low"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_agg_i3(self) -> None:
         prev = _turn("AGG_M_30-45_001", 3)
-        gaps = _draw_many(self.ctrl, self.vic, prev, "VIC")
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_i3"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_agg_i4(self) -> None:
         prev = _turn("AGG_M_30-45_001", 4)
-        gaps = _draw_many(self.ctrl, self.vic, prev, "VIC")
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_i4"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_agg_i5(self) -> None:
         prev = _turn("AGG_M_30-45_001", 5)
-        gaps = _draw_many(self.ctrl, self.vic, prev, "VIC")
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_i5"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(seq_gaps, lo, hi)
 
 
 # ---------------------------------------------------------------------------
@@ -131,15 +154,17 @@ class TestVICElephant:
 
     def test_vic_after_i1_in_elephant_range(self) -> None:
         prev = _turn("BEN_M_40-55_003", 1)  # Beneficiary — role AGG
-        gaps = _draw_many(self.ctrl, self.vic, prev, "VIC")
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _ELEPHANT_GAPS["vic_low"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_i4_in_elephant_range(self) -> None:
         prev = _turn("BEN_M_40-55_003", 4)
-        gaps = _draw_many(self.ctrl, self.vic, prev, "VIC")
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _ELEPHANT_GAPS["vic_i4"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_elephant_i4_shorter_than_she_proves(self) -> None:
         # Elephant vic_i4 hi (0.100) < She-Proves vic_i4 hi (0.150)
@@ -159,45 +184,47 @@ class TestAGGSheProves:
 
     def test_agg_i1_low_range(self) -> None:
         agg = _turn("AGG_M_30-45_001", 1)
-        gaps = _draw_many(self.ctrl, agg, self.prev, "AGG")
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG")
         lo, hi = _SHE_PROVES_GAPS["agg_low"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(_gaps_only(draws), lo, hi)
 
     def test_agg_i2_low_range(self) -> None:
         agg = _turn("AGG_M_30-45_001", 2)
-        gaps = _draw_many(self.ctrl, agg, self.prev, "AGG")
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG")
         lo, hi = _SHE_PROVES_GAPS["agg_low"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(_gaps_only(draws), lo, hi)
 
     def test_agg_i3_high_range(self) -> None:
         agg = _turn("AGG_M_30-45_001", 3)
-        # At I3, no pause chance (only I4–I5 allow deliberate pause).
-        gaps = _draw_many(self.ctrl, agg, self.prev, "AGG")
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
+        # At I3, sequential gaps must be in agg_high; overlap amounts in their own range.
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["agg_high"]
-        assert _all_in_range(gaps, lo, hi)
+        assert _all_in_range(seq_gaps, lo, hi)
 
     def test_agg_i4_within_combined_range(self) -> None:
-        # At I4 the gap is from agg_high OR agg_pause — both must fit within
-        # the union [agg_high.lo, agg_pause.hi].
+        # At I4 the sequential gap is from agg_high OR agg_pause.
         agg = _turn("AGG_M_30-45_001", 4)
-        gaps = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         combined_lo = _SHE_PROVES_GAPS["agg_high"].lo
         combined_hi = _SHE_PROVES_GAPS["agg_pause"].hi
-        assert _all_in_range(gaps, combined_lo, combined_hi)
+        assert _all_in_range(seq_gaps, combined_lo, combined_hi)
 
     def test_agg_i4_pause_drawn_sometimes(self) -> None:
-        # With 500 draws and 30 % probability, the chance of zero pauses is
-        # < (0.70)^500 ≈ 10^{-79} — effectively impossible.
+        # With 500 draws and ~45% chance of SEQUENTIAL + 30% pause probability
+        # among sequential, we still expect some pauses.
         agg = _turn("AGG_M_30-45_001", 4)
-        gaps = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
-        # Pauses must exceed agg_high.hi (0.200 s) to be distinguishable.
-        long_gaps = [g for g in gaps if g > _SHE_PROVES_GAPS["agg_high"].hi]
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
+        long_gaps = [g for g in seq_gaps if g > _SHE_PROVES_GAPS["agg_high"].hi]
         assert len(long_gaps) > 0, "expected some deliberate AGG pauses at I4"
 
     def test_agg_i5_pause_drawn_sometimes(self) -> None:
         agg = _turn("AGG_M_30-45_001", 5)
-        gaps = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
-        long_gaps = [g for g in gaps if g > _SHE_PROVES_GAPS["agg_high"].hi]
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
+        seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
+        long_gaps = [g for g in seq_gaps if g > _SHE_PROVES_GAPS["agg_high"].hi]
         assert len(long_gaps) > 0, "expected some deliberate AGG pauses at I5"
 
 
@@ -212,8 +239,8 @@ class TestUnknownRole:
         # WIT (witness) is not a defined role
         wit_turn = _turn("WIT_F_40-50_001", 2)
         prev = _turn("AGG_M_30-45_001", 2)
-        gaps = _draw_many(ctrl, wit_turn, prev, "WIT")
-        assert all(g > 0 for g in gaps)
+        draws = _draw_many(ctrl, wit_turn, prev, "WIT")
+        assert all(g > 0 for g, _ in draws)
 
 
 # ---------------------------------------------------------------------------
@@ -228,10 +255,10 @@ class TestReproducibility:
         prev = _turn("AGG_M_30-45_001", 3)
 
         rng_a = random.Random(7)
-        gaps_a = [ctrl.gap_seconds(current, prev, rng_a, "VIC") for _ in range(20)]
+        results_a = [ctrl.gap_seconds(current, prev, rng_a, "VIC") for _ in range(20)]
         rng_b = random.Random(7)
-        gaps_b = [ctrl.gap_seconds(current, prev, rng_b, "VIC") for _ in range(20)]
-        assert gaps_a == gaps_b
+        results_b = [ctrl.gap_seconds(current, prev, rng_b, "VIC") for _ in range(20)]
+        assert results_a == results_b
 
     def test_different_seeds_different_output(self) -> None:
         ctrl = TurnGapController(project="she_proves")
@@ -239,10 +266,10 @@ class TestReproducibility:
         prev = _turn("AGG_M_30-45_001", 3)
 
         rng_1 = random.Random(1)
-        gaps_a = [ctrl.gap_seconds(current, prev, rng_1, "VIC") for _ in range(20)]
+        results_a = [ctrl.gap_seconds(current, prev, rng_1, "VIC") for _ in range(20)]
         rng_2 = random.Random(2)
-        gaps_b = [ctrl.gap_seconds(current, prev, rng_2, "VIC") for _ in range(20)]
-        assert gaps_a != gaps_b
+        results_b = [ctrl.gap_seconds(current, prev, rng_2, "VIC") for _ in range(20)]
+        assert results_a != results_b
 
 
 # ---------------------------------------------------------------------------
@@ -273,3 +300,78 @@ class TestGapOrdering:
     def test_agg_pause_longer_than_agg_high(self, project: str, table: dict) -> None:
         # Menacing pause must be noticeably longer than cutting-in gap.
         assert table["agg_pause"].lo > table["agg_high"].hi
+
+
+# ---------------------------------------------------------------------------
+# M8a: MixMode selection and overlap depth (§4.6)
+# ---------------------------------------------------------------------------
+
+
+class TestOverlapModeSelection:
+    """Verify that gap_seconds() emits OVERLAP / BARGE_IN at the expected rates."""
+
+    def setup_method(self) -> None:
+        self.ctrl = TurnGapController(project="she_proves")
+        self.prev = _turn("VIC_F_25-35_001", 3)
+
+    def _mode_counts(
+        self,
+        current: DialogueTurn,
+        role: str,
+        n: int = 1000,
+    ) -> dict[MixMode, int]:
+        rng = random.Random(99)
+        counts: dict[MixMode, int] = {m: 0 for m in MixMode}
+        for _ in range(n):
+            _, mode = self.ctrl.gap_seconds(current, self.prev, rng, role)
+            counts[mode] += 1
+        return counts
+
+    def test_agg_i3_barge_in_rate(self) -> None:
+        """AGG at I3 should produce BARGE_IN ~10% of the time (±5% tolerance)."""
+        counts = self._mode_counts(_turn("AGG_M_30-45_001", 3), "AGG")
+        barge_in_rate = counts[MixMode.BARGE_IN] / 1000
+        assert 0.05 <= barge_in_rate <= 0.20, f"expected ~10%, got {barge_in_rate:.2%}"
+
+    def test_agg_i5_barge_in_rate(self) -> None:
+        """AGG at I5 should produce BARGE_IN ~40% of the time (±10% tolerance)."""
+        counts = self._mode_counts(_turn("AGG_M_30-45_001", 5), "AGG")
+        barge_in_rate = counts[MixMode.BARGE_IN] / 1000
+        assert 0.30 <= barge_in_rate <= 0.55, f"expected ~40%, got {barge_in_rate:.2%}"
+
+    def test_vic_overlap_rate(self) -> None:
+        """VIC at any intensity should produce OVERLAP ~10% of the time (±5%)."""
+        counts = self._mode_counts(_turn("VIC_F_25-35_001", 2), "VIC")
+        overlap_rate = counts[MixMode.OVERLAP] / 1000
+        assert 0.05 <= overlap_rate <= 0.20, f"expected ~10%, got {overlap_rate:.2%}"
+
+    def test_agg_i1_always_sequential(self) -> None:
+        """AGG at I1–I2 must never produce OVERLAP or BARGE_IN."""
+        for intensity in (1, 2):
+            counts = self._mode_counts(_turn("AGG_M_30-45_001", intensity), "AGG")
+            assert counts[MixMode.OVERLAP] == 0
+            assert counts[MixMode.BARGE_IN] == 0
+
+    def test_barge_in_amount_in_range(self) -> None:
+        """BARGE_IN amount must lie within _BARGE_IN_DEPTH_RANGE."""
+        rng = random.Random(42)
+        current = _turn("AGG_M_30-45_001", 5)
+        depths = []
+        for _ in range(1000):
+            amount, mode = self.ctrl.gap_seconds(current, self.prev, rng, "AGG")
+            if mode == MixMode.BARGE_IN:
+                depths.append(amount)
+        assert depths, "no BARGE_IN draws in 1000 trials at I5"
+        assert all(_BARGE_IN_DEPTH_RANGE.lo <= d <= _BARGE_IN_DEPTH_RANGE.hi for d in depths)
+
+    def test_overlap_amount_in_range(self) -> None:
+        """OVERLAP amount must lie within _OVERLAP_DEPTH_RANGE."""
+        rng = random.Random(42)
+        current = _turn("AGG_M_30-45_001", 3)
+        depths = []
+        for _ in range(1000):
+            amount, mode = self.ctrl.gap_seconds(current, self.prev, rng, "AGG")
+            if mode == MixMode.OVERLAP:
+                depths.append(amount)
+        assert depths, "no OVERLAP draws in 1000 trials at I3"
+        assert all(_OVERLAP_DEPTH_RANGE.lo <= d <= _OVERLAP_DEPTH_RANGE.hi for d in depths)

--- a/tests/unit/test_gap_controller.py
+++ b/tests/unit/test_gap_controller.py
@@ -40,10 +40,11 @@ def _draw_many(
     current: DialogueTurn,
     prev: DialogueTurn | None,
     current_role: str,
+    prev_role: str | None = None,
     n: int = 200,
 ) -> list[tuple[float, MixMode]]:
     rng = random.Random(42)
-    return [ctrl.gap_seconds(current, prev, rng, current_role) for _ in range(n)]
+    return [ctrl.gap_seconds(current, prev, rng, current_role, prev_role) for _ in range(n)]
 
 
 def _gaps_only(draws: list[tuple[float, MixMode]]) -> list[float]:
@@ -105,35 +106,35 @@ class TestVICSheProves:
 
     def test_vic_after_agg_i1(self) -> None:
         prev = _turn("AGG_M_30-45_001", 1)
-        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", prev_role="AGG", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_low"]
         assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_agg_i2(self) -> None:
         prev = _turn("AGG_M_30-45_001", 2)
-        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", prev_role="AGG", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_low"]
         assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_agg_i3(self) -> None:
         prev = _turn("AGG_M_30-45_001", 3)
-        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", prev_role="AGG", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_i3"]
         assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_agg_i4(self) -> None:
         prev = _turn("AGG_M_30-45_001", 4)
-        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", prev_role="AGG", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_i4"]
         assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_agg_i5(self) -> None:
         prev = _turn("AGG_M_30-45_001", 5)
-        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", prev_role="AGG", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["vic_i5"]
         assert _all_in_range(seq_gaps, lo, hi)
@@ -154,14 +155,14 @@ class TestVICElephant:
 
     def test_vic_after_i1_in_elephant_range(self) -> None:
         prev = _turn("BEN_M_40-55_003", 1)  # Beneficiary — role AGG
-        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", prev_role="AGG", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _ELEPHANT_GAPS["vic_low"]
         assert _all_in_range(seq_gaps, lo, hi)
 
     def test_vic_after_i4_in_elephant_range(self) -> None:
         prev = _turn("BEN_M_40-55_003", 4)
-        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", n=500)
+        draws = _draw_many(self.ctrl, self.vic, prev, "VIC", prev_role="AGG", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _ELEPHANT_GAPS["vic_i4"]
         assert _all_in_range(seq_gaps, lo, hi)
@@ -184,19 +185,19 @@ class TestAGGSheProves:
 
     def test_agg_i1_low_range(self) -> None:
         agg = _turn("AGG_M_30-45_001", 1)
-        draws = _draw_many(self.ctrl, agg, self.prev, "AGG")
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", prev_role="VIC")
         lo, hi = _SHE_PROVES_GAPS["agg_low"]
         assert _all_in_range(_gaps_only(draws), lo, hi)
 
     def test_agg_i2_low_range(self) -> None:
         agg = _turn("AGG_M_30-45_001", 2)
-        draws = _draw_many(self.ctrl, agg, self.prev, "AGG")
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", prev_role="VIC")
         lo, hi = _SHE_PROVES_GAPS["agg_low"]
         assert _all_in_range(_gaps_only(draws), lo, hi)
 
     def test_agg_i3_high_range(self) -> None:
         agg = _turn("AGG_M_30-45_001", 3)
-        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", prev_role="VIC", n=500)
         # At I3, sequential gaps must be in agg_high; overlap amounts in their own range.
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         lo, hi = _SHE_PROVES_GAPS["agg_high"]
@@ -205,24 +206,24 @@ class TestAGGSheProves:
     def test_agg_i4_within_combined_range(self) -> None:
         # At I4 the sequential gap is from agg_high OR agg_pause.
         agg = _turn("AGG_M_30-45_001", 4)
-        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", prev_role="VIC", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         combined_lo = _SHE_PROVES_GAPS["agg_high"].lo
         combined_hi = _SHE_PROVES_GAPS["agg_pause"].hi
         assert _all_in_range(seq_gaps, combined_lo, combined_hi)
 
     def test_agg_i4_pause_drawn_sometimes(self) -> None:
-        # With 500 draws and ~45% chance of SEQUENTIAL + 30% pause probability
+        # With 500 draws and ~55% chance of SEQUENTIAL + 30% pause probability
         # among sequential, we still expect some pauses.
         agg = _turn("AGG_M_30-45_001", 4)
-        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", prev_role="VIC", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         long_gaps = [g for g in seq_gaps if g > _SHE_PROVES_GAPS["agg_high"].hi]
         assert len(long_gaps) > 0, "expected some deliberate AGG pauses at I4"
 
     def test_agg_i5_pause_drawn_sometimes(self) -> None:
         agg = _turn("AGG_M_30-45_001", 5)
-        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", n=500)
+        draws = _draw_many(self.ctrl, agg, self.prev, "AGG", prev_role="VIC", n=500)
         seq_gaps = [g for g, m in draws if m == MixMode.SEQUENTIAL]
         long_gaps = [g for g in seq_gaps if g > _SHE_PROVES_GAPS["agg_high"].hi]
         assert len(long_gaps) > 0, "expected some deliberate AGG pauses at I5"
@@ -239,7 +240,7 @@ class TestUnknownRole:
         # WIT (witness) is not a defined role
         wit_turn = _turn("WIT_F_40-50_001", 2)
         prev = _turn("AGG_M_30-45_001", 2)
-        draws = _draw_many(ctrl, wit_turn, prev, "WIT")
+        draws = _draw_many(ctrl, wit_turn, prev, "WIT", prev_role="AGG")
         assert all(g > 0 for g, _ in draws)
 
 
@@ -255,9 +256,9 @@ class TestReproducibility:
         prev = _turn("AGG_M_30-45_001", 3)
 
         rng_a = random.Random(7)
-        results_a = [ctrl.gap_seconds(current, prev, rng_a, "VIC") for _ in range(20)]
+        results_a = [ctrl.gap_seconds(current, prev, rng_a, "VIC", "AGG") for _ in range(20)]
         rng_b = random.Random(7)
-        results_b = [ctrl.gap_seconds(current, prev, rng_b, "VIC") for _ in range(20)]
+        results_b = [ctrl.gap_seconds(current, prev, rng_b, "VIC", "AGG") for _ in range(20)]
         assert results_a == results_b
 
     def test_different_seeds_different_output(self) -> None:
@@ -266,9 +267,9 @@ class TestReproducibility:
         prev = _turn("AGG_M_30-45_001", 3)
 
         rng_1 = random.Random(1)
-        results_a = [ctrl.gap_seconds(current, prev, rng_1, "VIC") for _ in range(20)]
+        results_a = [ctrl.gap_seconds(current, prev, rng_1, "VIC", "AGG") for _ in range(20)]
         rng_2 = random.Random(2)
-        results_b = [ctrl.gap_seconds(current, prev, rng_2, "VIC") for _ in range(20)]
+        results_b = [ctrl.gap_seconds(current, prev, rng_2, "VIC", "AGG") for _ in range(20)]
         assert results_a != results_b
 
 
@@ -312,43 +313,61 @@ class TestOverlapModeSelection:
 
     def setup_method(self) -> None:
         self.ctrl = TurnGapController(project="she_proves")
-        self.prev = _turn("VIC_F_25-35_001", 3)
+        self.prev_vic = _turn("VIC_F_25-35_001", 3)  # used as prev for AGG-current tests
+        self.prev_agg = _turn("AGG_M_30-45_001", 3)  # used as prev for VIC-current tests
 
     def _mode_counts(
         self,
         current: DialogueTurn,
         role: str,
+        prev_role: str | None,
+        prev: DialogueTurn | None = None,
         n: int = 1000,
     ) -> dict[MixMode, int]:
         rng = random.Random(99)
+        prev_turn = (
+            prev if prev is not None else (self.prev_agg if role == "VIC" else self.prev_vic)
+        )
         counts: dict[MixMode, int] = {m: 0 for m in MixMode}
         for _ in range(n):
-            _, mode = self.ctrl.gap_seconds(current, self.prev, rng, role)
+            _, mode = self.ctrl.gap_seconds(current, prev_turn, rng, role, prev_role)
             counts[mode] += 1
         return counts
 
     def test_agg_i3_barge_in_rate(self) -> None:
         """AGG at I3 should produce BARGE_IN ~10% of the time (±5% tolerance)."""
-        counts = self._mode_counts(_turn("AGG_M_30-45_001", 3), "AGG")
+        counts = self._mode_counts(_turn("AGG_M_30-45_001", 3), "AGG", prev_role="VIC")
         barge_in_rate = counts[MixMode.BARGE_IN] / 1000
         assert 0.05 <= barge_in_rate <= 0.20, f"expected ~10%, got {barge_in_rate:.2%}"
 
     def test_agg_i5_barge_in_rate(self) -> None:
         """AGG at I5 should produce BARGE_IN ~40% of the time (±10% tolerance)."""
-        counts = self._mode_counts(_turn("AGG_M_30-45_001", 5), "AGG")
+        counts = self._mode_counts(_turn("AGG_M_30-45_001", 5), "AGG", prev_role="VIC")
         barge_in_rate = counts[MixMode.BARGE_IN] / 1000
         assert 0.30 <= barge_in_rate <= 0.55, f"expected ~40%, got {barge_in_rate:.2%}"
 
     def test_vic_overlap_rate(self) -> None:
         """VIC at any intensity should produce OVERLAP ~10% of the time (±5%)."""
-        counts = self._mode_counts(_turn("VIC_F_25-35_001", 2), "VIC")
+        counts = self._mode_counts(_turn("VIC_F_25-35_001", 2), "VIC", prev_role="AGG")
         overlap_rate = counts[MixMode.OVERLAP] / 1000
         assert 0.05 <= overlap_rate <= 0.20, f"expected ~10%, got {overlap_rate:.2%}"
 
     def test_agg_i1_always_sequential(self) -> None:
         """AGG at I1–I2 must never produce OVERLAP or BARGE_IN."""
         for intensity in (1, 2):
-            counts = self._mode_counts(_turn("AGG_M_30-45_001", intensity), "AGG")
+            counts = self._mode_counts(_turn("AGG_M_30-45_001", intensity), "AGG", prev_role="VIC")
+            assert counts[MixMode.OVERLAP] == 0
+            assert counts[MixMode.BARGE_IN] == 0
+
+    def test_same_role_never_overlaps(self) -> None:
+        """Same-role transitions (AGG→AGG) must always be SEQUENTIAL per §4.6."""
+        # _OVERLAP_PROBS has no (AGG, AGG, *) or (VIC, VIC, *) entries.
+        for intensity in (3, 4, 5):
+            counts = self._mode_counts(
+                _turn("AGG_M_30-45_001", intensity),
+                "AGG",
+                prev_role="AGG",  # same role
+            )
             assert counts[MixMode.OVERLAP] == 0
             assert counts[MixMode.BARGE_IN] == 0
 
@@ -358,7 +377,7 @@ class TestOverlapModeSelection:
         current = _turn("AGG_M_30-45_001", 5)
         depths = []
         for _ in range(1000):
-            amount, mode = self.ctrl.gap_seconds(current, self.prev, rng, "AGG")
+            amount, mode = self.ctrl.gap_seconds(current, self.prev_vic, rng, "AGG", "VIC")
             if mode == MixMode.BARGE_IN:
                 depths.append(amount)
         assert depths, "no BARGE_IN draws in 1000 trials at I5"
@@ -370,7 +389,7 @@ class TestOverlapModeSelection:
         current = _turn("AGG_M_30-45_001", 3)
         depths = []
         for _ in range(1000):
-            amount, mode = self.ctrl.gap_seconds(current, self.prev, rng, "AGG")
+            amount, mode = self.ctrl.gap_seconds(current, self.prev_vic, rng, "AGG", "VIC")
             if mode == MixMode.OVERLAP:
                 depths.append(amount)
         assert depths, "no OVERLAP draws in 1000 trials at I3"

--- a/tests/unit/test_gap_controller.py
+++ b/tests/unit/test_gap_controller.py
@@ -243,6 +243,15 @@ class TestUnknownRole:
         draws = _draw_many(ctrl, wit_turn, prev, "WIT", prev_role="AGG")
         assert all(g > 0 for g, _ in draws)
 
+    def test_prev_role_none_with_prev_turn_skips_overlap(self) -> None:
+        """prev_role=None with a real prev_turn bypasses the overlap table (line 175)."""
+        ctrl = TurnGapController(project="she_proves")
+        # High-intensity AGG turn that would normally trigger BARGE_IN when prev_role="VIC".
+        current = _turn("AGG_M_30-45_001", 5)
+        prev = _turn("VIC_F_25-35_001", 3)
+        draws = _draw_many(ctrl, current, prev, "AGG", prev_role=None, n=300)
+        assert all(m == MixMode.SEQUENTIAL for m in _modes_only(draws))
+
 
 # ---------------------------------------------------------------------------
 # Reproducibility

--- a/tests/unit/test_gap_controller.py
+++ b/tests/unit/test_gap_controller.py
@@ -15,7 +15,7 @@ from synthbanshee.tts.gap_controller import (
     _SHE_PROVES_GAPS,
     TurnGapController,
 )
-from synthbanshee.tts.mixer import MixMode
+from synthbanshee.tts.mix_mode import MixMode
 
 
 def _turn(speaker_id: str, intensity: int) -> DialogueTurn:

--- a/tests/unit/test_mixer.py
+++ b/tests/unit/test_mixer.py
@@ -8,7 +8,7 @@ import wave
 import numpy as np
 import pytest
 
-from synthbanshee.tts.mixer import _TARGET_SR, SceneMixer, _apply_rms_gain
+from synthbanshee.tts.mixer import _TARGET_SR, MixMode, SceneMixer, _apply_rms_gain
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -67,7 +67,7 @@ class TestSceneMixer:
     def test_single_segment_no_pause(self):
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None)])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
 
         assert result.sample_rate == _TARGET_SR
         assert len(result.turn_onsets_s) == 1
@@ -80,7 +80,7 @@ class TestSceneMixer:
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         pause_s = 0.3
-        result = mixer.mix_sequential([(wav, pause_s, "SPK_001", None)])
+        result = mixer.mix_sequential([(wav, pause_s, "SPK_001", None, MixMode.SEQUENTIAL)])
 
         assert result.turn_onsets_s[0] == pytest.approx(pause_s, abs=0.01)
         assert result.duration_s == pytest.approx(pause_s + 0.5, abs=0.05)
@@ -91,8 +91,8 @@ class TestSceneMixer:
         wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "SPK_A", None),
-                (wav2, 0.2, "SPK_B", None),
+                (wav1, 0.0, "SPK_A", None, MixMode.SEQUENTIAL),
+                (wav2, 0.2, "SPK_B", None, MixMode.SEQUENTIAL),
             ]
         )
 
@@ -105,9 +105,27 @@ class TestSceneMixer:
     def test_total_duration_matches_samples(self):
         mixer = SceneMixer()
         segments = [
-            (_sine_wav_bytes(duration_s=0.8, sample_rate=_TARGET_SR), 0.1, "S1", None),
-            (_sine_wav_bytes(duration_s=0.6, sample_rate=_TARGET_SR), 0.2, "S2", None),
-            (_sine_wav_bytes(duration_s=0.4, sample_rate=_TARGET_SR), 0.15, "S3", None),
+            (
+                _sine_wav_bytes(duration_s=0.8, sample_rate=_TARGET_SR),
+                0.1,
+                "S1",
+                None,
+                MixMode.SEQUENTIAL,
+            ),
+            (
+                _sine_wav_bytes(duration_s=0.6, sample_rate=_TARGET_SR),
+                0.2,
+                "S2",
+                None,
+                MixMode.SEQUENTIAL,
+            ),
+            (
+                _sine_wav_bytes(duration_s=0.4, sample_rate=_TARGET_SR),
+                0.15,
+                "S3",
+                None,
+                MixMode.SEQUENTIAL,
+            ),
         ]
         result = mixer.mix_sequential(segments)
         computed_duration = len(result.samples) / result.sample_rate
@@ -117,7 +135,7 @@ class TestSceneMixer:
         """Mixer should downsample 24 kHz input to 16 kHz output."""
         mixer = SceneMixer()
         wav_24k = _sine_wav_bytes(duration_s=0.5, sample_rate=24000)
-        result = mixer.mix_sequential([(wav_24k, 0.0, "SPK_001", None)])
+        result = mixer.mix_sequential([(wav_24k, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
 
         assert result.sample_rate == _TARGET_SR
         # Duration should still be approximately 0.5 s
@@ -126,7 +144,7 @@ class TestSceneMixer:
     def test_downmixes_stereo_to_mono(self):
         mixer = SceneMixer()
         stereo_wav = _stereo_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(stereo_wav, 0.0, "SPK_001", None)])
+        result = mixer.mix_sequential([(stereo_wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
 
         assert result.samples.ndim == 1
         assert result.duration_s == pytest.approx(1.0, abs=0.05)
@@ -134,14 +152,26 @@ class TestSceneMixer:
     def test_output_samples_are_float32(self):
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None)])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
         assert result.samples.dtype == np.float32
 
     def test_offsets_greater_than_onsets(self):
         mixer = SceneMixer()
         segments = [
-            (_sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR), 0.1, "S1", None),
-            (_sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR), 0.2, "S2", None),
+            (
+                _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR),
+                0.1,
+                "S1",
+                None,
+                MixMode.SEQUENTIAL,
+            ),
+            (
+                _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR),
+                0.2,
+                "S2",
+                None,
+                MixMode.SEQUENTIAL,
+            ),
         ]
         result = mixer.mix_sequential(segments)
         for onset, offset in zip(result.turn_onsets_s, result.turn_offsets_s, strict=True):
@@ -196,7 +226,7 @@ class TestRmsGainInMixer:
         """Passing None for rms_target_dbfs must not alter the signal level."""
         wav = _sine_wav_bytes(amplitude=0.1, duration_s=1.0, sample_rate=_TARGET_SR)
         mixer = SceneMixer()
-        result = mixer.mix_sequential([(wav, 0.0, "SPK", None)])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL)])
         # RMS of 0.1-amplitude sine = 0.1/sqrt(2) ≈ −23 dBFS; allow ±2 dB
         assert self._rms_dbfs(result.samples) == pytest.approx(-23.0, abs=2.0)
 
@@ -205,7 +235,7 @@ class TestRmsGainInMixer:
         wav = _sine_wav_bytes(amplitude=0.02, duration_s=1.0, sample_rate=_TARGET_SR)
         mixer = SceneMixer()
         target = -20.0
-        result = mixer.mix_sequential([(wav, 0.0, "SPK", target)])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK", target, MixMode.SEQUENTIAL)])
         assert self._rms_dbfs(result.samples) == pytest.approx(target, abs=0.5)
 
     def test_escalation_across_two_segments(self):
@@ -215,8 +245,8 @@ class TestRmsGainInMixer:
         mixer = SceneMixer()
         result = mixer.mix_sequential(
             [
-                (wav_quiet, 0.0, "AGG", -28.0),
-                (wav_loud, 0.0, "AGG", -15.0),
+                (wav_quiet, 0.0, "AGG", -28.0, MixMode.SEQUENTIAL),
+                (wav_loud, 0.0, "AGG", -15.0, MixMode.SEQUENTIAL),
             ]
         )
         # Verify combined duration is correct
@@ -226,3 +256,158 @@ class TestRmsGainInMixer:
         rms_q = self._rms_dbfs(result.samples[:half])
         rms_l = self._rms_dbfs(result.samples[half:])
         assert rms_l > rms_q + 8.0  # ≥ 8 dB gap matches the M3 spec target
+
+
+# ---------------------------------------------------------------------------
+# M8a: Overlap and BARGE_IN mixing tests
+# ---------------------------------------------------------------------------
+
+
+class TestOverlapMixing:
+    """Tests for OVERLAP and BARGE_IN MixMode placement (M8a §4.6)."""
+
+    def test_overlap_onset_earlier_than_sequential(self):
+        """OVERLAP onset must be earlier than the end of the previous segment."""
+        mixer = SceneMixer()
+        dur = 1.0
+        overlap_s = 0.3
+        wav1 = _sine_wav_bytes(freq=440, duration_s=dur, sample_rate=_TARGET_SR)
+        wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR)
+        result = mixer.mix_sequential(
+            [
+                (wav1, 0.0, "AGG", None, MixMode.SEQUENTIAL),
+                (wav2, overlap_s, "VIC", None, MixMode.OVERLAP),
+            ]
+        )
+        # rendered onset of turn 2 should be dur - overlap_s
+        assert result.rendered_onsets_s[1] == pytest.approx(dur - overlap_s, abs=0.02)
+
+    def test_overlap_total_duration_shorter_than_sequential(self):
+        """Overlapping turns produce a shorter output than strict sequential."""
+        mixer = SceneMixer()
+        dur = 1.0
+        overlap_s = 0.3
+        wav1 = _sine_wav_bytes(duration_s=dur, sample_rate=_TARGET_SR)
+        wav2 = _sine_wav_bytes(duration_s=dur, sample_rate=_TARGET_SR)
+
+        seq_result = mixer.mix_sequential(
+            [
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                (wav2, 0.0, "B", None, MixMode.SEQUENTIAL),
+            ]
+        )
+        olap_result = mixer.mix_sequential(
+            [
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                (wav2, overlap_s, "B", None, MixMode.OVERLAP),
+            ]
+        )
+        assert olap_result.duration_s < seq_result.duration_s
+
+    def test_overlap_both_turns_audible_in_region(self):
+        """In an OVERLAP mix, the overlap region has energy from both turns."""
+        mixer = SceneMixer()
+        dur = 1.0
+        overlap_s = 0.3
+        wav1 = _sine_wav_bytes(freq=440, duration_s=dur, sample_rate=_TARGET_SR, amplitude=0.3)
+        wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR, amplitude=0.3)
+
+        result = mixer.mix_sequential(
+            [
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                (wav2, overlap_s, "B", None, MixMode.OVERLAP),
+            ]
+        )
+        # The overlap region lies between rendered_onsets_s[1] and rendered_offsets_s[0].
+        overlap_start = int(result.rendered_onsets_s[1] * _TARGET_SR)
+        overlap_end = int(result.rendered_offsets_s[0] * _TARGET_SR)
+        assert overlap_end > overlap_start
+        # Overlap region amplitude should exceed what a single sine of amplitude 0.3 would give.
+        overlap_region = result.samples[overlap_start:overlap_end]
+        assert float(np.max(np.abs(overlap_region))) > 0.0
+
+    def test_barge_in_previous_turn_truncated(self):
+        """BARGE_IN: the previous turn's audio must be zero after the barge-in point."""
+        mixer = SceneMixer()
+        dur = 1.5
+        barge_depth = 0.4
+        wav1 = _sine_wav_bytes(freq=440, duration_s=dur, sample_rate=_TARGET_SR, amplitude=0.4)
+        wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR, amplitude=0.0)
+
+        result = mixer.mix_sequential(
+            [
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                (wav2, barge_depth, "B", None, MixMode.BARGE_IN),
+            ]
+        )
+        # The interrupted turn's audible_end_s must be < rendered_offsets_s.
+        assert result.audible_ends_s[0] < result.rendered_offsets_s[0]
+        # No audio from the first turn must remain after the barge-in point.
+        barge_sample = int(result.rendered_onsets_s[1] * _TARGET_SR)
+        # Buffer from barge-in point to rendered end of first turn is zero (silent wav2 added).
+        tail = result.samples[barge_sample : int(result.rendered_offsets_s[0] * _TARGET_SR)]
+        assert np.allclose(tail, 0.0, atol=1e-5)
+
+    def test_barge_in_audible_end_equals_onset_of_next(self):
+        """Interrupted turn's audible_end_s == barge-in turn's rendered_onset_s."""
+        mixer = SceneMixer()
+        wav1 = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
+        wav2 = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
+        result = mixer.mix_sequential(
+            [
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                (wav2, 0.3, "B", None, MixMode.BARGE_IN),
+            ]
+        )
+        assert result.audible_ends_s[0] == pytest.approx(result.rendered_onsets_s[1], abs=1e-4)
+
+    def test_three_timeline_fields_populated(self):
+        """MixedScene must expose script / rendered / audible timeline fields."""
+        mixer = SceneMixer()
+        wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
+        result = mixer.mix_sequential(
+            [
+                (wav, 0.1, "A", None, MixMode.SEQUENTIAL),
+                (wav, 0.2, "B", None, MixMode.SEQUENTIAL),
+            ]
+        )
+        for attr in (
+            "script_onsets_s",
+            "script_offsets_s",
+            "rendered_onsets_s",
+            "rendered_offsets_s",
+            "audible_onsets_s",
+            "audible_ends_s",
+        ):
+            vals = getattr(result, attr)
+            assert len(vals) == 2, f"{attr} should have 2 entries"
+
+    def test_sequential_three_timelines_equal(self):
+        """For purely sequential mixes, all three timelines must be identical."""
+        mixer = SceneMixer()
+        wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
+        result = mixer.mix_sequential(
+            [
+                (wav, 0.1, "A", None, MixMode.SEQUENTIAL),
+                (wav, 0.2, "B", None, MixMode.SEQUENTIAL),
+            ]
+        )
+        for i in range(2):
+            assert result.script_onsets_s[i] == pytest.approx(result.rendered_onsets_s[i], abs=1e-6)
+            assert result.audible_onsets_s[i] == pytest.approx(
+                result.rendered_onsets_s[i], abs=1e-6
+            )
+            assert result.audible_ends_s[i] == pytest.approx(result.rendered_offsets_s[i], abs=1e-6)
+
+    def test_turn_onsets_backward_compat(self):
+        """turn_onsets_s / turn_offsets_s must mirror rendered_onsets_s / rendered_offsets_s."""
+        mixer = SceneMixer()
+        wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
+        result = mixer.mix_sequential(
+            [
+                (wav, 0.0, "A", None, MixMode.SEQUENTIAL),
+                (wav, 0.3, "B", None, MixMode.OVERLAP),
+            ]
+        )
+        assert result.turn_onsets_s == result.rendered_onsets_s
+        assert result.turn_offsets_s == result.rendered_offsets_s

--- a/tests/unit/test_mixer.py
+++ b/tests/unit/test_mixer.py
@@ -413,3 +413,34 @@ class TestOverlapMixing:
         )
         assert result.turn_onsets_s == result.audible_onsets_s
         assert result.turn_offsets_s == result.audible_ends_s
+
+    def test_overlap_as_first_segment_clamps_to_zero(self):
+        """OVERLAP as first segment (no previous turn in buffer) must clamp onset to ≥ 0."""
+        mixer = SceneMixer()
+        wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
+        # amount_s would push onset to render_cursor_s(0) - 0.5 = -0.5 → clamped to 0.
+        result = mixer.mix_sequential([(wav, 0.5, "A", None, MixMode.OVERLAP)])
+        assert result.rendered_onsets_s[0] == pytest.approx(0.0, abs=1e-4)
+        assert result.duration_s == pytest.approx(1.0, abs=0.05)
+
+    def test_barge_in_as_first_segment_clamps_to_zero(self):
+        """BARGE_IN as first segment (no previous turn in buffer) must clamp onset to ≥ 0."""
+        mixer = SceneMixer()
+        wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
+        result = mixer.mix_sequential([(wav, 0.5, "A", None, MixMode.BARGE_IN)])
+        assert result.rendered_onsets_s[0] == pytest.approx(0.0, abs=1e-4)
+
+    def test_barge_in_full_depth_truncates_entirely(self):
+        """BARGE_IN with overlap depth ≥ previous duration zeroes out the previous turn."""
+        mixer = SceneMixer()
+        wav1 = _sine_wav_bytes(freq=440, duration_s=0.5, sample_rate=_TARGET_SR, amplitude=0.4)
+        wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR)
+        # overlap depth (1.0) > prev duration (0.5): onset_sample == prev_onset_sample → max_samples == 0.
+        result = mixer.mix_sequential(
+            [
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                (wav2, 1.0, "B", None, MixMode.BARGE_IN),
+            ]
+        )
+        # The interrupted turn's audible end should collapse to its onset.
+        assert result.audible_ends_s[0] == pytest.approx(result.audible_onsets_s[0], abs=1e-4)

--- a/tests/unit/test_mixer.py
+++ b/tests/unit/test_mixer.py
@@ -444,3 +444,21 @@ class TestOverlapMixing:
         )
         # The interrupted turn's audible end should collapse to its onset.
         assert result.audible_ends_s[0] == pytest.approx(result.audible_onsets_s[0], abs=1e-4)
+
+    def test_barge_in_zero_depth_no_truncation(self):
+        """BARGE_IN with amount_s=0 leaves previous turn intact (max_samples >= len(prev_mono))."""
+        mixer = SceneMixer()
+        dur = 0.5
+        wav1 = _sine_wav_bytes(freq=440, duration_s=dur, sample_rate=_TARGET_SR, amplitude=0.4)
+        wav2 = _sine_wav_bytes(freq=880, duration_s=dur, sample_rate=_TARGET_SR)
+        # amount_s=0 → onset is clamped to prev_offset_s → max_samples == len(prev_mono) → no truncation.
+        result = mixer.mix_sequential(
+            [
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                (wav2, 0.0, "B", None, MixMode.BARGE_IN),
+            ]
+        )
+        # Previous turn plays its full duration (audible end == script end).
+        assert result.audible_ends_s[0] == pytest.approx(result.script_offsets_s[0], abs=1e-4)
+        # New turn starts right where the previous one ended.
+        assert result.rendered_onsets_s[1] == pytest.approx(dur, abs=0.02)

--- a/tests/unit/test_mixer.py
+++ b/tests/unit/test_mixer.py
@@ -322,9 +322,9 @@ class TestOverlapMixing:
         overlap_start = int(result.rendered_onsets_s[1] * _TARGET_SR)
         overlap_end = int(result.rendered_offsets_s[0] * _TARGET_SR)
         assert overlap_end > overlap_start
-        # Overlap region amplitude should exceed what a single sine of amplitude 0.3 would give.
+        # Overlap region peak amplitude should exceed what a single sine of amplitude 0.3 would give.
         overlap_region = result.samples[overlap_start:overlap_end]
-        assert float(np.max(np.abs(overlap_region))) > 0.0
+        assert float(np.max(np.abs(overlap_region))) > 0.3
 
     def test_barge_in_previous_turn_truncated(self):
         """BARGE_IN: the previous turn's audio must be zero after the barge-in point."""
@@ -340,12 +340,14 @@ class TestOverlapMixing:
                 (wav2, barge_depth, "B", None, MixMode.BARGE_IN),
             ]
         )
-        # The interrupted turn's audible_end_s must be < rendered_offsets_s.
-        assert result.audible_ends_s[0] < result.rendered_offsets_s[0]
+        # After COPILOT-6: rendered_offsets_s is updated to the truncation point,
+        # so audible_ends_s[0] == rendered_offsets_s[0] < script_offsets_s[0].
+        assert result.audible_ends_s[0] == pytest.approx(result.rendered_offsets_s[0], abs=1e-4)
+        assert result.audible_ends_s[0] < result.script_offsets_s[0]
         # No audio from the first turn must remain after the barge-in point.
         barge_sample = int(result.rendered_onsets_s[1] * _TARGET_SR)
-        # Buffer from barge-in point to rendered end of first turn is zero (silent wav2 added).
-        tail = result.samples[barge_sample : int(result.rendered_offsets_s[0] * _TARGET_SR)]
+        # Buffer from barge-in point onward is zero (silent wav2 added, prev truncated).
+        tail = result.samples[barge_sample : int(result.script_offsets_s[0] * _TARGET_SR)]
         assert np.allclose(tail, 0.0, atol=1e-5)
 
     def test_barge_in_audible_end_equals_onset_of_next(self):
@@ -400,7 +402,7 @@ class TestOverlapMixing:
             assert result.audible_ends_s[i] == pytest.approx(result.rendered_offsets_s[i], abs=1e-6)
 
     def test_turn_onsets_backward_compat(self):
-        """turn_onsets_s / turn_offsets_s must mirror rendered_onsets_s / rendered_offsets_s."""
+        """turn_onsets_s / turn_offsets_s must mirror the audible timeline (COPILOT-2)."""
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
@@ -409,5 +411,5 @@ class TestOverlapMixing:
                 (wav, 0.3, "B", None, MixMode.OVERLAP),
             ]
         )
-        assert result.turn_onsets_s == result.rendered_onsets_s
-        assert result.turn_offsets_s == result.rendered_offsets_s
+        assert result.turn_onsets_s == result.audible_onsets_s
+        assert result.turn_offsets_s == result.audible_ends_s


### PR DESCRIPTION
## Problem

All turn boundaries are clean silence gaps. Real coercive confrontations include barge-in behavior (AGG interrupting VIC mid-sentence), which is a significant structural marker of dominance. Without this, the model cannot learn interruption as a violence signal.

## Solution

Implements §4.6 of `docs/audio_generation_v3_design.md`:

1. **`MixMode` enum** (`SEQUENTIAL` / `OVERLAP` / `BARGE_IN`) added to `synthbanshee/tts/mixer.py`.
2. **Buffer-based mixer**: `SceneMixer.mix_sequential()` accepts 5-tuples `(wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode)`. `amount_s` is a silence gap for `SEQUENTIAL` or an overlap depth for `OVERLAP`/`BARGE_IN`. `BARGE_IN` truncates the previous segment at the barge-in point before additive mixing.
3. **Three-timeline `MixedScene`**: adds `script_onsets_s/script_offsets_s`, `rendered_onsets_s/rendered_offsets_s`, `audible_onsets_s/audible_ends_s`. For a `BARGE_IN`-interrupted turn, `audible_ends_s` is set to the barge-in onset. `turn_onsets_s`/`turn_offsets_s` remain as backward-compat aliases of the rendered lists.
4. **Asymmetric overlap probabilities**: `TurnGapController.gap_seconds()` now returns `tuple[float, MixMode]`. AGG at I3/I4/I5 barges in at 10%/25%/40% and overlaps at 15%/20%/15%; VIC at any intensity overlaps 10% and barges in 5%.
5. **`TTSRenderer.render_scene()`** unpacks the new tuple and passes 5-tuples to the mixer.

## Files changed

| File | Change |
|------|--------|
| `synthbanshee/tts/mixer.py` | Add `MixMode` enum; rewrite `mix_sequential()` with buffer-based placement; populate three-timeline fields |
| `synthbanshee/script/types.py` | Add 6 new timeline fields to `MixedScene` with `default_factory=list` |
| `synthbanshee/tts/gap_controller.py` | Import `MixMode`; add `_OVERLAP_PROBS`, depth ranges; change return type to `tuple[float, MixMode]` |
| `synthbanshee/tts/renderer.py` | Unpack `(gap_s, mix_mode)` tuple; build 5-tuples for segments |
| `tests/unit/test_mixer.py` | Update all 4-tuple calls to 5-tuples; add 8 new OVERLAP/BARGE_IN tests |
| `tests/unit/test_gap_controller.py` | Update `_draw_many` return type; add `_gaps_only`/`_modes_only` helpers; update all gap range assertions; add 6 MixMode distribution tests |

## Test plan

- [x] `pytest tests/unit/test_mixer.py` — all existing tests pass with updated 5-tuple API; new OVERLAP/BARGE_IN placement and three-timeline tests pass
- [x] `pytest tests/unit/test_gap_controller.py` — gap range assertions updated for sequential-only draws; MixMode rate tests pass at expected probabilities
- [x] `pytest tests/unit/test_tts.py` — `render_scene()` integration tests pass with new tuple unpacking
- [x] Full suite: `pytest` — 1124 passed
- [x] `ruff check` — no issues
- [x] `mypy` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)