### PR TITLE
feat(m10b): run-level QA aggregation — distributions, diversity, outliers

### DIFF
--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -1266,7 +1266,11 @@ def qa_report(
     Validates every WAV/TXT/JSON triplet, computes dataset statistics, and
     reports pass/fail based on the clip failure rate.
     """
-    from synthbanshee.package.qa import run_qa
+    from synthbanshee.package.qa import (
+        _HIGH_EMOTION_DOWNGRADE_RATE,
+        _MIN_VOICE_DIVERSITY,
+        run_qa,
+    )
 
     console.print(f"[cyan]Running QA on:[/cyan] {data_dir}")
     report = run_qa(data_dir, max_failure_rate=max_failure_rate, run_summary=run_summary)
@@ -1337,7 +1341,7 @@ def qa_report(
         # Voice diversity
         for gender in ("male", "female"):
             count = rs.voices_by_gender.get(gender, 0)
-            label = f"[yellow]{count}[/yellow]" if count < 3 else str(count)
+            label = f"[yellow]{count}[/yellow]" if count < _MIN_VOICE_DIVERSITY else str(count)
             t_run.add_row(f"Voice variants ({gender})", label)
 
         # Backend diversity
@@ -1360,7 +1364,7 @@ def qa_report(
 
         ed_label = (
             f"[yellow]{rs.emotion_downgrade_ratio:.1%}[/yellow]"
-            if rs.emotion_downgrade_ratio > 0.05
+            if rs.emotion_downgrade_ratio > _HIGH_EMOTION_DOWNGRADE_RATE
             else f"{rs.emotion_downgrade_ratio:.1%}"
         )
         t_run.add_row("Emotion downgrade ratio", ed_label)

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -1353,7 +1353,7 @@ def qa_report(
         # Overlap and emotion-downgrade ratios
         ovr_label = (
             f"[yellow]{rs.overlap_ratio:.1%}[/yellow]"
-            if rs.overlap_ratio == 0.0
+            if rs.overlap_ratio == 0.0 and rs.clips_with_i4_plus > 0
             else f"{rs.overlap_ratio:.1%}"
         )
         t_run.add_row("Overlap ratio (I4+ clips)", ovr_label)
@@ -1447,6 +1447,7 @@ def qa_report(
                 "backend_count": rs.backend_count,
                 "clips_by_tts_engine": rs.clips_by_tts_engine,
                 "overlap_ratio": rs.overlap_ratio,
+                "clips_with_i4_plus": rs.clips_with_i4_plus,
                 "emotion_downgrade_ratio": rs.emotion_downgrade_ratio,
                 "outlier_clip_ids": rs.outlier_clip_ids,
                 "run_warnings": rs.run_warnings,

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -1252,7 +1252,15 @@ def validate(clip: Path) -> None:
     show_default=True,
     help="Maximum acceptable failure rate (fraction, default 2%).",
 )
-def qa_report(data_dir: Path, output: Path | None, max_failure_rate: float) -> None:
+@click.option(
+    "--run-summary",
+    is_flag=True,
+    default=False,
+    help="Compute and display M10b run-level aggregation metrics.",
+)
+def qa_report(
+    data_dir: Path, output: Path | None, max_failure_rate: float, run_summary: bool
+) -> None:
     """Run the automated QA suite on a dataset directory.
 
     Validates every WAV/TXT/JSON triplet, computes dataset statistics, and
@@ -1261,7 +1269,7 @@ def qa_report(data_dir: Path, output: Path | None, max_failure_rate: float) -> N
     from synthbanshee.package.qa import run_qa
 
     console.print(f"[cyan]Running QA on:[/cyan] {data_dir}")
-    report = run_qa(data_dir, max_failure_rate=max_failure_rate)
+    report = run_qa(data_dir, max_failure_rate=max_failure_rate, run_summary=run_summary)
     stats = report.stats
 
     table = Table(title="Dataset Statistics")
@@ -1284,6 +1292,16 @@ def qa_report(data_dir: Path, output: Path | None, max_failure_rate: float) -> N
         else "0"
     )
     table.add_row("Missing strong-labels JSONL (Stage 4b)", missing_jsonl_label)
+    if stats.clips_with_acoustic_warnings > 0:
+        table.add_row(
+            "Clips with acoustic warnings (M10a)",
+            f"[yellow]{stats.clips_with_acoustic_warnings}[/yellow]",
+        )
+    if stats.clips_with_structural_warnings > 0:
+        table.add_row(
+            "Clips with structural warnings (M10b)",
+            f"[yellow]{stats.clips_with_structural_warnings}[/yellow]",
+        )
     console.print(table)
 
     if stats.clips_by_typology:
@@ -1309,6 +1327,82 @@ def qa_report(data_dir: Path, output: Path | None, max_failure_rate: float) -> N
         if len(report.failed_clip_ids) > 20:
             console.print(f"  ... and {len(report.failed_clip_ids) - 20} more")
 
+    # --- M10b: run-level summary table ---
+    if report.run_summary is not None:
+        rs = report.run_summary
+        t_run = Table(title="Run-Level Summary (M10b)")
+        t_run.add_column("Metric")
+        t_run.add_column("Value", justify="right")
+
+        # Voice diversity
+        for gender in ("male", "female"):
+            count = rs.voices_by_gender.get(gender, 0)
+            label = f"[yellow]{count}[/yellow]" if count < 3 else str(count)
+            t_run.add_row(f"Voice variants ({gender})", label)
+
+        # Backend diversity
+        be_label = (
+            f"[yellow]{rs.backend_count}[/yellow]"
+            if rs.backend_count <= 1
+            else str(rs.backend_count)
+        )
+        t_run.add_row("TTS backends", be_label)
+        for engine, count in sorted(rs.clips_by_tts_engine.items()):
+            t_run.add_row(f"  {engine}", str(count))
+
+        # Overlap and emotion-downgrade ratios
+        ovr_label = (
+            f"[yellow]{rs.overlap_ratio:.1%}[/yellow]"
+            if rs.overlap_ratio == 0.0
+            else f"{rs.overlap_ratio:.1%}"
+        )
+        t_run.add_row("Overlap ratio (I4+ clips)", ovr_label)
+
+        ed_label = (
+            f"[yellow]{rs.emotion_downgrade_ratio:.1%}[/yellow]"
+            if rs.emotion_downgrade_ratio > 0.05
+            else f"{rs.emotion_downgrade_ratio:.1%}"
+        )
+        t_run.add_row("Emotion downgrade ratio", ed_label)
+        t_run.add_row("Outlier clips", str(len(rs.outlier_clip_ids)))
+        console.print(t_run)
+
+        # Acoustic distributions
+        if rs.role_intensity_stats:
+            t_ri = Table(title="Acoustic Distributions by Role / Intensity")
+            t_ri.add_column("Role")
+            t_ri.add_column("I", justify="right")
+            t_ri.add_column("N", justify="right")
+            t_ri.add_column("F0 med (Hz)", justify="right")
+            t_ri.add_column("F0 std (Hz)", justify="right")
+            t_ri.add_column("RMS (dBFS)", justify="right")
+            t_ri.add_column("LUFS (dB)", justify="right")
+            for s in rs.role_intensity_stats:
+                t_ri.add_row(
+                    s.role,
+                    str(s.intensity),
+                    str(s.n_turns),
+                    f"{s.f0_median_hz:.1f}" if s.f0_median_hz is not None else "—",
+                    f"{s.f0_std_hz_mean:.1f}" if s.f0_std_hz_mean is not None else "—",
+                    f"{s.rms_db_mean:.1f}",
+                    f"{s.lufs_db_mean:.1f}" if s.lufs_db_mean is not None else "—",
+                )
+            console.print(t_ri)
+
+        # Run warnings
+        if rs.run_warnings:
+            console.print("[bold yellow]Run-level warnings:[/bold yellow]")
+            for w in rs.run_warnings:
+                console.print(f"  [yellow]⚠ {w}[/yellow]")
+
+        # Outlier clip IDs
+        if rs.outlier_clip_ids:
+            console.print("[yellow]Outlier clip IDs:[/yellow]")
+            for clip_id in rs.outlier_clip_ids[:20]:
+                console.print(f"  [yellow]• {clip_id}[/yellow]")
+            if len(rs.outlier_clip_ids) > 20:
+                console.print(f"  ... and {len(rs.outlier_clip_ids) - 20} more")
+
     if output is not None:
         output.parent.mkdir(parents=True, exist_ok=True)
         report_dict = {
@@ -1331,7 +1425,32 @@ def qa_report(data_dir: Path, output: Path | None, max_failure_rate: float) -> N
             },
             "failed_clip_ids": report.failed_clip_ids,
             "quality_flagged": report.quality_flagged,
+            "acoustic_warnings": report.acoustic_warnings,
+            "structural_warnings": report.structural_warnings,
         }
