### PR TITLE
ci: upgrade pr-agent-context refresh to v4.0.19 scheduled fallback pattern

### DIFF
--- a/.agent-plan.md
+++ b/.agent-plan.md
@@ -61,3 +61,9 @@ Full detail: `docs/audio_generation_v3_design.md` §Implementation Tracker
 | Hard rules for all agents | `AGENTS.md` (CLAUDE.md symlinks here) |
 | Taxonomy labels | `configs/taxonomy.yaml` |
 | Example configs | `configs/examples/` |
+| CI workflow rules | `AGENTS.md` § CI / Workflow conventions |
+
+## CI / Workflow notes
+
+- `pr-agent-context` reusable workflow is referenced as `@v4` (floating major tag) in both `.github/workflows/ci.yml` and `.github/workflows/pr-agent-context-refresh.yml`. **Do not pin to a patch version.** The `tool_ref: v4` input mirrors it.
+- The refresh workflow runs on a 15-minute `schedule` (dispatched via `workflow_dispatch` to each open same-repo PR) as a fallback for bot-authored review events.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,8 @@ jobs:
       target_patch_coverage: "100"
       include_review_comments: true
       include_failing_checks: true
+      include_failed_step_output: true
       include_patch_coverage: true
-      patch_coverage_source_mode: coverage_xml_artifact
-      coverage_report_artifact_name: coverage-xml
-      coverage_report_filename: coverage.xml
+      coverage_artifact_prefix: pr-agent-context-coverage
       prompt_template_file: .github/pr-agent-context-template.md
       debug_artifacts: true

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -126,21 +126,43 @@ jobs:
             });
 
             const hasCurrentRefreshComment = async (pull) => {
-              const { data: comments } = await github.rest.issues.listComments({
-                owner,
-                repo,
-                issue_number: pull.number,
-                per_page: 50,
-                sort: 'created',
-                direction: 'desc',
-              });
+              const perPage = 100;
+              const maxCommentsToInspect = 500;
+              let page = 1;
+              let inspectedComments = 0;
 
-              return comments.some(
-                (comment) =>
-                  comment.body?.startsWith(markerPrefix) &&
-                  comment.body.includes('execution_mode=refresh;') &&
-                  comment.body.includes(`head_sha=${pull.head.sha};`),
-              );
+              while (inspectedComments < maxCommentsToInspect) {
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner,
+                  repo,
+                  issue_number: pull.number,
+                  per_page: perPage,
+                  page,
+                  sort: 'created',
+                  direction: 'desc',
+                });
+
+                if (
+                  comments.some(
+                    (comment) =>
+                      comment.body?.startsWith(markerPrefix) &&
+                      comment.body.includes('execution_mode=refresh;') &&
+                      comment.body.includes(`head_sha=${pull.head.sha};`),
+                  )
+                ) {
+                  return true;
+                }
+
+                inspectedComments += comments.length;
+
+                if (comments.length < perPage) {
+                  break;
+                }
+
+                page += 1;
+              }
+
+              return false;
             };
 
             const hasRecentOrInFlightScheduledDispatchRun = (pull) => {

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -1,4 +1,25 @@
 name: pr-agent-context-refresh
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' &&
+    format(
+      'scheduled refresh PR #{0} @ {1}',
+      github.event.inputs.pull_request_number,
+      github.event.inputs.pull_request_head_sha
+    ) ||
+    github.event_name == 'schedule' &&
+    'scheduled refresh fanout' ||
+    github.event_name == 'pull_request_review' &&
+    format('review refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'pull_request_review_comment' &&
+    format('review-comment refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'check_run' &&
+    format(
+      'check refresh {0}',
+      github.event.check_run.pull_requests[0].number || github.event.check_run.head_sha
+    ) ||
+    github.workflow
+  }}
 
 on:
   pull_request_review:
@@ -7,38 +28,218 @@ on:
     types: [created, edited, deleted]
   check_run:
     types: [completed]
-  status:
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to refresh explicitly.
+        required: true
+        type: string
+      pull_request_base_sha:
+        description: Base SHA for the explicit refresh target.
+        required: true
+        type: string
+      pull_request_head_sha:
+        description: Head SHA for the explicit refresh target.
+        required: true
+        type: string
+      trigger_event_name:
+        description: Synthetic trigger event name used in rendered metadata.
+        required: false
+        default: workflow_dispatch
+        type: string
+      trigger_event_action:
+        description: Synthetic trigger event action used in rendered metadata.
+        required: false
+        default: ""
+        type: string
+  schedule:
+    - cron: "*/15 * * * *"
 
 concurrency:
   group: >-
-    ${{ github.workflow }}-${{
-      github.event.pull_request.number ||
-      github.event.pull_request_review.pull_request.number ||
-      github.event.pull_request_review_comment.pull_request.number ||
-      github.event.check_run.head_sha ||
-      github.event.sha ||
-      github.sha
+    ${{
+      github.event_name == 'workflow_dispatch' &&
+      format(
+        '{0}-{1}-{2}',
+        github.workflow,
+        github.event.inputs.pull_request_number,
+        github.event.inputs.pull_request_head_sha
+      ) ||
+      format(
+        '{0}-{1}',
+        github.workflow,
+        github.event.pull_request.number ||
+        github.event.check_run.pull_requests[0].number ||
+        github.event.check_run.head_sha ||
+        github.ref_name ||
+        github.sha
+      )
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
 
 jobs:
-  pr-agent-context-refresh:
-    name: "PR agent context refresh"
-    if: >-
-      github.event_name == 'pull_request_review' ||
-      github.event_name == 'pull_request_review_comment' ||
-      (github.event_name == 'check_run' &&
-       github.event.action == 'completed' &&
-       toJson(github.event.check_run.pull_requests) != '[]') ||
-      (github.event_name == 'status' && github.event.state != 'pending')
+  dispatch-scheduled-refreshes:
+    name: Dispatch scheduled refreshes
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read
-      pull-requests: write
-    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.18
+      actions: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const sameRepoPulls = pulls.filter(
+              (pull) => pull.head?.repo?.full_name === `${owner}/${repo}`,
+            );
+
+            const markerPrefix = '<!-- pr-agent-context:managed-comment;';
+            let dispatchCount = 0;
+            let skipCount = 0;
+            let errorCount = 0;
+            const recentDispatchWindowMs = 60 * 60 * 1000;
+
+            const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRunsForWorkflow({
+              owner,
+              repo,
+              workflow_id: 'pr-agent-context-refresh.yml',
+              event: 'workflow_dispatch',
+              per_page: 100,
+            });
+            const workflowDispatchRuns = workflowRunsResponse.workflow_runs.filter((run) => {
+              const createdTimestamp = run.created_at ? Date.parse(run.created_at) : 0;
+              return createdTimestamp >= recentDispatchCutoff || run.status !== 'completed';
+            });
+
+            const hasCurrentRefreshComment = async (pull) => {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: pull.number,
+                per_page: 50,
+                sort: 'created',
+                direction: 'desc',
+              });
+
+              return comments.some(
+                (comment) =>
+                  comment.body?.startsWith(markerPrefix) &&
+                  comment.body.includes('execution_mode=refresh;') &&
+                  comment.body.includes(`head_sha=${pull.head.sha};`),
+              );
+            };
+
+            const hasRecentOrInFlightScheduledDispatchRun = (pull) => {
+              const expectedTitle = `scheduled refresh PR #${pull.number} @ ${pull.head.sha}`;
+              const now = Date.now();
+
+              return workflowDispatchRuns.some((run) => {
+                if (run.display_title !== expectedTitle) {
+                  return false;
+                }
+                if (run.status !== 'completed') {
+                  return true;
+                }
+                const completedTimestamp = run.updated_at
+                  ? new Date(run.updated_at).getTime()
+                  : run.created_at
+                    ? new Date(run.created_at).getTime()
+                    : 0;
+                return completedTimestamp > 0 && now - completedTimestamp <= recentDispatchWindowMs;
+              });
+            };
+
+            for (const pull of sameRepoPulls) {
+              try {
+                const refreshCommentExists = await hasCurrentRefreshComment(pull);
+                const hasRecentDispatchRun = hasRecentOrInFlightScheduledDispatchRun(pull);
+
+                if (refreshCommentExists) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+                if (hasRecentDispatchRun) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: recent or in-flight scheduled dispatch for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: 'pr-agent-context-refresh.yml',
+                  ref: context.ref.replace('refs/heads/', ''),
+                  inputs: {
+                    pull_request_number: String(pull.number),
+                    pull_request_base_sha: pull.base.sha,
+                    pull_request_head_sha: pull.head.sha,
+                    trigger_event_name: 'schedule',
+                    trigger_event_action: '',
+                  },
+                });
+                dispatchCount += 1;
+              } catch (error) {
+                errorCount += 1;
+                core.warning(
+                  `Unable to evaluate or dispatch PR #${pull.number}: ${error instanceof Error ? error.message : String(error)}`,
+                );
+              }
+            }
+
+            core.notice(
+              `Scheduled refresh guard dispatched ${dispatchCount} run(s) and skipped ${skipCount}.`,
+            );
+            if (errorCount > 0) {
+              core.warning(`Scheduled refresh guard encountered ${errorCount} per-PR error(s).`);
+            }
+
+  pr-agent-context-refresh:
+    name: PR agent context refresh
+    if: >-
+      github.event_name != 'schedule' &&
+      (
+        (github.event_name == 'pull_request_review' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'pull_request_review_comment' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'check_run' &&
+         github.event.action == 'completed' &&
+         github.event.check_run.app.slug != 'github-actions' &&
+         toJson(github.event.check_run.pull_requests) != '[]' &&
+         github.event.check_run.pull_requests[0].head.repo.full_name == github.repository) ||
+        (github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.pull_request_number != '' &&
+         github.event.inputs.pull_request_base_sha != '' &&
+         github.event.inputs.pull_request_head_sha != '')
+      )
+    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4
     with:
-      tool_ref: v4.0.18
+      tool_ref: v4
       execution_mode: refresh
+      trigger_event_name_override: ${{ github.event.inputs.trigger_event_name || '' }}
+      trigger_event_action_override: ${{ github.event.inputs.trigger_event_action || '' }}
+      pull_request_number_override: ${{ github.event.inputs.pull_request_number || '' }}
+      pull_request_base_sha_override: ${{ github.event.inputs.pull_request_base_sha || '' }}
+      pull_request_head_sha_override: ${{ github.event.inputs.pull_request_head_sha || '' }}
       publish_mode: append
       publish_all_clear_comments_in_refresh: false
       wait_for_reviews_to_settle: true
@@ -46,10 +247,9 @@ jobs:
       include_review_comments: true
       include_outdated_review_threads: true
       include_failing_checks: true
+      include_failed_step_output: true
       include_patch_coverage: true
-      patch_coverage_source_mode: coverage_xml_artifact
-      coverage_report_artifact_name: coverage-xml
-      coverage_report_filename: coverage.xml
+      coverage_artifact_prefix: pr-agent-context-coverage
       enable_cross_run_coverage_lookup: true
       coverage_source_workflows: CI
       prompt_template_file: .github/pr-agent-context-template.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,15 @@ When addressing PR review comments (Copilot, human, or bot):
    ```
 4. Do **not** leave threads open after the corresponding change is committed — unresolved threads imply unfinished work.
 
+## CI / Workflow conventions
+
+- `pr-agent-context` is wired in two workflow files:
+  - `.github/workflows/ci.yml` — initial CI run (produces the baseline context comment)
+  - `.github/workflows/pr-agent-context-refresh.yml` — refresh run (review/check/schedule-driven)
+- Both workflows call the reusable workflow via **`@v4` (floating major tag)** — do **not** pin to a specific patch version (e.g. `@v4.0.18`). The floating tag is intentional: it picks up compatible patch releases automatically, and the `tool_ref: v4` input mirrors it.
+- Coverage artifacts are named `pr-agent-context-coverage-py<version>` (uploaded by the matrix `test` job). Both the CI `pr-agent-context` job and the refresh workflow reference them via `coverage_artifact_prefix: pr-agent-context-coverage` — do not change this prefix or the naming convention without updating both workflow files.
+- The refresh workflow includes a `dispatch-scheduled-refreshes` job that runs every 15 minutes and fans out `workflow_dispatch` runs to open same-repo PRs that lack a current refresh comment. This is the fallback for bot-authored review events that do not fire a `pull_request_review` GitHub event.
+
 ## What NOT to do
 
 - Don't mix speaker personas across train/val/test splits
@@ -142,3 +151,4 @@ When addressing PR review comments (Copilot, human, or bot):
 - Don't use lossy audio formats
 - Don't generate clips shorter than 3.0 s
 - Don't add a new typology to `taxonomy.yaml` without adding it to `_TYPOLOGY_INTENSITY_MAP`
+- Don't pin `pr-agent-context` workflow references to a specific patch version — keep `@v4` floating

--- a/llms.txt
+++ b/llms.txt
@@ -79,6 +79,12 @@ Synthetic Hebrew audio dataset generator for two DataHack AI safety projects:
 - tests/unit/test_labels.py           — label generation
 - tests/integration/                  — end-to-end clip generation tests
 
+## CI / Workflows
+- .github/workflows/ci.yml                       — test matrix (3.11+3.12), lint, coverage, pr-agent-context baseline
+- .github/workflows/pr-agent-context-refresh.yml — refresh on review/check/schedule events
+- pr-agent-context uses @v4 (floating major tag) — intentional; do not pin to a patch version
+- Coverage artifacts: prefix pr-agent-context-coverage-py<ver>; referenced via coverage_artifact_prefix in both workflow files
+
 ## Milestone status (as of 2026-04-16)
 Done (P0):  M1, M2a, M3a, M3b, IAA utilities (kappa, IAAReport, iaa-report CLI)
 Next (P0):  M4 — Emotional-state metadata consistency


### PR DESCRIPTION
## Problem

The existing refresh workflow (`pr-agent-context-refresh.yml`) was pinned to v4.0.18 and lacked the approval-gated fallback mechanism introduced in v4.0.19. Bot-authored review events (e.g. Copilot review submissions) and situations where no human `pull_request_review` event fires could leave a PR without a refresh comment until someone manually re-ran the workflow or pushed a new commit.

Specific gaps vs the v4.0.19 recommended pattern:
- No `schedule` + `workflow_dispatch` fallback — if a bot review never fires a `pull_request_review` event the refresh silently never runs
- No fork-repo guard on `pull_request_review` / `pull_request_review_comment` (ran for fork PRs even when it couldn't write back)
- No `app.slug != 'github-actions'` guard on `check_run` (every Actions check completion triggered a redundant refresh)
- Stale `status:` event trigger (removed upstream since v4.0.18)
- Stale event-path expressions in `concurrency.group`
- Hard-coded `cancel-in-progress: true` would cancel a `workflow_dispatch`-dispatched run if any other event fired concurrently
- Pinned `@v4.0.18` / `tool_ref: v4.0.18` instead of floating `@v4` (intentional — floating major tag picks up compatible patches automatically)
- No PR-context override pass-through inputs — `workflow_dispatch` runs had no way to specify which PR to refresh
- XML-artifact coverage mode (`patch_coverage_source_mode: coverage_xml_artifact`) instead of the preferred prefix mode (`coverage_artifact_prefix`)

## Solution

Upgrade both workflow files to the v4.0.19 recommended pattern while preserving all repo-specific settings. Document the intentional floating `@v4` ref convention in agent-facing files (`AGENTS.md`, `llms.txt`, `.agent-plan.md`) to prevent future re-pinning.

## Changes

| File | Change |
|---|---|
| `.github/workflows/pr-agent-context-refresh.yml` | Full upgrade to v4.0.19 pattern — see details below |
| `.github/workflows/ci.yml` | `pr-agent-context` job: switch to `coverage_artifact_prefix` mode; add `include_failed_step_output: true` |
| `AGENTS.md` | New "CI / Workflow conventions" section: floating `@v4` rule, coverage artifact naming, scheduled fallback |
| `llms.txt` | New "CI / Workflows" section with pointers and floating-tag note |
| `.agent-plan.md` | "CI / Workflow notes" block + context-pointer row |

### `pr-agent-context-refresh.yml` details

- **New `dispatch-scheduled-refreshes` job** (runs every 15 min on `schedule`): pages all open same-repo PRs, checks whether a current refresh comment already exists for the head SHA and whether a recent/in-flight `workflow_dispatch` run is already targeting that SHA — if either is true it skips; otherwise fires a `workflow_dispatch` with explicit `pull_request_number`, `pull_request_base_sha`, `pull_request_head_sha` inputs. Per-PR errors are isolated and logged as warnings; overall dispatch and skip counts are reported as notices.
- **`workflow_dispatch` trigger** with 5 inputs (`pull_request_number`, `pull_request_base_sha`, `pull_request_head_sha`, `trigger_event_name`, `trigger_event_action`) — consumed by the dispatcher job above.
- **`schedule: */15`** — fires the dispatcher every 15 minutes.
- **Removed `status:` trigger** — dropped upstream in v4.0.18; no longer needed.
- **SHA-aware `concurrency.group`**: `workflow_dispatch` runs get a per-PR-per-SHA group so two dispatches for the same SHA dedupe; event-driven runs keep the existing per-PR group.
- **`cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}`** — event-driven runs still cancel each other; scheduler dispatches are never cancelled mid-run.
- **Workflow-level `permissions`** (moved from job level).
- **Fork-repo guards** on `pull_request_review` and `pull_request_review_comment`.
- **`app.slug != 'github-actions'` guard** on `check_run` — prevents Actions-internal check completions from triggering a refresh.
- **Fork-repo guard** on `check_run`.
- **`workflow_dispatch` arm** in the main job `if:` condition.
- **`schedule` exclusion** (`github.event_name != 'schedule'`) in the main job `if:` — the schedule event is handled only by the dispatcher job.
- **Unpin** `@v4.0.18` → floating `@v4` / `tool_ref: v4` (intentional; see `AGENTS.md` § CI / Workflow conventions).
- **Override pass-through inputs**: `pull_request_number_override`, `pull_request_base_sha_override`, `pull_request_head_sha_override`, `trigger_event_name_override`, `trigger_event_action_override` passed to the reusable workflow.
- **`include_failed_step_output: true`** (available since v4.0.16).
- **Coverage mode**: `patch_coverage_source_mode: coverage_xml_artifact` + XML artifact params → `coverage_artifact_prefix: pr-agent-context-coverage` (uses raw `.coverage.*` artifacts already uploaded by the matrix test jobs).
- **`run-name`**: dynamic expression for readable run names in the Actions UI.
- Preserved repo-specific settings: `include_outdated_review_threads: true`, `prompt_template_file: .github/pr-agent-context-template.md`, `target_patch_coverage: "100"`, `wait_for_reviews_to_settle: true`.

## Test plan

- [x] Both YAML files pass Python `yaml.safe_load` validation
- [x] All pre-commit hooks pass (`check yaml`, `trim trailing whitespace`, etc.)
- [ ] After merge: confirm the `dispatch-scheduled-refreshes` job fires on schedule and the Actions UI shows the `scheduled refresh fanout` run name
- [ ] After merge: confirm a bot review on a PR (no human `pull_request_review` event) triggers a `scheduled refresh PR #N @ <sha>` dispatch within 15 minutes
- [ ] After merge: confirm event-driven refreshes (human review, check_run) still work and produce `review refresh PR #N` / `check refresh N` run names

🤖 Generated with [Claude Code](https://claude.com/claude-code)