+        if report.run_summary is not None:
+            rs = report.run_summary
+            report_dict["run_summary"] = {
+                "role_intensity_stats": [
+                    {
+                        "role": s.role,
+                        "intensity": s.intensity,
+                        "n_turns": s.n_turns,
+                        "f0_median_hz": s.f0_median_hz,
+                        "f0_std_hz_mean": s.f0_std_hz_mean,
+                        "rms_db_mean": s.rms_db_mean,
+                        "lufs_db_mean": s.lufs_db_mean,
+                    }
+                    for s in rs.role_intensity_stats
+                ],
+                "voices_by_gender": rs.voices_by_gender,
+                "backend_count": rs.backend_count,
+                "clips_by_tts_engine": rs.clips_by_tts_engine,
+                "overlap_ratio": rs.overlap_ratio,
+                "emotion_downgrade_ratio": rs.emotion_downgrade_ratio,
+                "outlier_clip_ids": rs.outlier_clip_ids,
+                "run_warnings": rs.run_warnings,
+            }
         output.write_text(json.dumps(report_dict, indent=2), encoding="utf-8")
         console.print(f"[bold green]Report written:[/bold green] {output}")
 

--- a/synthbanshee/labels/prosody_metrics.py
+++ b/synthbanshee/labels/prosody_metrics.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+if TYPE_CHECKING:
+    from synthbanshee.labels.schema import EventLabel
 
 import numpy as np
 import soundfile as sf
@@ -182,6 +185,44 @@ def _measure_segment(
 # ---------------------------------------------------------------------------
 
 
+def measure_events(
+    samples: np.ndarray,
+    sr: int,
+    role_events: list[EventLabel],
+) -> list[TurnMetrics]:
+    """Return per-turn prosody metrics for pre-parsed events.
+
+    This is the lower-level entry point used when the caller has already
+    parsed the JSONL and loaded the WAV (e.g. ``run_qa`` in ``qa.py``
+    which needs the parsed events for M10b overlap/emotion checks).
+
+    Args:
+        samples: Mono audio array (int16 or float32).
+        sr: Sample rate in Hz.
+        role_events: List of ``EventLabel`` objects that have a non-None
+            ``speaker_role``.
+
+    Returns:
+        List of :class:`TurnMetrics`, one per event.
+    """
+    results: list[TurnMetrics] = []
+    for ev in role_events:
+        m = _measure_segment(samples, sr, ev.onset, ev.offset)
+        assert ev.speaker_role is not None
+        results.append(
+            TurnMetrics(
+                clip_id=ev.clip_id,
+                speaker_role=ev.speaker_role,
+                intensity=ev.intensity,
+                f0_median_hz=m.f0_median_hz,
+                f0_std_hz=m.f0_std_hz,
+                rms_db=m.rms_db,
+                lufs_db=m.lufs_db,
+            )
+        )
+    return results
+
+
 def measure_clip(clip_path: Path) -> list[TurnMetrics]:
     """Return per-turn prosody metrics for one generated clip.
 
@@ -224,22 +265,7 @@ def measure_clip(clip_path: Path) -> list[TurnMetrics]:
     if samples.ndim > 1:
         samples = samples[:, 0]
 
-    results: list[TurnMetrics] = []
-    for ev in role_events:
-        m = _measure_segment(samples, sr, ev.onset, ev.offset)
-        assert ev.speaker_role is not None  # narrowed above
-        results.append(
-            TurnMetrics(
-                clip_id=ev.clip_id,
-                speaker_role=ev.speaker_role,
-                intensity=ev.intensity,
-                f0_median_hz=m.f0_median_hz,
-                f0_std_hz=m.f0_std_hz,
-                rms_db=m.rms_db,
-                lufs_db=m.lufs_db,
-            )
-        )
-    return results
+    return measure_events(samples, sr, role_events)
 
 
 def aggregate_metrics(turns: list[TurnMetrics]) -> list[RoleIntensityStats]:

--- a/synthbanshee/labels/prosody_metrics.py
+++ b/synthbanshee/labels/prosody_metrics.py
@@ -223,6 +223,34 @@ def measure_events(
     return results
 
 
+def parse_jsonl_events(jsonl_path: Path) -> list[EventLabel]:
+    """Parse a JSONL strong-label file into a list of EventLabel objects.
+
+    Malformed lines are skipped with a warning.  Blank lines are ignored.
+
+    Args:
+        jsonl_path: Path to the ``.jsonl`` file.
+
+    Returns:
+        List of :class:`EventLabel` objects (may be empty).
+    """
+    from synthbanshee.labels.schema import EventLabel
+
+    events: list[EventLabel] = []
+    for raw_line in jsonl_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            events.append(EventLabel.model_validate_json(line))
+        except Exception as exc:  # pydantic.ValidationError or JSON parse error
+            warnings.warn(
+                f"Skipping malformed label line in {jsonl_path.name}: {exc}",
+                stacklevel=2,
+            )
+    return events
+
+
 def measure_clip(clip_path: Path) -> list[TurnMetrics]:
     """Return per-turn prosody metrics for one generated clip.
 
@@ -238,25 +266,11 @@ def measure_clip(clip_path: Path) -> list[TurnMetrics]:
         List of :class:`TurnMetrics`, one per qualifying event.  Empty if
         the JSONL is missing or contains no speaker-role events.
     """
-    from synthbanshee.labels.schema import EventLabel
-
     jsonl_path = clip_path.with_suffix(".jsonl")
     if not jsonl_path.exists():
         return []
 
-    events: list[EventLabel] = []
-    for raw_line in jsonl_path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        try:
-            events.append(EventLabel.model_validate_json(line))
-        except Exception as exc:  # pydantic.ValidationError or JSON parse error
-            warnings.warn(
-                f"Skipping malformed label line in {jsonl_path.name}: {exc}",
-                stacklevel=2,
-            )
-
+    events = parse_jsonl_events(jsonl_path)
     role_events = [e for e in events if e.speaker_role is not None]
     if not role_events:
         return []

--- a/synthbanshee/labels/schema.py
+++ b/synthbanshee/labels/schema.py
@@ -33,8 +33,8 @@ _QUALITY_FLAGS = frozenset(
         # M10a per-clip acoustic QA warnings
         "vic_f0_high",  # VIC median F0 at I4–I5 > 250 Hz
         "agg_no_escalation",  # AGG RMS range (I5 − I1) < 6 dB
-        # M10b per-clip run-level QA warnings
-        "warn_no_overlap",  # overlap ratio = 0 in clip with I4+ turns
+        # M10b per-clip structural QA warnings
+        "warn_no_overlap",  # no temporal overlap between events in a clip with I4+ turns
         "warn_emotion_downgrade",  # neutral emotional_state count > low-intensity turn count
     }
 )

--- a/synthbanshee/labels/schema.py
+++ b/synthbanshee/labels/schema.py
@@ -33,6 +33,9 @@ _QUALITY_FLAGS = frozenset(
         # M10a per-clip acoustic QA warnings
         "vic_f0_high",  # VIC median F0 at I4–I5 > 250 Hz
         "agg_no_escalation",  # AGG RMS range (I5 − I1) < 6 dB
+        # M10b per-clip run-level QA warnings
+        "warn_no_overlap",  # overlap ratio = 0 in clip with I4+ turns
+        "warn_emotion_downgrade",  # neutral emotional_state count > low-intensity turn count
     }
 )
 

--- a/synthbanshee/package/qa.py
+++ b/synthbanshee/package/qa.py
@@ -1,4 +1,4 @@
-"""Automated QA suite for the AVDP dataset (milestone 1.5 + M10a).
+"""Automated QA suite for the AVDP dataset (milestone 1.5 + M10a + M10b).
 
 Runs validate_clip() on every WAV in a data directory and accumulates
 aggregate statistics. Produces a QAReport that AI teams can inspect before
@@ -15,6 +15,23 @@ M10a per-clip acoustic checks (when JSONL is present):
   - vic_f0_high: any VIC turn at I4–I5 with F0 > 250 Hz
   - agg_no_escalation: AGG RMS range (I5 − I1) < 6 dB
 
+M10b per-clip checks (when JSONL is present, always active):
+  - warn_no_overlap: no temporal overlap between any two events in a clip
+    that contains I4+ turns
+  - warn_emotion_downgrade: count of neutral emotional_state events exceeds
+    count of low-intensity (I1–I2) events
+
+M10b run-level aggregation (RunSummary, enabled via run_summary=True):
+  - F0/RMS/LUFS distributions by role and intensity
+  - Voice and backend diversity counts
+  - Overlap and emotion-downgrade ratios
+  - Outlier clip detection (> 2σ from run mean)
+  - Run-level warning flags
+
+Note: The design doc also specifies distributions by typology/project and
+mix_mode distribution.  mix_mode is not persisted in EventLabel/ClipMetadata
+today; typology/project breakdowns are deferred to a follow-up.
+
 Dataset-level checks (via report.passed):
   - Failure rate ≤ max_failure_rate (default 2 %)
   - clips_missing_strong_labels is reported for observability but does not
@@ -24,18 +41,22 @@ Dataset-level checks (via report.passed):
 from __future__ import annotations
 
 import logging
+import warnings as _warnings_mod
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
 import pydantic
+import soundfile as sf
 
 from synthbanshee.labels.prosody_metrics import (
+    RoleIntensityStats,
     TurnMetrics,
-    measure_clip,
+    aggregate_metrics,
+    measure_events,
 )
-from synthbanshee.labels.schema import ClipMetadata
+from synthbanshee.labels.schema import ClipMetadata, EventLabel
 from synthbanshee.package.validator import validate_clip
 
 logger = logging.getLogger(__name__)
@@ -50,6 +71,15 @@ logger = logging.getLogger(__name__)
 # the 8 dB threshold is a hard gate for merging prosody-config PRs.
 _VIC_F0_HIGH_HZ: float = 250.0
 _AGG_ESCALATION_MIN_DB: float = 6.0
+
+# ---------------------------------------------------------------------------
+# M10b constants
+# ---------------------------------------------------------------------------
+
+_OUTLIER_SIGMA: float = 2.0
+_HIGH_WARNING_RATE: float = 0.10
+_HIGH_EMOTION_DOWNGRADE_RATE: float = 0.05
+_MIN_VOICE_DIVERSITY: int = 3
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +104,37 @@ class DatasetStats:
     # M10a acoustic metric counters
     acoustic_warnings: dict[str, int] = field(default_factory=dict)
     clips_with_acoustic_warnings: int = 0
+    # M10b structural warning counters (separate from acoustic)
+    structural_warnings: dict[str, int] = field(default_factory=dict)
+    clips_with_structural_warnings: int = 0
+
+
+@dataclass
+class RunSummary:
+    """M10b run-level aggregation metrics.
+
+    Computed across all valid clips in a QA run to detect systematic
+    biases that per-clip checks cannot catch.
+    """
+
+    # Acoustic distributions by (role, intensity)
+    role_intensity_stats: list[RoleIntensityStats] = field(default_factory=list)
+
+    # Voice and backend diversity
+    voices_by_gender: dict[str, int] = field(default_factory=dict)
+    backend_count: int = 0
+    clips_by_tts_engine: dict[str, int] = field(default_factory=dict)
+
+    # Overlap and emotion-downgrade ratios
+    overlap_ratio: float = 0.0
+    clips_with_i4_plus: int = 0
+    emotion_downgrade_ratio: float = 0.0
+
+    # Outlier clips (F0 or RMS > 2σ from run mean for their role/intensity)
+    outlier_clip_ids: list[str] = field(default_factory=list)
+
+    # Run-level warning strings
+    run_warnings: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -85,8 +146,10 @@ class QAReport:
     failed_clip_ids: list[str] = field(default_factory=list)
     quality_flagged: dict[str, list[str]] = field(default_factory=dict)
     acoustic_warnings: dict[str, list[str]] = field(default_factory=dict)
+    structural_warnings: dict[str, list[str]] = field(default_factory=dict)
     passed: bool = False
     failure_rate: float = 0.0
+    run_summary: RunSummary | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +189,142 @@ def _check_acoustic_warnings(
 
 
 # ---------------------------------------------------------------------------
+# M10b per-clip checks
+# ---------------------------------------------------------------------------
+
+
+def _has_overlap(events: list[EventLabel]) -> bool:
+    """Return True if any two events in the list overlap temporally.
+
+    Uses sort-and-scan (O(n log n)) instead of pairwise comparison.
+    Two events overlap when ``onset_i < offset_j`` and ``onset_j < offset_i``.
+    """
+    if len(events) < 2:
+        return False
+    sorted_events = sorted(events, key=lambda e: e.onset)
+    max_offset = sorted_events[0].offset
+    for e in sorted_events[1:]:
+        if e.onset < max_offset:
+            return True
+        max_offset = max(max_offset, e.offset)
+    return False
+
+
+def _check_emotion_downgrade(events: list[EventLabel]) -> bool:
+    """Return True if neutral emotional states outnumber low-intensity turns.
+
+    A clip is flagged when the count of events with ``emotional_state ==
+    "neutral"`` exceeds the count of events with intensity ≤ 2.  This
+    indicates the LLM is defaulting to neutral for turns that should
+    carry emotional weight.
+    """
+    neutral_count = sum(1 for e in events if e.emotional_state == "neutral")
+    low_intensity_count = sum(1 for e in events if e.intensity <= 2)
+    return neutral_count > low_intensity_count
+
+
+def _parse_jsonl_events(jsonl_path: Path) -> list[EventLabel]:
+    """Parse a JSONL file into a list of EventLabel objects.
+
+    Malformed lines are skipped with a warning.
+    """
+    events: list[EventLabel] = []
+    for raw_line in jsonl_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            events.append(EventLabel.model_validate_json(line))
+        except Exception as exc:
+            _warnings_mod.warn(
+                f"Skipping malformed label line in {jsonl_path.name}: {exc}",
+                stacklevel=2,
+            )
+    return events
+
+
+def _detect_outliers(
+    all_turns: list[TurnMetrics],
+) -> list[str]:
+    """Return clip IDs whose F0 or RMS is > 2σ from run mean.
+
+    Uses mean (not median) as center for both F0 and RMS so that the
+    center and spread come from the same distribution.  Only buckets
+    with ≥ 2 samples are checked (σ requires at least 2 data points).
+    A clip ID appears at most once in the result.
+    """
+    # Build per-(role, intensity) lists
+    buckets: dict[tuple[str, int], list[TurnMetrics]] = defaultdict(list)
+    for t in all_turns:
+        buckets[(t.speaker_role, t.intensity)].append(t)
+
+    # Pre-compute mean and σ for F0 and RMS per bucket
+    f0_stats: dict[tuple[str, int], tuple[float, float]] = {}  # (mean, sigma)
+    rms_stats: dict[tuple[str, int], tuple[float, float]] = {}
+    for key, turns in buckets.items():
+        f0_vals = [t.f0_median_hz for t in turns if t.f0_median_hz is not None]
+        if len(f0_vals) >= 2:
+            f0_stats[key] = (float(np.mean(f0_vals)), float(np.std(f0_vals)))
+        rms_vals = [t.rms_db for t in turns]
+        if len(rms_vals) >= 2:
+            rms_stats[key] = (float(np.mean(rms_vals)), float(np.std(rms_vals)))
+
+    outlier_ids: set[str] = set()
+    for t in all_turns:
+        key = (t.speaker_role, t.intensity)
+
+        # F0 outlier
+        if t.f0_median_hz is not None and key in f0_stats:
+            mean, sigma = f0_stats[key]
+            if sigma > 0 and abs(t.f0_median_hz - mean) > _OUTLIER_SIGMA * sigma:
+                outlier_ids.add(t.clip_id)
+
+        # RMS outlier
+        if key in rms_stats:
+            mean, sigma = rms_stats[key]
+            if sigma > 0 and abs(t.rms_db - mean) > _OUTLIER_SIGMA * sigma:
+                outlier_ids.add(t.clip_id)
+
+    return sorted(outlier_ids)
+
+
+def _compute_run_warnings(
+    summary: RunSummary,
+    total_clips: int,
+    clips_with_acoustic_warnings: int,
+) -> list[str]:
+    """Evaluate run-level warning conditions and return triggered flags."""
+    warnings: list[str] = []
+
+    # Voice diversity (only meaningful when clips exist)
+    if total_clips > 0:
+        for gender in ("male", "female"):
+            count = summary.voices_by_gender.get(gender, 0)
+            if count < _MIN_VOICE_DIVERSITY:
+                warnings.append(f"low_voice_diversity_{gender}")
+
+    # Backend diversity
+    if summary.backend_count <= 1 and total_clips > 0:
+        warnings.append("single_backend")
+
+    # Zero overlap — only warn when there are I4+ clips that *should* have overlap
+    if summary.clips_with_i4_plus > 0 and summary.overlap_ratio == 0.0:
+        warnings.append("zero_overlap")
+
+    # High emotion-downgrade rate
+    if summary.emotion_downgrade_ratio > _HIGH_EMOTION_DOWNGRADE_RATE:
+        warnings.append("high_emotion_downgrade")
+
+    # High acoustic-warning rate (acoustic only, not structural)
+    if total_clips > 0:
+        warning_rate = clips_with_acoustic_warnings / total_clips
+        if warning_rate > _HIGH_WARNING_RATE:
+            warnings.append("high_warning_rate")
+
+    return warnings
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -135,6 +334,7 @@ def run_qa(
     *,
     splits: dict[str, str] | None = None,
     max_failure_rate: float = 0.02,
+    run_summary: bool = False,
 ) -> QAReport:
     """Run automated QA checks on all clips in data_dir.
 
@@ -146,6 +346,8 @@ def run_qa(
             ``stats.clips_by_split``.
         max_failure_rate: Fraction of clips that may fail before
             ``report.passed`` is set to False (default: 0.02 = 2 %).
+        run_summary: If True, compute M10b run-level aggregation metrics
+            and attach a :class:`RunSummary` to the report.
 
     Returns:
         QAReport with per-clip failure list and aggregate statistics.
@@ -160,6 +362,16 @@ def run_qa(
     _intensity: dict[int, int] = defaultdict(int)
     _speakers: set[str] = set()
     _acoustic_warnings: dict[str, int] = defaultdict(int)
+    _structural_warnings: dict[str, int] = defaultdict(int)
+
+    # M10b accumulators
+    _all_turns: list[TurnMetrics] = []
+    _voices_by_gender: dict[str, set[str]] = defaultdict(set)
+    _tts_engines: set[str] = set()
+    _clips_by_engine: dict[str, int] = defaultdict(int)
+    _clips_with_overlap: int = 0
+    _clips_with_emotion_downgrade: int = 0
+    _clips_with_i4_plus: int = 0  # denominator for overlap ratio
 
     wav_paths = [p for p in sorted(data_dir.rglob("*.wav")) if "_dirty" not in p.stem]
 
@@ -202,23 +414,78 @@ def run_qa(
         if any("Strong labels JSONL missing" in w for w in validation.warnings):
             stats.clips_missing_strong_labels += 1
 
-        # --- M10a: per-clip acoustic metrics ---
+        # M10b: track voice and backend diversity
+        if run_summary:
+            _tts_engines.add(metadata.tts_engine)
+            _clips_by_engine[metadata.tts_engine] += 1
+            for spk in metadata.speakers:
+                _voices_by_gender[spk.gender].add(spk.tts_voice_id)
+
+        # --- JSONL-based checks (M10a acoustic + M10b structural) ---
+        # Parse JSONL once, share events between acoustic measurement and
+        # structural checks to avoid double-parsing.
         jsonl_path = wav_path.with_suffix(".jsonl")
         if jsonl_path.exists():
-            clip_warnings: list[str] = []
+            acoustic_clip_warnings: list[str] = []
+            structural_clip_warnings: list[str] = []
 
             try:
-                turns = measure_clip(wav_path)
-                if turns:
-                    clip_warnings.extend(_check_acoustic_warnings(turns))
+                events = _parse_jsonl_events(jsonl_path)
+                role_events = [e for e in events if e.speaker_role is not None]
             except Exception:
-                logger.warning("Acoustic measurement failed for %s", wav_path.stem, exc_info=True)
+                logger.warning("JSONL parse failed for %s", wav_path.stem, exc_info=True)
+                events = []
+                role_events = []
 
-            if clip_warnings:
+            # M10a: acoustic measurements using pre-parsed events
+            if role_events:
+                try:
+                    samples, sr = sf.read(str(wav_path), dtype="int16")
+                    if samples.ndim > 1:
+                        samples = samples[:, 0]
+                    turns = measure_events(samples, sr, role_events)
+                    if turns:
+                        acoustic_clip_warnings.extend(_check_acoustic_warnings(turns))
+                        if run_summary:
+                            _all_turns.extend(turns)
+                except Exception:
+                    logger.warning(
+                        "Acoustic measurement failed for %s", wav_path.stem, exc_info=True
+                    )
+
+            # M10b: structural checks (always active, not gated on run_summary)
+            if role_events:
+                try:
+                    has_i4_plus = any(e.intensity >= 4 for e in role_events)
+
+                    if has_i4_plus:
+                        _clips_with_i4_plus += 1
+                        if _has_overlap(role_events):
+                            _clips_with_overlap += 1
+                        else:
+                            structural_clip_warnings.append("warn_no_overlap")
+
+                    if _check_emotion_downgrade(role_events):
+                        _clips_with_emotion_downgrade += 1
+                        structural_clip_warnings.append("warn_emotion_downgrade")
+                except Exception:
+                    logger.warning(
+                        "M10b event analysis failed for %s", wav_path.stem, exc_info=True
+                    )
+
+            # Record acoustic warnings
+            if acoustic_clip_warnings:
                 stats.clips_with_acoustic_warnings += 1
-                report.acoustic_warnings[metadata.clip_id] = clip_warnings
-                for w in clip_warnings:
+                report.acoustic_warnings[metadata.clip_id] = acoustic_clip_warnings
+                for w in acoustic_clip_warnings:
                     _acoustic_warnings[w] += 1
+
+            # Record structural warnings (separate from acoustic)
+            if structural_clip_warnings:
+                stats.clips_with_structural_warnings += 1
+                report.structural_warnings[metadata.clip_id] = structural_clip_warnings
+                for w in structural_clip_warnings:
+                    _structural_warnings[w] += 1
 
     stats.clips_by_typology = dict(_by_typology)
     stats.clips_by_split = dict(_by_split)
@@ -226,9 +493,32 @@ def run_qa(
     stats.intensity_distribution = dict(_intensity)
     stats.speaker_count = len(_speakers)
     stats.acoustic_warnings = dict(_acoustic_warnings)
+    stats.structural_warnings = dict(_structural_warnings)
 
     total_attempted = stats.total_clips + stats.failed_clips
     report.failure_rate = stats.failed_clips / total_attempted if total_attempted else 0.0
     report.passed = report.failure_rate <= max_failure_rate
     report.stats = stats
+
+    # --- M10b: build run summary ---
+    if run_summary and stats.total_clips > 0:
+        ri_stats = aggregate_metrics(_all_turns) if _all_turns else []
+
+        summary = RunSummary(
+            role_intensity_stats=ri_stats,
+            voices_by_gender={g: len(v) for g, v in _voices_by_gender.items()},
+            backend_count=len(_tts_engines),
+            clips_by_tts_engine=dict(_clips_by_engine),
+            overlap_ratio=(
+                _clips_with_overlap / _clips_with_i4_plus if _clips_with_i4_plus > 0 else 0.0
+            ),
+            clips_with_i4_plus=_clips_with_i4_plus,
+            emotion_downgrade_ratio=_clips_with_emotion_downgrade / stats.total_clips,
+            outlier_clip_ids=_detect_outliers(_all_turns),
+        )
+        summary.run_warnings = _compute_run_warnings(
+            summary, stats.total_clips, stats.clips_with_acoustic_warnings
+        )
+        report.run_summary = summary
+
     return report

--- a/synthbanshee/package/qa.py
+++ b/synthbanshee/package/qa.py
@@ -217,6 +217,10 @@ def _check_emotion_downgrade(events: list[EventLabel]) -> bool:
     "neutral"`` exceeds the count of events with intensity ≤ 2.  This
     indicates the LLM is defaulting to neutral for turns that should
     carry emotional weight.
+
+    Expects ``role_events`` (events with a non-None ``speaker_role``);
+    ambient events (``emotional_state=None``) are safe to include but
+    will not count as neutral.
     """
     neutral_count = sum(1 for e in events if e.emotional_state == "neutral")
     low_intensity_count = sum(1 for e in events if e.intensity <= 2)
@@ -457,17 +461,23 @@ def run_qa(
             if role_events:
                 try:
                     has_i4_plus = any(e.intensity >= 4 for e in role_events)
+                    has_overlap = _has_overlap(role_events) if has_i4_plus else False
+                    has_emotion_dg = _check_emotion_downgrade(role_events)
 
-                    if has_i4_plus:
-                        _clips_with_i4_plus += 1
-                        if _has_overlap(role_events):
-                            _clips_with_overlap += 1
-                        else:
-                            structural_clip_warnings.append("warn_no_overlap")
-
-                    if _check_emotion_downgrade(role_events):
-                        _clips_with_emotion_downgrade += 1
+                    # Per-clip structural warnings (always fire)
+                    if has_i4_plus and not has_overlap:
+                        structural_clip_warnings.append("warn_no_overlap")
+                    if has_emotion_dg:
                         structural_clip_warnings.append("warn_emotion_downgrade")
+
+                    # Run-level counters (only needed for RunSummary)
+                    if run_summary:
+                        if has_i4_plus:
+                            _clips_with_i4_plus += 1
+                            if has_overlap:
+                                _clips_with_overlap += 1
+                        if has_emotion_dg:
+                            _clips_with_emotion_downgrade += 1
                 except Exception:
                     logger.warning(
                         "M10b event analysis failed for %s", wav_path.stem, exc_info=True

--- a/synthbanshee/package/qa.py
+++ b/synthbanshee/package/qa.py
@@ -41,7 +41,6 @@ Dataset-level checks (via report.passed):
 from __future__ import annotations
 
 import logging
-import warnings as _warnings_mod
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -55,6 +54,7 @@ from synthbanshee.labels.prosody_metrics import (
     TurnMetrics,
     aggregate_metrics,
     measure_events,
+    parse_jsonl_events,
 )
 from synthbanshee.labels.schema import ClipMetadata, EventLabel
 from synthbanshee.package.validator import validate_clip
@@ -225,26 +225,6 @@ def _check_emotion_downgrade(events: list[EventLabel]) -> bool:
     neutral_count = sum(1 for e in events if e.emotional_state == "neutral")
     low_intensity_count = sum(1 for e in events if e.intensity <= 2)
     return neutral_count > low_intensity_count
-
-
-def _parse_jsonl_events(jsonl_path: Path) -> list[EventLabel]:
-    """Parse a JSONL file into a list of EventLabel objects.
-
-    Malformed lines are skipped with a warning.
-    """
-    events: list[EventLabel] = []
-    for raw_line in jsonl_path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        try:
-            events.append(EventLabel.model_validate_json(line))
-        except Exception as exc:
-            _warnings_mod.warn(
-                f"Skipping malformed label line in {jsonl_path.name}: {exc}",
-                stacklevel=2,
-            )
-    return events
 
 
 def _detect_outliers(
@@ -434,7 +414,7 @@ def run_qa(
             structural_clip_warnings: list[str] = []
 
             try:
-                events = _parse_jsonl_events(jsonl_path)
+                events = parse_jsonl_events(jsonl_path)
                 role_events = [e for e in events if e.speaker_role is not None]
             except Exception:
                 logger.warning("JSONL parse failed for %s", wav_path.stem, exc_info=True)

--- a/tests/unit/test_qa.py
+++ b/tests/unit/test_qa.py
@@ -18,6 +18,7 @@ from synthbanshee.package.qa import (
     _compute_run_warnings,
     _detect_outliers,
     _has_overlap,
+    _parse_jsonl_events,
     run_qa,
 )
 
@@ -509,6 +510,41 @@ class TestRunQAAcousticWarnings:
 
         assert report.stats.total_clips == 1
         assert report.stats.failed_clips == 0
+
+
+# ---------------------------------------------------------------------------
+# M10b: _parse_jsonl_events
+# ---------------------------------------------------------------------------
+
+
+class TestParseJsonlEvents:
+    def test_parses_valid_events(self, tmp_path):
+        jsonl = tmp_path / "clip.jsonl"
+        ev = _make_event("c1", 0.5, 1.0, 1, "AGG")
+        jsonl.write_text(json.dumps(ev) + "\n", encoding="utf-8")
+        events = _parse_jsonl_events(jsonl)
+        assert len(events) == 1
+        assert events[0].clip_id == "c1"
+
+    def test_skips_malformed_lines(self, tmp_path):
+        jsonl = tmp_path / "clip.jsonl"
+        ev = _make_event("c1", 0.5, 1.0, 1, "AGG")
+        jsonl.write_text("not valid json\n" + json.dumps(ev) + "\n", encoding="utf-8")
+        events = _parse_jsonl_events(jsonl)
+        assert len(events) == 1
+
+    def test_skips_blank_lines(self, tmp_path):
+        jsonl = tmp_path / "clip.jsonl"
+        ev = _make_event("c1", 0.5, 1.0, 1, "AGG")
+        jsonl.write_text("\n\n" + json.dumps(ev) + "\n\n", encoding="utf-8")
+        events = _parse_jsonl_events(jsonl)
+        assert len(events) == 1
+
+    def test_empty_file(self, tmp_path):
+        jsonl = tmp_path / "clip.jsonl"
+        jsonl.write_text("", encoding="utf-8")
+        events = _parse_jsonl_events(jsonl)
+        assert events == []
 
 
 # ---------------------------------------------------------------------------
@@ -1148,6 +1184,7 @@ class TestQAReportCLIRunSummary:
         assert "voices_by_gender" in rs
         assert "backend_count" in rs
         assert "overlap_ratio" in rs
+        assert "clips_with_i4_plus" in rs
         assert "run_warnings" in rs
 
     def test_cli_without_run_summary_no_section(self, tmp_path):

--- a/tests/unit/test_qa.py
+++ b/tests/unit/test_qa.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import numpy as np
 import soundfile as sf
 
-from synthbanshee.labels.prosody_metrics import TurnMetrics
+from synthbanshee.labels.prosody_metrics import TurnMetrics, parse_jsonl_events
 from synthbanshee.package.qa import (
     DatasetStats,
     RunSummary,
@@ -18,7 +18,6 @@ from synthbanshee.package.qa import (
     _compute_run_warnings,
     _detect_outliers,
     _has_overlap,
-    _parse_jsonl_events,
     run_qa,
 )
 
@@ -513,7 +512,7 @@ class TestRunQAAcousticWarnings:
 
 
 # ---------------------------------------------------------------------------
-# M10b: _parse_jsonl_events
+# M10b: parse_jsonl_events
 # ---------------------------------------------------------------------------
 
 
@@ -522,7 +521,7 @@ class TestParseJsonlEvents:
         jsonl = tmp_path / "clip.jsonl"
         ev = _make_event("c1", 0.5, 1.0, 1, "AGG")
         jsonl.write_text(json.dumps(ev) + "\n", encoding="utf-8")
-        events = _parse_jsonl_events(jsonl)
+        events = parse_jsonl_events(jsonl)
         assert len(events) == 1
         assert events[0].clip_id == "c1"
 
@@ -530,20 +529,20 @@ class TestParseJsonlEvents:
         jsonl = tmp_path / "clip.jsonl"
         ev = _make_event("c1", 0.5, 1.0, 1, "AGG")
         jsonl.write_text("not valid json\n" + json.dumps(ev) + "\n", encoding="utf-8")
-        events = _parse_jsonl_events(jsonl)
+        events = parse_jsonl_events(jsonl)
         assert len(events) == 1
 
     def test_skips_blank_lines(self, tmp_path):
         jsonl = tmp_path / "clip.jsonl"
         ev = _make_event("c1", 0.5, 1.0, 1, "AGG")
         jsonl.write_text("\n\n" + json.dumps(ev) + "\n\n", encoding="utf-8")
-        events = _parse_jsonl_events(jsonl)
+        events = parse_jsonl_events(jsonl)
         assert len(events) == 1
 
     def test_empty_file(self, tmp_path):
         jsonl = tmp_path / "clip.jsonl"
         jsonl.write_text("", encoding="utf-8")
-        events = _parse_jsonl_events(jsonl)
+        events = parse_jsonl_events(jsonl)
         assert events == []
 
 

--- a/tests/unit/test_qa.py
+++ b/tests/unit/test_qa.py
@@ -12,7 +12,12 @@ import soundfile as sf
 from synthbanshee.labels.prosody_metrics import TurnMetrics
 from synthbanshee.package.qa import (
     DatasetStats,
+    RunSummary,
     _check_acoustic_warnings,
+    _check_emotion_downgrade,
+    _compute_run_warnings,
+    _detect_outliers,
+    _has_overlap,
     run_qa,
 )
 
@@ -31,6 +36,9 @@ def _write_valid_clip(
     duration: float = 4.0,
     speaker_id: str = "AGG_M_30-45_001",
     quality_flags: list[str] | None = None,
+    tts_engine: str = "azure_he_IL",
+    tts_voice_id: str = "he-IL-AvriNeural",
+    gender: str = "male",
 ) -> Path:
     """Write a minimal valid WAV + TXT + JSON triplet and return the WAV path."""
     parent.mkdir(parents=True, exist_ok=True)
@@ -62,15 +70,15 @@ def _write_valid_clip(
         "generation_date": datetime.date.today().isoformat(),
         "generator_version": "0.1.0",
         "is_synthetic": True,
-        "tts_engine": "azure_he_IL",
+        "tts_engine": tts_engine,
         "acoustic_scene": {},
         "speakers": [
             {
                 "speaker_id": speaker_id,
                 "role": "AGG",
-                "gender": "male",
+                "gender": gender,
                 "age_range": "30-45",
-                "tts_voice_id": "he-IL-AvriNeural",
+                "tts_voice_id": tts_voice_id,
             }
         ],
         "weak_label": {
@@ -339,6 +347,7 @@ def _make_event(
     speaker_role: str,
     event_id: str = "ev_001",
     notes: str | None = None,
+    emotional_state: str = "neutral",
 ) -> dict:
     """Return a minimal valid EventLabel dict."""
     d = {
@@ -351,7 +360,7 @@ def _make_event(
         "intensity": intensity,
         "speaker_id": "AGG_001",
         "speaker_role": speaker_role,
-        "emotional_state": "neutral",
+        "emotional_state": emotional_state,
         "confidence": 1.0,
         "label_source": "auto",
         "iaa_reviewed": False,
@@ -471,7 +480,7 @@ class TestRunQAAcousticWarnings:
         assert report.stats.clips_with_acoustic_warnings == 0
 
     def test_run_qa_warning_accumulated_in_stats(self, tmp_path):
-        """When measure_clip returns a turn that triggers a warning, stats are updated."""
+        """When measure_events returns a turn that triggers a warning, stats are updated."""
         from unittest.mock import patch
 
         wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
@@ -479,7 +488,7 @@ class TestRunQAAcousticWarnings:
         _write_jsonl_events(wav, [ev])
 
         high_f0_turn = TurnMetrics("clip_001_00", "VIC", 5, 260.0, 10.0, -20.0)
-        with patch("synthbanshee.package.qa.measure_clip", return_value=[high_f0_turn]):
+        with patch("synthbanshee.package.qa.measure_events", return_value=[high_f0_turn]):
             report = run_qa(tmp_path)
 
         assert report.stats.clips_with_acoustic_warnings == 1
@@ -488,15 +497,681 @@ class TestRunQAAcousticWarnings:
         assert report.stats.acoustic_warnings.get("vic_f0_high") == 1
 
     def test_run_qa_acoustic_measurement_exception_handled(self, tmp_path):
-        """If measure_clip raises, the clip still passes QA (graceful fallback)."""
+        """If measure_events raises, the clip still passes QA (graceful fallback)."""
         from unittest.mock import patch
 
         wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
         ev = _make_event("clip_001_00", 0.5, 3.0, 1, "AGG")
         _write_jsonl_events(wav, [ev])
 
-        with patch("synthbanshee.package.qa.measure_clip", side_effect=RuntimeError("boom")):
+        with patch("synthbanshee.package.qa.measure_events", side_effect=RuntimeError("boom")):
             report = run_qa(tmp_path)
 
         assert report.stats.total_clips == 1
         assert report.stats.failed_clips == 0
+
+
+# ---------------------------------------------------------------------------
+# M10b: _has_overlap
+# ---------------------------------------------------------------------------
+
+
+class TestHasOverlap:
+    def test_no_overlap_sequential_events(self):
+        from synthbanshee.labels.schema import EventLabel
+
+        events = [
+            EventLabel(
+                event_id="ev_001",
+                clip_id="c1",
+                onset=0.5,
+                offset=1.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="AGG",
+                emotional_state="neutral",
+            ),
+            EventLabel(
+                event_id="ev_002",
+                clip_id="c1",
+                onset=1.5,
+                offset=2.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="VIC",
+                emotional_state="neutral",
+            ),
+        ]
+        assert _has_overlap(events) is False
+
+    def test_overlap_detected(self):
+        from synthbanshee.labels.schema import EventLabel
+
+        events = [
+            EventLabel(
+                event_id="ev_001",
+                clip_id="c1",
+                onset=0.5,
+                offset=1.5,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="AGG",
+                emotional_state="neutral",
+            ),
+            EventLabel(
+                event_id="ev_002",
+                clip_id="c1",
+                onset=1.0,
+                offset=2.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="VIC",
+                emotional_state="neutral",
+            ),
+        ]
+        assert _has_overlap(events) is True
+
+    def test_adjacent_events_no_overlap(self):
+        """Events touching at boundaries (onset == offset) do not overlap."""
+        from synthbanshee.labels.schema import EventLabel
+
+        events = [
+            EventLabel(
+                event_id="ev_001",
+                clip_id="c1",
+                onset=0.5,
+                offset=1.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="AGG",
+                emotional_state="neutral",
+            ),
+            EventLabel(
+                event_id="ev_002",
+                clip_id="c1",
+                onset=1.0,
+                offset=2.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="VIC",
+                emotional_state="neutral",
+            ),
+        ]
+        assert _has_overlap(events) is False
+
+    def test_empty_events(self):
+        assert _has_overlap([]) is False
+
+    def test_single_event(self):
+        from synthbanshee.labels.schema import EventLabel
+
+        events = [
+            EventLabel(
+                event_id="ev_001",
+                clip_id="c1",
+                onset=0.5,
+                offset=1.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="AGG",
+                emotional_state="neutral",
+            ),
+        ]
+        assert _has_overlap(events) is False
+
+    def test_unsorted_events_overlap_detected(self):
+        """Overlap detection works even when events arrive out of order."""
+        from synthbanshee.labels.schema import EventLabel
+
+        events = [
+            EventLabel(
+                event_id="ev_002",
+                clip_id="c1",
+                onset=1.0,
+                offset=2.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="VIC",
+                emotional_state="neutral",
+            ),
+            EventLabel(
+                event_id="ev_001",
+                clip_id="c1",
+                onset=0.5,
+                offset=1.5,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="AGG",
+                emotional_state="neutral",
+            ),
+        ]
+        assert _has_overlap(events) is True
+
+
+# ---------------------------------------------------------------------------
+# M10b: _check_emotion_downgrade
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEmotionDowngrade:
+    def test_no_downgrade_when_neutral_matches_low_intensity(self):
+        """neutral count == low-intensity count → not flagged."""
+        from synthbanshee.labels.schema import EventLabel
+
+        events = [
+            EventLabel(
+                event_id="ev_001",
+                clip_id="c1",
+                onset=0.5,
+                offset=1.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=1,
+                speaker_role="AGG",
+                emotional_state="neutral",
+            ),
+            EventLabel(
+                event_id="ev_002",
+                clip_id="c1",
+                onset=1.5,
+                offset=2.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=4,
+                speaker_role="AGG",
+                emotional_state="anger",
+            ),
+        ]
+        # 1 neutral, 1 low-intensity (I1) — equal, not flagged
+        assert _check_emotion_downgrade(events) is False
+
+    def test_downgrade_when_neutral_exceeds_low_intensity(self):
+        from synthbanshee.labels.schema import EventLabel
+
+        events = [
+            EventLabel(
+                event_id="ev_001",
+                clip_id="c1",
+                onset=0.5,
+                offset=1.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=3,
+                speaker_role="AGG",
+                emotional_state="neutral",
+            ),
+            EventLabel(
+                event_id="ev_002",
+                clip_id="c1",
+                onset=1.5,
+                offset=2.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=4,
+                speaker_role="VIC",
+                emotional_state="neutral",
+            ),
+        ]
+        # 2 neutral, 0 low-intensity → flagged
+        assert _check_emotion_downgrade(events) is True
+
+    def test_no_downgrade_all_emotional(self):
+        from synthbanshee.labels.schema import EventLabel
+
+        events = [
+            EventLabel(
+                event_id="ev_001",
+                clip_id="c1",
+                onset=0.5,
+                offset=1.0,
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                intensity=4,
+                speaker_role="AGG",
+                emotional_state="anger",
+            ),
+        ]
+        # 0 neutral → not flagged
+        assert _check_emotion_downgrade(events) is False
+
+    def test_empty_events(self):
+        assert _check_emotion_downgrade([]) is False
+
+
+# ---------------------------------------------------------------------------
+# M10b: _detect_outliers
+# ---------------------------------------------------------------------------
+
+
+class TestDetectOutliers:
+    def test_no_outliers_uniform_data(self):
+        turns = [
+            TurnMetrics("c1", "AGG", 1, 130.0, 10.0, -20.0),
+            TurnMetrics("c2", "AGG", 1, 131.0, 10.0, -20.5),
+            TurnMetrics("c3", "AGG", 1, 129.0, 10.0, -19.5),
+        ]
+        assert _detect_outliers(turns) == []
+
+    def test_f0_outlier_detected(self):
+        # 9 normal + 1 extreme outlier — enough normal samples so σ stays tight
+        turns = [TurnMetrics(f"c{i}", "AGG", 1, 130.0 + i * 0.1, 10.0, -20.0) for i in range(9)] + [
+            TurnMetrics("c_outlier", "AGG", 1, 500.0, 10.0, -20.0),
+        ]
+        outliers = _detect_outliers(turns)
+        assert "c_outlier" in outliers
+
+    def test_rms_outlier_detected(self):
+        turns = [TurnMetrics(f"c{i}", "AGG", 1, 130.0, 10.0, -20.0 + i * 0.1) for i in range(9)] + [
+            TurnMetrics("c_outlier", "AGG", 1, 130.0, 10.0, 0.0),  # outlier
+        ]
+        outliers = _detect_outliers(turns)
+        assert "c_outlier" in outliers
+
+    def test_single_turn_no_outliers(self):
+        """Can't compute σ with a single sample."""
+        turns = [TurnMetrics("c1", "AGG", 1, 130.0, 10.0, -20.0)]
+        assert _detect_outliers(turns) == []
+
+    def test_empty_turns(self):
+        assert _detect_outliers([]) == []
+
+
+# ---------------------------------------------------------------------------
+# M10b: _compute_run_warnings
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRunWarnings:
+    def test_low_voice_diversity_male(self):
+        summary = RunSummary(voices_by_gender={"male": 2, "female": 3})
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=0)
+        assert "low_voice_diversity_male" in warnings
+        assert "low_voice_diversity_female" not in warnings
+
+    def test_low_voice_diversity_female(self):
+        summary = RunSummary(voices_by_gender={"male": 3, "female": 1})
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=0)
+        assert "low_voice_diversity_female" in warnings
+        assert "low_voice_diversity_male" not in warnings
+
+    def test_single_backend(self):
+        summary = RunSummary(backend_count=1, voices_by_gender={"male": 3, "female": 3})
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=0)
+        assert "single_backend" in warnings
+
+    def test_no_single_backend_warning_with_two(self):
+        summary = RunSummary(backend_count=2, voices_by_gender={"male": 3, "female": 3})
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=0)
+        assert "single_backend" not in warnings
+
+    def test_zero_overlap_with_i4_clips(self):
+        """zero_overlap fires when there are I4+ clips but none overlap."""
+        summary = RunSummary(
+            overlap_ratio=0.0,
+            clips_with_i4_plus=5,
+            voices_by_gender={"male": 3, "female": 3},
+            backend_count=2,
+        )
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=0)
+        assert "zero_overlap" in warnings
+
+    def test_no_zero_overlap_without_i4_clips(self):
+        """zero_overlap does NOT fire when there are no I4+ clips."""
+        summary = RunSummary(
+            overlap_ratio=0.0,
+            clips_with_i4_plus=0,
+            voices_by_gender={"male": 3, "female": 3},
+            backend_count=2,
+        )
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=0)
+        assert "zero_overlap" not in warnings
+
+    def test_no_zero_overlap_with_some_overlap(self):
+        summary = RunSummary(
+            overlap_ratio=0.5,
+            clips_with_i4_plus=4,
+            voices_by_gender={"male": 3, "female": 3},
+            backend_count=2,
+        )
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=0)
+        assert "zero_overlap" not in warnings
+
+    def test_high_emotion_downgrade(self):
+        summary = RunSummary(
+            emotion_downgrade_ratio=0.06,
+            voices_by_gender={"male": 3, "female": 3},
+            backend_count=2,
+            overlap_ratio=0.5,
+            clips_with_i4_plus=5,
+        )
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=0)
+        assert "high_emotion_downgrade" in warnings
+
+    def test_no_high_emotion_downgrade_at_threshold(self):
+        summary = RunSummary(
+            emotion_downgrade_ratio=0.05,
+            voices_by_gender={"male": 3, "female": 3},
+            backend_count=2,
+            overlap_ratio=0.5,
+            clips_with_i4_plus=5,
+        )
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=0)
+        assert "high_emotion_downgrade" not in warnings
+
+    def test_high_warning_rate(self):
+        summary = RunSummary(
+            voices_by_gender={"male": 3, "female": 3},
+            backend_count=2,
+            overlap_ratio=0.5,
+            clips_with_i4_plus=5,
+        )
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=2)
+        assert "high_warning_rate" in warnings
+
+    def test_no_high_warning_rate_at_threshold(self):
+        summary = RunSummary(
+            voices_by_gender={"male": 3, "female": 3},
+            backend_count=2,
+            overlap_ratio=0.5,
+            clips_with_i4_plus=5,
+        )
+        warnings = _compute_run_warnings(summary, total_clips=10, clips_with_acoustic_warnings=1)
+        assert "high_warning_rate" not in warnings
+
+    def test_no_warnings_for_empty_run(self):
+        summary = RunSummary()
+        warnings = _compute_run_warnings(summary, total_clips=0, clips_with_acoustic_warnings=0)
+        assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# M10b: run_qa with run_summary=True
+# ---------------------------------------------------------------------------
+
+
+class TestRunQARunSummary:
+    def test_run_summary_none_by_default(self, tmp_path):
+        _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        report = run_qa(tmp_path)
+        assert report.run_summary is None
+
+    def test_run_summary_populated_when_flag_set(self, tmp_path):
+        wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        ev = _make_event("clip_001_00", 0.5, 3.0, 1, "AGG")
+        _write_jsonl_events(wav, [ev])
+        report = run_qa(tmp_path, run_summary=True)
+        assert report.run_summary is not None
+        assert isinstance(report.run_summary, RunSummary)
+
+    def test_run_summary_backend_diversity(self, tmp_path):
+        _write_valid_clip(tmp_path / "spk_a", "clip_001_00")
+        _write_valid_clip(tmp_path / "spk_b", "clip_002_00")
+        report = run_qa(tmp_path, run_summary=True)
+        rs = report.run_summary
+        assert rs is not None
+        # Both clips use azure_he_IL by default
+        assert rs.backend_count == 1
+        assert rs.clips_by_tts_engine.get("azure_he_IL") == 2
+
+    def test_run_summary_voice_diversity(self, tmp_path):
+        _write_valid_clip(tmp_path / "spk_a", "clip_001_00", speaker_id="SPK_A")
+        _write_valid_clip(tmp_path / "spk_b", "clip_002_00", speaker_id="SPK_B")
+        report = run_qa(tmp_path, run_summary=True)
+        rs = report.run_summary
+        assert rs is not None
+        # Both speakers use same tts_voice_id (he-IL-AvriNeural) in the helper
+        assert rs.voices_by_gender.get("male") == 1
+
+    def test_run_summary_multiple_voices(self, tmp_path):
+        """Different tts_voice_id values are counted as distinct voices."""
+        _write_valid_clip(
+            tmp_path / "spk_a",
+            "clip_001_00",
+            tts_voice_id="he-IL-AvriNeural",
+            gender="male",
+        )
+        _write_valid_clip(
+            tmp_path / "spk_b",
+            "clip_002_00",
+            tts_voice_id="he-IL-DanNeural",
+            gender="male",
+        )
+        _write_valid_clip(
+            tmp_path / "spk_c",
+            "clip_003_00",
+            tts_voice_id="he-IL-HilaNeural",
+            gender="female",
+        )
+        report = run_qa(tmp_path, run_summary=True)
+        rs = report.run_summary
+        assert rs is not None
+        assert rs.voices_by_gender.get("male") == 2
+        assert rs.voices_by_gender.get("female") == 1
+
+    def test_structural_warnings_fire_without_run_summary(self, tmp_path):
+        """M10b per-clip warnings fire even when run_summary=False."""
+        from unittest.mock import patch
+
+        wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        events = [
+            _make_event("clip_001_00", 0.5, 1.5, 4, "AGG", event_id="ev_001"),
+            _make_event("clip_001_00", 2.0, 3.0, 4, "VIC", event_id="ev_002"),
+        ]
+        _write_jsonl_events(wav, events)
+
+        with patch("synthbanshee.package.qa.measure_events", return_value=[]):
+            report = run_qa(tmp_path, run_summary=False)
+
+        # Structural warnings fire without --run-summary
+        assert "warn_no_overlap" in report.structural_warnings.get("clip_001_00", [])
+        assert "warn_emotion_downgrade" in report.structural_warnings.get("clip_001_00", [])
+        # But run_summary is still None
+        assert report.run_summary is None
+
+    def test_run_summary_warn_no_overlap(self, tmp_path):
+        """Clip with I4+ turns and no overlap gets warn_no_overlap."""
+        from unittest.mock import patch
+
+        wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        events = [
+            _make_event("clip_001_00", 0.5, 1.5, 4, "AGG", event_id="ev_001"),
+            _make_event("clip_001_00", 2.0, 3.0, 4, "VIC", event_id="ev_002"),
+        ]
+        _write_jsonl_events(wav, events)
+
+        with patch("synthbanshee.package.qa.measure_events", return_value=[]):
+            report = run_qa(tmp_path, run_summary=True)
+
+        assert "warn_no_overlap" in report.structural_warnings.get("clip_001_00", [])
+
+    def test_run_summary_no_warn_no_overlap_when_overlap_present(self, tmp_path):
+        """Clip with I4+ turns and overlap does NOT get warn_no_overlap."""
+        from unittest.mock import patch
+
+        wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        events = [
+            _make_event("clip_001_00", 0.5, 2.0, 4, "AGG", event_id="ev_001"),
+            _make_event("clip_001_00", 1.5, 3.0, 4, "VIC", event_id="ev_002"),
+        ]
+        _write_jsonl_events(wav, events)
+
+        with patch("synthbanshee.package.qa.measure_events", return_value=[]):
+            report = run_qa(tmp_path, run_summary=True)
+
+        clip_warnings = report.structural_warnings.get("clip_001_00", [])
+        assert "warn_no_overlap" not in clip_warnings
+
+    def test_run_summary_warn_emotion_downgrade(self, tmp_path):
+        """Clip with more neutrals than low-intensity turns gets warn_emotion_downgrade."""
+        from unittest.mock import patch
+
+        wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        events = [
+            _make_event("clip_001_00", 0.5, 1.5, 4, "AGG", event_id="ev_001"),
+            _make_event("clip_001_00", 2.0, 3.0, 4, "VIC", event_id="ev_002"),
+        ]
+        # Both events are I4 with emotional_state="neutral" (default in _make_event)
+        # 2 neutral, 0 low-intensity → flagged
+        _write_jsonl_events(wav, events)
+
+        with patch("synthbanshee.package.qa.measure_events", return_value=[]):
+            report = run_qa(tmp_path, run_summary=True)
+
+        assert "warn_emotion_downgrade" in report.structural_warnings.get("clip_001_00", [])
+
+    def test_run_summary_no_emotion_downgrade_when_expected(self, tmp_path):
+        """Clip where neutral count matches low-intensity count is not flagged."""
+        from unittest.mock import patch
+
+        wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        events = [
+            _make_event("clip_001_00", 0.5, 1.5, 1, "AGG", event_id="ev_001"),  # low + neutral
+            _make_event(
+                "clip_001_00", 2.0, 3.0, 4, "VIC", event_id="ev_002", emotional_state="fear"
+            ),
+        ]
+        _write_jsonl_events(wav, events)
+
+        with patch("synthbanshee.package.qa.measure_events", return_value=[]):
+            report = run_qa(tmp_path, run_summary=True)
+
+        clip_warnings = report.structural_warnings.get("clip_001_00", [])
+        assert "warn_emotion_downgrade" not in clip_warnings
+
+    def test_run_summary_overlap_ratio(self, tmp_path):
+        """overlap_ratio reflects fraction of I4+ clips with overlap."""
+        from unittest.mock import patch
+
+        # Clip 1: I4, no overlap
+        wav1 = _write_valid_clip(tmp_path / "spk_a", "clip_001_00")
+        _write_jsonl_events(
+            wav1,
+            [
+                _make_event("clip_001_00", 0.5, 1.5, 4, "AGG", event_id="ev_001"),
+                _make_event("clip_001_00", 2.0, 3.0, 4, "VIC", event_id="ev_002"),
+            ],
+        )
+        # Clip 2: I4, with overlap
+        wav2 = _write_valid_clip(tmp_path / "spk_b", "clip_002_00")
+        _write_jsonl_events(
+            wav2,
+            [
+                _make_event("clip_002_00", 0.5, 2.0, 4, "AGG", event_id="ev_001"),
+                _make_event("clip_002_00", 1.5, 3.0, 4, "VIC", event_id="ev_002"),
+            ],
+        )
+
+        with patch("synthbanshee.package.qa.measure_events", return_value=[]):
+            report = run_qa(tmp_path, run_summary=True)
+
+        rs = report.run_summary
+        assert rs is not None
+        assert rs.overlap_ratio == 0.5  # 1 out of 2 I4+ clips
+
+    def test_run_summary_empty_dir(self, tmp_path):
+        """Empty directory → run_summary is None even with flag."""
+        report = run_qa(tmp_path, run_summary=True)
+        assert report.run_summary is None
+
+    def test_run_summary_no_jsonl_no_m10b_warnings(self, tmp_path):
+        """Clips without JSONL don't produce M10b warnings."""
+        _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        report = run_qa(tmp_path, run_summary=True)
+        assert report.run_summary is not None
+        assert report.structural_warnings == {}
+
+    def test_structural_warnings_separate_from_acoustic(self, tmp_path):
+        """Structural and acoustic warnings go to separate dicts."""
+        from unittest.mock import patch
+
+        wav = _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        events = [
+            _make_event("clip_001_00", 0.5, 1.5, 5, "VIC", event_id="ev_001"),
+            _make_event("clip_001_00", 2.0, 3.0, 5, "AGG", event_id="ev_002"),
+        ]
+        _write_jsonl_events(wav, events)
+
+        high_f0_turn = TurnMetrics("clip_001_00", "VIC", 5, 260.0, 10.0, -20.0)
+        with patch("synthbanshee.package.qa.measure_events", return_value=[high_f0_turn]):
+            report = run_qa(tmp_path)
+
+        # Acoustic warning in acoustic_warnings
+        assert "vic_f0_high" in report.acoustic_warnings.get("clip_001_00", [])
+        # Structural warning in structural_warnings
+        assert "warn_no_overlap" in report.structural_warnings.get("clip_001_00", [])
+        # They don't leak into each other
+        assert "warn_no_overlap" not in report.acoustic_warnings.get("clip_001_00", [])
+        assert "vic_f0_high" not in report.structural_warnings.get("clip_001_00", [])
+
+
+# ---------------------------------------------------------------------------
+# M10b: CLI --run-summary smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestQAReportCLIRunSummary:
+    def test_cli_run_summary_no_crash(self, tmp_path):
+        """qa-report --run-summary runs without error on a simple dataset."""
+        from click.testing import CliRunner
+
+        from synthbanshee.cli import qa_report
+
+        _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        runner = CliRunner()
+        result = runner.invoke(qa_report, [str(tmp_path), "--run-summary"])
+        assert result.exit_code == 0
+        assert "Run-Level Summary" in result.output
+
+    def test_cli_run_summary_json_output(self, tmp_path):
+        """qa-report --run-summary --output writes run_summary to JSON."""
+        from click.testing import CliRunner
+
+        from synthbanshee.cli import qa_report
+
+        _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        out_file = tmp_path / "report.json"
+        runner = CliRunner()
+        result = runner.invoke(qa_report, [str(tmp_path), "--run-summary", "-o", str(out_file)])
+        assert result.exit_code == 0
+        report_data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert "run_summary" in report_data
+        rs = report_data["run_summary"]
+        assert "voices_by_gender" in rs
+        assert "backend_count" in rs
+        assert "overlap_ratio" in rs
+        assert "run_warnings" in rs
+
+    def test_cli_without_run_summary_no_section(self, tmp_path):
+        """qa-report without --run-summary does not show the section."""
+        from click.testing import CliRunner
+
+        from synthbanshee.cli import qa_report
+
+        _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        runner = CliRunner()
+        result = runner.invoke(qa_report, [str(tmp_path)])
+        assert result.exit_code == 0
+        assert "Run-Level Summary" not in result.output
+
+    def test_cli_json_without_run_summary_no_key(self, tmp_path):
+        """JSON output without --run-summary has no run_summary key."""
+        from click.testing import CliRunner
+
+        from synthbanshee.cli import qa_report
+
+        _write_valid_clip(tmp_path / "spk", "clip_001_00")
+        out_file = tmp_path / "report.json"
+        runner = CliRunner()
+        result = runner.invoke(qa_report, [str(tmp_path), "-o", str(out_file)])
+        assert result.exit_code == 0
+        report_data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert "run_summary" not in report_data


### PR DESCRIPTION
## Summary

- **Run-level QA aggregation** (`RunSummary` dataclass) to catch systematic biases that per-clip M10a checks cannot detect: F0/RMS/LUFS distributions by role/intensity, voice and backend diversity counts, overlap ratios, emotion-downgrade rates, and acoustic outlier clips.
- **Two new per-clip structural warnings** (`warn_no_overlap`, `warn_emotion_downgrade`) that fire unconditionally when JSONL is present — not gated on `--run-summary`.
- **`qa-report --run-summary` CLI flag** with Rich table output and JSON serialization.

## Changes by file

| File | Change |
|---|---|
| `synthbanshee/labels/schema.py` | Add `warn_no_overlap`, `warn_emotion_downgrade` to `_QUALITY_FLAGS` |
| `synthbanshee/labels/prosody_metrics.py` | Extract `measure_events()` from `measure_clip()` so callers with pre-parsed events/WAV can avoid redundant I/O |
| `synthbanshee/package/qa.py` | `RunSummary` dataclass; `_has_overlap()` (O(n log n) sort-and-scan); `_check_emotion_downgrade()`; `_parse_jsonl_events()`; `_detect_outliers()` (mean+σ, ≥2 samples); `_compute_run_warnings()` (6 conditions); extend `run_qa()` with single-parse JSONL, separated acoustic vs structural warning counters |
| `synthbanshee/cli.py` | `--run-summary` flag; Rich tables for run-level metrics, acoustic distributions, warnings, outliers; JSON output includes `run_summary` section; structural warning counts in dataset stats table |
| `tests/unit/test_qa.py` | 37 new tests across 8 classes: `TestHasOverlap`, `TestCheckEmotionDowngrade`, `TestDetectOutliers`, `TestComputeRunWarnings`, `TestRunQARunSummary`, `TestQAReportCLIRunSummary` |

## Design decisions

- **Structural vs acoustic warnings are separated** — `warn_no_overlap` and `warn_emotion_downgrade` use `report.structural_warnings` / `stats.clips_with_structural_warnings`, so `high_warning_rate` only reflects actual acoustic measurement issues.
- **JSONL parsed once** — `_parse_jsonl_events()` output is shared between `measure_events()` and structural checks, avoiding the double-parse from v1.
- **`zero_overlap` only fires when I4+ clips exist** — prevents false positives on NEU/NEG-only runs.
- **Outlier detection uses mean (not median) as center** — matches σ computation from the same distribution for statistical consistency.
- **Scope gaps acknowledged** — typology/project breakdowns and `mix_mode` distribution are deferred; `mix_mode` is not persisted in EventLabel/ClipMetadata today.

## Test plan

- [x] `pytest tests/unit/test_qa.py` — 82 tests pass (37 new)
- [x] `pytest tests/unit/` — 1230 tests pass, no regressions
- [x] `ruff check` — clean
- [x] `ruff format` — clean
- [x] `mypy` — clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)