### PR TITLE
feat(m11): GenerationMetadata for pipeline provenance tracking

### DIFF
--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -546,16 +546,31 @@ def _run_generate_pipeline(
     quality_flags = ["emotion_downgrade"] if emotion_downgrade_turns else []
 
     # M11: Build GenerationMetadata for pipeline provenance.
+    from collections import Counter
+
     from synthbanshee import __version__
     from synthbanshee.labels.schema import GenerationMetadata
 
-    # Determine dominant TTS backend and voice family from speakers.
-    _backends = [spk.tts_provider for spk in speakers.values()]
-    _dominant_backend = max(set(_backends), key=_backends.count) if _backends else "azure"
-    _voice_families = [spk.voice_family or spk.tts_voice_id for spk in speakers.values()]
-    _dominant_voice = _voice_families[0] if _voice_families else ""
+    # Per-speaker TTS backend and voice family.
+    _backends_map: dict[str, str] = {sid: spk.tts_provider for sid, spk in speakers.items()}
+    _voices_map = {sid: spk.voice_family or spk.tts_voice_id for sid, spk in speakers.items()}
 
-    # Collect final speaker state snapshots from the last turn per speaker.
+    # Dominant mix mode from actual mixer output.
+    if mixed.mix_modes:
+        _mode_counts = Counter(mixed.mix_modes)
+        _dominant_mix_mode = _mode_counts.most_common(1)[0][0].upper()
+    else:
+        _dominant_mix_mode = "SEQUENTIAL"
+
+    # Final speaker state: capture post-last-update state by replaying
+    # the last turn's update on top of the pre-render snapshot.
+    # speaker_state_snapshot is captured *before* update() in the renderer,
+    # so it reflects the state going into the last turn, not the state after.
+    # We need the post-update state for provenance; use the SpeakerState
+    # objects still alive in the renderer — but they're local to render_scene().
+    # Instead, collect the last snapshot per speaker and note it represents
+    # the pre-render state of the final turn (the best we have without
+    # a renderer API change).
     _speaker_states: dict[str, dict[str, float]] = {}
     for turn in reversed(turns):
         if turn.speaker_id not in _speaker_states and turn.speaker_state_snapshot:
@@ -563,9 +578,9 @@ def _run_generate_pipeline(
 
     gen_meta = GenerationMetadata(
         pipeline_version=__version__,
-        tts_backend=_dominant_backend,
-        voice_family=_dominant_voice,
-        mix_mode_used="SEQUENTIAL",
+        tts_backend=_backends_map,
+        voice_family=_voices_map,
+        mix_mode_used=_dominant_mix_mode,
         normalization_strategy="per_turn_rms_v1",
         breathiness_applied=False,
         speaker_state_serialized=_speaker_states,

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -558,7 +558,7 @@ def _run_generate_pipeline(
     # Dominant mix mode from actual mixer output.
     if mixed.mix_modes:
         _mode_counts = Counter(mixed.mix_modes)
-        _dominant_mix_mode = _mode_counts.most_common(1)[0][0].upper()
+        _dominant_mix_mode = _mode_counts.most_common(1)[0][0]
     else:
         _dominant_mix_mode = "SEQUENTIAL"
 

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -544,6 +544,33 @@ def _run_generate_pipeline(
         silence_padded=True,
     )
     quality_flags = ["emotion_downgrade"] if emotion_downgrade_turns else []
+
+    # M11: Build GenerationMetadata for pipeline provenance.
+    from synthbanshee import __version__
+    from synthbanshee.labels.schema import GenerationMetadata
+
+    # Determine dominant TTS backend and voice family from speakers.
+    _backends = [spk.tts_provider for spk in speakers.values()]
+    _dominant_backend = max(set(_backends), key=_backends.count) if _backends else "azure"
+    _voice_families = [spk.voice_family or spk.tts_voice_id for spk in speakers.values()]
+    _dominant_voice = _voice_families[0] if _voice_families else ""
+
+    # Collect final speaker state snapshots from the last turn per speaker.
+    _speaker_states: dict[str, dict[str, float]] = {}
+    for turn in reversed(turns):
+        if turn.speaker_id not in _speaker_states and turn.speaker_state_snapshot:
+            _speaker_states[turn.speaker_id] = turn.speaker_state_snapshot
+
+    gen_meta = GenerationMetadata(
+        pipeline_version=__version__,
+        tts_backend=_dominant_backend,
+        voice_family=_dominant_voice,
+        mix_mode_used="SEQUENTIAL",
+        normalization_strategy="per_turn_rms_v1",
+        breathiness_applied=False,
+        speaker_state_serialized=_speaker_states,
+    )
+
     metadata = label_gen.generate_clip_metadata(
         clip_id=f"{clip_id}_00",
         project=scene.project,
@@ -559,6 +586,7 @@ def _run_generate_pipeline(
         transcript_path=str(clip_txt),
         acoustic_scene=acoustic_scene_meta,
         quality_flags=quality_flags,
+        generation_metadata=gen_meta,
     )
     label_gen.write_clip_metadata_json(metadata, clip_json)
 

--- a/synthbanshee/labels/__init__.py
+++ b/synthbanshee/labels/__init__.py
@@ -1,5 +1,5 @@
 """Label schema, auto-generator, and IAA utilities."""
 
-from synthbanshee.labels.schema import ClipMetadata, EventLabel, WeakLabel
+from synthbanshee.labels.schema import ClipMetadata, EventLabel, GenerationMetadata, WeakLabel
 
-__all__ = ["ClipMetadata", "EventLabel", "WeakLabel"]
+__all__ = ["ClipMetadata", "EventLabel", "GenerationMetadata", "WeakLabel"]

--- a/synthbanshee/labels/generator.py
+++ b/synthbanshee/labels/generator.py
@@ -21,6 +21,7 @@ from synthbanshee.labels.schema import (
     ClipAcousticScene,
     ClipMetadata,
     EventLabel,
+    GenerationMetadata,
     PreprocessingApplied,
     SpeakerInfo,
     WeakLabel,
@@ -224,6 +225,7 @@ class LabelGenerator:
         transcript_path: str | None = None,
         snr_db_estimated: float | None = None,
         quality_flags: list[str] | None = None,
+        generation_metadata: GenerationMetadata | None = None,
     ) -> ClipMetadata:
         """Build a ClipMetadata record from pipeline outputs."""
         violence_categories = sorted(
@@ -260,6 +262,7 @@ class LabelGenerator:
             dirty_file_path=dirty_file_path,
             transcript_path=transcript_path,
             quality_flags=quality_flags or [],
+            generation_metadata=generation_metadata,
         )
 
     def write_strong_labels_jsonl(self, labels: list[EventLabel], path: Path) -> None:

--- a/synthbanshee/labels/schema.py
+++ b/synthbanshee/labels/schema.py
@@ -126,6 +126,25 @@ class PreprocessingApplied(BaseModel):
     silence_padded: bool = False
 
 
+class GenerationMetadata(BaseModel):
+    """Pipeline provenance metadata for ablation studies (spec §4.11).
+
+    Captures which TTS provider, voice, SSML parameters, mixer settings,
+    preprocessing steps, and augmentation config were used to generate a clip.
+    """
+
+    pipeline_version: str
+    tts_backend: str
+    voice_family: str
+    text_normalization_version: str = ""
+    prosody_controller_version: str = ""
+    timing_controller_version: str = ""
+    mix_mode_used: str = "SEQUENTIAL"
+    normalization_strategy: str = "per_turn_rms_v1"
+    breathiness_applied: bool = False
+    speaker_state_serialized: dict[str, dict[str, float]] = Field(default_factory=dict)
+
+
 # ---------------------------------------------------------------------------
 # Per-clip metadata (one .json per clip)
 # ---------------------------------------------------------------------------
@@ -158,6 +177,7 @@ class ClipMetadata(BaseModel):
     iaa_reviewed: bool = False
     she_proves_meta: dict | None = None
     elephant_meta: dict | None = None
+    generation_metadata: GenerationMetadata | None = None
 
     @field_validator("violence_typology")
     @classmethod

--- a/synthbanshee/labels/schema.py
+++ b/synthbanshee/labels/schema.py
@@ -139,7 +139,7 @@ class GenerationMetadata(BaseModel):
     text_normalization_version: str | None = None
     prosody_controller_version: str | None = None
     timing_controller_version: str | None = None
-    mix_mode_used: str = "SEQUENTIAL"
+    mix_mode_used: str = "sequential"
     normalization_strategy: str = "per_turn_rms_v1"
     breathiness_applied: bool = False
     speaker_state_serialized: dict[str, dict[str, float]] = Field(default_factory=dict)

--- a/synthbanshee/labels/schema.py
+++ b/synthbanshee/labels/schema.py
@@ -134,11 +134,11 @@ class GenerationMetadata(BaseModel):
     """
 
     pipeline_version: str
-    tts_backend: str
-    voice_family: str
-    text_normalization_version: str = ""
-    prosody_controller_version: str = ""
-    timing_controller_version: str = ""
+    tts_backend: dict[str, str] = Field(default_factory=dict)
+    voice_family: dict[str, str] = Field(default_factory=dict)
+    text_normalization_version: str | None = None
+    prosody_controller_version: str | None = None
+    timing_controller_version: str | None = None
     mix_mode_used: str = "SEQUENTIAL"
     normalization_strategy: str = "per_turn_rms_v1"
     breathiness_applied: bool = False

--- a/synthbanshee/script/types.py
+++ b/synthbanshee/script/types.py
@@ -106,3 +106,5 @@ class MixedScene:
     rendered_offsets_s: list[float] = field(default_factory=list)
     audible_onsets_s: list[float] = field(default_factory=list)
     audible_ends_s: list[float] = field(default_factory=list)
+    # M11: per-turn MixMode values (parallel with onsets/offsets).
+    mix_modes: list[str] = field(default_factory=list)

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -121,6 +121,7 @@ class SceneMixer:
         audible_onsets: list[float] = []
         audible_ends: list[float] = []
         speaker_ids: list[str] = []
+        mix_modes: list[str] = []
 
         # render_cursor_s tracks the end of the last placed segment in buffer time.
         # script_cursor_s advances sequentially (overlap is not subtracted).
@@ -216,6 +217,7 @@ class SceneMixer:
             audible_onsets.append(onset_s)
             audible_ends.append(offset_s)
             speaker_ids.append(speaker_id)
+            mix_modes.append(mix_mode.value)
 
         # --- Build output buffer ---
         if placed:
@@ -241,4 +243,5 @@ class SceneMixer:
             rendered_offsets_s=rendered_offsets,
             audible_onsets_s=audible_onsets,
             audible_ends_s=audible_ends,
+            mix_modes=mix_modes,
         )

--- a/tests/unit/test_generation_metadata.py
+++ b/tests/unit/test_generation_metadata.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 
 from synthbanshee.labels.schema import (
     ClipMetadata,
@@ -40,14 +41,13 @@ class TestGenerationMetadata:
     """Tests for the GenerationMetadata Pydantic model."""
 
     def test_minimal_construction(self) -> None:
-        gm = GenerationMetadata(
-            pipeline_version="v3.0",
-            tts_backend="azure",
-            voice_family="he-IL-AvriNeural",
-        )
+        gm = GenerationMetadata(pipeline_version="v3.0")
         assert gm.pipeline_version == "v3.0"
-        assert gm.tts_backend == "azure"
-        assert gm.voice_family == "he-IL-AvriNeural"
+        assert gm.tts_backend == {}
+        assert gm.voice_family == {}
+        assert gm.text_normalization_version is None
+        assert gm.prosody_controller_version is None
+        assert gm.timing_controller_version is None
         assert gm.breathiness_applied is False
         assert gm.mix_mode_used == "SEQUENTIAL"
         assert gm.normalization_strategy == "per_turn_rms_v1"
@@ -57,8 +57,8 @@ class TestGenerationMetadata:
         states = {"spk_a": {"rate_offset": 0.05, "pitch_offset": 1.2, "volume_offset": 3.0}}
         gm = GenerationMetadata(
             pipeline_version="v3.0",
-            tts_backend="google",
-            voice_family="he-IL-Chirp3-HD-Aoede",
+            tts_backend={"spk_a": "google", "spk_b": "azure"},
+            voice_family={"spk_a": "he-IL-Chirp3-HD-Aoede", "spk_b": "he-IL-AvriNeural"},
             text_normalization_version="1.0",
             prosody_controller_version="1.0",
             timing_controller_version="1.0",
@@ -67,15 +67,34 @@ class TestGenerationMetadata:
             breathiness_applied=True,
             speaker_state_serialized=states,
         )
-        assert gm.tts_backend == "google"
+        assert gm.tts_backend == {"spk_a": "google", "spk_b": "azure"}
         assert gm.breathiness_applied is True
         assert gm.speaker_state_serialized["spk_a"]["pitch_offset"] == 1.2
+
+    def test_per_speaker_backend_and_voice(self) -> None:
+        """Per-speaker maps capture mixed-provider scenes (M9a)."""
+        gm = GenerationMetadata(
+            pipeline_version="v3.0",
+            tts_backend={"agg_m": "azure", "vic_f": "google"},
+            voice_family={"agg_m": "he-IL-AvriNeural", "vic_f": "he-IL-Chirp3-HD-Aoede"},
+        )
+        assert gm.tts_backend["agg_m"] == "azure"
+        assert gm.tts_backend["vic_f"] == "google"
+        assert gm.voice_family["vic_f"] == "he-IL-Chirp3-HD-Aoede"
+
+    def test_version_fields_default_to_none(self) -> None:
+        """Version fields default to None (not empty string) to distinguish
+        'not tracked' from 'tracked as empty'."""
+        gm = GenerationMetadata(pipeline_version="v3.0")
+        assert gm.text_normalization_version is None
+        assert gm.prosody_controller_version is None
+        assert gm.timing_controller_version is None
 
     def test_serialization_roundtrip(self) -> None:
         gm = GenerationMetadata(
             pipeline_version="v3.0",
-            tts_backend="azure",
-            voice_family="he-IL-AvriNeural",
+            tts_backend={"spk_a": "azure"},
+            voice_family={"spk_a": "he-IL-AvriNeural"},
             speaker_state_serialized={"spk_a": {"rate_offset": 0.1}},
         )
         raw = gm.model_dump_json()
@@ -95,20 +114,20 @@ class TestClipMetadataWithGenerationMetadata:
     def test_with_generation_metadata(self) -> None:
         gm_data = {
             "pipeline_version": "v3.0",
-            "tts_backend": "azure",
-            "voice_family": "he-IL-AvriNeural",
+            "tts_backend": {"spk_a": "azure"},
+            "voice_family": {"spk_a": "he-IL-AvriNeural"},
         }
         data = _minimal_clip_metadata(generation_metadata=gm_data)
         cm = ClipMetadata.model_validate(data)
         assert cm.generation_metadata is not None
         assert cm.generation_metadata.pipeline_version == "v3.0"
-        assert cm.generation_metadata.tts_backend == "azure"
+        assert cm.generation_metadata.tts_backend == {"spk_a": "azure"}
 
     def test_json_roundtrip_with_generation_metadata(self) -> None:
         gm = GenerationMetadata(
             pipeline_version="v3.0",
-            tts_backend="azure",
-            voice_family="he-IL-AvriNeural",
+            tts_backend={"spk_a": "azure"},
+            voice_family={"spk_a": "he-IL-AvriNeural"},
             breathiness_applied=False,
             speaker_state_serialized={"spk_a": {"rate_offset": 0.05}},
         )
@@ -125,8 +144,8 @@ class TestClipMetadataWithGenerationMetadata:
     def test_json_output_contains_generation_metadata_key(self) -> None:
         gm = GenerationMetadata(
             pipeline_version="v3.0",
-            tts_backend="azure",
-            voice_family="he-IL-AvriNeural",
+            tts_backend={"spk_a": "azure"},
+            voice_family={"spk_a": "he-IL-AvriNeural"},
         )
         data = _minimal_clip_metadata(generation_metadata=gm.model_dump())
         cm = ClipMetadata.model_validate(data)
@@ -141,3 +160,103 @@ class TestClipMetadataWithGenerationMetadata:
         # When None, the key should still appear in the output (Pydantic default)
         # but the value should be null — backward compat is about parsing, not omission.
         assert output.get("generation_metadata") is None
+
+
+class TestMixedSceneMixModes:
+    """Tests for MixedScene.mix_modes populated by SceneMixer."""
+
+    def test_mixer_populates_mix_modes(self) -> None:
+        """SceneMixer.mix_sequential must populate mix_modes on MixedScene."""
+        import io
+
+        import numpy as np
+        import soundfile as sf
+
+        from synthbanshee.tts.mix_mode import MixMode
+        from synthbanshee.tts.mixer import SceneMixer
+
+        mono = np.zeros(1600, dtype=np.float32)  # 0.1s at 16kHz
+        buf = io.BytesIO()
+        sf.write(buf, mono, 16000, format="WAV", subtype="FLOAT")
+        wav_bytes = buf.getvalue()
+
+        mixer = SceneMixer()
+        segments = [
+            (wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL),
+            (wav_bytes, 0.05, "spk_b", None, MixMode.OVERLAP),
+            (wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL),
+        ]
+        scene = mixer.mix_sequential(segments)
+        assert scene.mix_modes == ["sequential", "overlap", "sequential"]
+
+    def test_dominant_mix_mode_from_counter(self) -> None:
+        """Counter.most_common gives deterministic dominant mode."""
+        modes = ["sequential", "overlap", "sequential", "barge_in"]
+        dominant = Counter(modes).most_common(1)[0][0].upper()
+        assert dominant == "SEQUENTIAL"
+
+        modes2 = ["overlap", "overlap", "barge_in"]
+        dominant2 = Counter(modes2).most_common(1)[0][0].upper()
+        assert dominant2 == "OVERLAP"
+
+
+class TestGenerateClipMetadataWithGenMeta:
+    """Tests that LabelGenerator.generate_clip_metadata passes through generation_metadata."""
+
+    def test_passthrough(self) -> None:
+        from synthbanshee.labels.generator import LabelGenerator, ScriptEvent
+
+        gen = LabelGenerator()
+        events = [
+            ScriptEvent(
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                onset=0.0,
+                offset=1.0,
+                intensity=1,
+            ),
+        ]
+        labels = gen.generate_event_labels("test_00", events)
+        gm = GenerationMetadata(
+            pipeline_version="v3.0",
+            tts_backend={"spk_a": "azure"},
+            voice_family={"spk_a": "he-IL-AvriNeural"},
+            mix_mode_used="OVERLAP",
+        )
+        metadata = gen.generate_clip_metadata(
+            clip_id="test_00",
+            project="she_proves",
+            violence_typology="NEU",
+            tier="A",
+            duration_seconds=5.0,
+            events=labels,
+            generation_metadata=gm,
+        )
+        assert metadata.generation_metadata is not None
+        assert metadata.generation_metadata.pipeline_version == "v3.0"
+        assert metadata.generation_metadata.mix_mode_used == "OVERLAP"
+        assert metadata.generation_metadata.tts_backend == {"spk_a": "azure"}
+
+    def test_none_by_default(self) -> None:
+        from synthbanshee.labels.generator import LabelGenerator, ScriptEvent
+
+        gen = LabelGenerator()
+        events = [
+            ScriptEvent(
+                tier1_category="NONE",
+                tier2_subtype="NONE_AMBIENT",
+                onset=0.0,
+                offset=1.0,
+                intensity=1,
+            ),
+        ]
+        labels = gen.generate_event_labels("test_00", events)
+        metadata = gen.generate_clip_metadata(
+            clip_id="test_00",
+            project="she_proves",
+            violence_typology="NEU",
+            tier="A",
+            duration_seconds=5.0,
+            events=labels,
+        )
+        assert metadata.generation_metadata is None

--- a/tests/unit/test_generation_metadata.py
+++ b/tests/unit/test_generation_metadata.py
@@ -49,12 +49,19 @@ class TestGenerationMetadata:
         assert gm.prosody_controller_version is None
         assert gm.timing_controller_version is None
         assert gm.breathiness_applied is False
-        assert gm.mix_mode_used == "SEQUENTIAL"
+        assert gm.mix_mode_used == "sequential"
         assert gm.normalization_strategy == "per_turn_rms_v1"
         assert gm.speaker_state_serialized == {}
 
     def test_full_construction(self) -> None:
-        states = {"spk_a": {"rate_offset": 0.05, "pitch_offset": 1.2, "volume_offset": 3.0}}
+        states = {
+            "spk_a": {
+                "rate_offset": 1.05,
+                "pitch_offset_st": 1.2,
+                "volume_offset_db": 3.0,
+                "breathiness_level": 0.0,
+            }
+        }
         gm = GenerationMetadata(
             pipeline_version="v3.0",
             tts_backend={"spk_a": "google", "spk_b": "azure"},
@@ -62,14 +69,14 @@ class TestGenerationMetadata:
             text_normalization_version="1.0",
             prosody_controller_version="1.0",
             timing_controller_version="1.0",
-            mix_mode_used="OVERLAP",
+            mix_mode_used="overlap",
             normalization_strategy="per_turn_rms_v1",
             breathiness_applied=True,
             speaker_state_serialized=states,
         )
         assert gm.tts_backend == {"spk_a": "google", "spk_b": "azure"}
         assert gm.breathiness_applied is True
-        assert gm.speaker_state_serialized["spk_a"]["pitch_offset"] == 1.2
+        assert gm.speaker_state_serialized["spk_a"]["pitch_offset_st"] == 1.2
 
     def test_per_speaker_backend_and_voice(self) -> None:
         """Per-speaker maps capture mixed-provider scenes (M9a)."""
@@ -153,13 +160,13 @@ class TestClipMetadataWithGenerationMetadata:
         assert "generation_metadata" in output
         assert output["generation_metadata"]["pipeline_version"] == "v3.0"
 
-    def test_json_output_omits_generation_metadata_when_none(self) -> None:
+    def test_generation_metadata_null_when_not_provided(self) -> None:
+        """When generation_metadata is not set, the key serializes as null."""
         data = _minimal_clip_metadata()
         cm = ClipMetadata.model_validate(data)
         output = json.loads(cm.model_dump_json())
-        # When None, the key should still appear in the output (Pydantic default)
-        # but the value should be null — backward compat is about parsing, not omission.
-        assert output.get("generation_metadata") is None
+        assert "generation_metadata" in output
+        assert output["generation_metadata"] is None
 
 
 class TestMixedSceneMixModes:
@@ -192,12 +199,12 @@ class TestMixedSceneMixModes:
     def test_dominant_mix_mode_from_counter(self) -> None:
         """Counter.most_common gives deterministic dominant mode."""
         modes = ["sequential", "overlap", "sequential", "barge_in"]
-        dominant = Counter(modes).most_common(1)[0][0].upper()
-        assert dominant == "SEQUENTIAL"
+        dominant = Counter(modes).most_common(1)[0][0]
+        assert dominant == "sequential"
 
         modes2 = ["overlap", "overlap", "barge_in"]
-        dominant2 = Counter(modes2).most_common(1)[0][0].upper()
-        assert dominant2 == "OVERLAP"
+        dominant2 = Counter(modes2).most_common(1)[0][0]
+        assert dominant2 == "overlap"
 
 
 class TestGenerateClipMetadataWithGenMeta:
@@ -221,7 +228,7 @@ class TestGenerateClipMetadataWithGenMeta:
             pipeline_version="v3.0",
             tts_backend={"spk_a": "azure"},
             voice_family={"spk_a": "he-IL-AvriNeural"},
-            mix_mode_used="OVERLAP",
+            mix_mode_used="overlap",
         )
         metadata = gen.generate_clip_metadata(
             clip_id="test_00",
@@ -234,7 +241,7 @@ class TestGenerateClipMetadataWithGenMeta:
         )
         assert metadata.generation_metadata is not None
         assert metadata.generation_metadata.pipeline_version == "v3.0"
-        assert metadata.generation_metadata.mix_mode_used == "OVERLAP"
+        assert metadata.generation_metadata.mix_mode_used == "overlap"
         assert metadata.generation_metadata.tts_backend == {"spk_a": "azure"}
 
     def test_none_by_default(self) -> None:

--- a/tests/unit/test_generation_metadata.py
+++ b/tests/unit/test_generation_metadata.py
@@ -1,0 +1,143 @@
+"""Unit tests for GenerationMetadata (M11 — spec §4.11)."""
+
+from __future__ import annotations
+
+import json
+
+from synthbanshee.labels.schema import (
+    ClipMetadata,
+    GenerationMetadata,
+)
+
+
+def _minimal_clip_metadata(**overrides) -> dict:
+    """Return a minimal valid ClipMetadata dict for testing."""
+    base = {
+        "clip_id": "test_clip_00",
+        "project": "she_proves",
+        "language": "he",
+        "violence_typology": "NEU",
+        "tier": "A",
+        "duration_seconds": 5.0,
+        "sample_rate": 16000,
+        "channels": 1,
+        "generation_date": "2026-05-01",
+        "generator_version": "0.1.0",
+        "is_synthetic": True,
+        "tts_engine": "azure_he_IL",
+        "weak_label": {
+            "has_violence": False,
+            "violence_categories": [],
+            "max_intensity": 1,
+            "violence_typology": "NEU",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+class TestGenerationMetadata:
+    """Tests for the GenerationMetadata Pydantic model."""
+
+    def test_minimal_construction(self) -> None:
+        gm = GenerationMetadata(
+            pipeline_version="v3.0",
+            tts_backend="azure",
+            voice_family="he-IL-AvriNeural",
+        )
+        assert gm.pipeline_version == "v3.0"
+        assert gm.tts_backend == "azure"
+        assert gm.voice_family == "he-IL-AvriNeural"
+        assert gm.breathiness_applied is False
+        assert gm.mix_mode_used == "SEQUENTIAL"
+        assert gm.normalization_strategy == "per_turn_rms_v1"
+        assert gm.speaker_state_serialized == {}
+
+    def test_full_construction(self) -> None:
+        states = {"spk_a": {"rate_offset": 0.05, "pitch_offset": 1.2, "volume_offset": 3.0}}
+        gm = GenerationMetadata(
+            pipeline_version="v3.0",
+            tts_backend="google",
+            voice_family="he-IL-Chirp3-HD-Aoede",
+            text_normalization_version="1.0",
+            prosody_controller_version="1.0",
+            timing_controller_version="1.0",
+            mix_mode_used="OVERLAP",
+            normalization_strategy="per_turn_rms_v1",
+            breathiness_applied=True,
+            speaker_state_serialized=states,
+        )
+        assert gm.tts_backend == "google"
+        assert gm.breathiness_applied is True
+        assert gm.speaker_state_serialized["spk_a"]["pitch_offset"] == 1.2
+
+    def test_serialization_roundtrip(self) -> None:
+        gm = GenerationMetadata(
+            pipeline_version="v3.0",
+            tts_backend="azure",
+            voice_family="he-IL-AvriNeural",
+            speaker_state_serialized={"spk_a": {"rate_offset": 0.1}},
+        )
+        raw = gm.model_dump_json()
+        restored = GenerationMetadata.model_validate_json(raw)
+        assert restored == gm
+
+
+class TestClipMetadataWithGenerationMetadata:
+    """Tests for ClipMetadata backward compatibility with generation_metadata."""
+
+    def test_backward_compat_no_generation_metadata(self) -> None:
+        """Existing V1 clips without generation_metadata must still validate."""
+        data = _minimal_clip_metadata()
+        cm = ClipMetadata.model_validate(data)
+        assert cm.generation_metadata is None
+
+    def test_with_generation_metadata(self) -> None:
+        gm_data = {
+            "pipeline_version": "v3.0",
+            "tts_backend": "azure",
+            "voice_family": "he-IL-AvriNeural",
+        }
+        data = _minimal_clip_metadata(generation_metadata=gm_data)
+        cm = ClipMetadata.model_validate(data)
+        assert cm.generation_metadata is not None
+        assert cm.generation_metadata.pipeline_version == "v3.0"
+        assert cm.generation_metadata.tts_backend == "azure"
+
+    def test_json_roundtrip_with_generation_metadata(self) -> None:
+        gm = GenerationMetadata(
+            pipeline_version="v3.0",
+            tts_backend="azure",
+            voice_family="he-IL-AvriNeural",
+            breathiness_applied=False,
+            speaker_state_serialized={"spk_a": {"rate_offset": 0.05}},
+        )
+        data = _minimal_clip_metadata(generation_metadata=gm.model_dump())
+        cm = ClipMetadata.model_validate(data)
+        raw_json = cm.model_dump_json(indent=2)
+        restored = ClipMetadata.model_validate_json(raw_json)
+        assert restored.generation_metadata is not None
+        assert restored.generation_metadata.pipeline_version == "v3.0"
+        assert restored.generation_metadata.speaker_state_serialized == {
+            "spk_a": {"rate_offset": 0.05}
+        }
+
+    def test_json_output_contains_generation_metadata_key(self) -> None:
+        gm = GenerationMetadata(
+            pipeline_version="v3.0",
+            tts_backend="azure",
+            voice_family="he-IL-AvriNeural",
+        )
+        data = _minimal_clip_metadata(generation_metadata=gm.model_dump())
+        cm = ClipMetadata.model_validate(data)
+        output = json.loads(cm.model_dump_json())
+        assert "generation_metadata" in output
+        assert output["generation_metadata"]["pipeline_version"] == "v3.0"
+
+    def test_json_output_omits_generation_metadata_when_none(self) -> None:
+        data = _minimal_clip_metadata()
+        cm = ClipMetadata.model_validate(data)
+        output = json.loads(cm.model_dump_json())
+        # When None, the key should still appear in the output (Pydantic default)
+        # but the value should be null — backward compat is about parsing, not omission.
+        assert output.get("generation_metadata") is None


### PR DESCRIPTION
## Summary

- Adds `GenerationMetadata` Pydantic model (spec §4.11) capturing per-clip pipeline provenance: TTS backend, voice family, mix mode, normalization strategy, breathiness flag, and final speaker state snapshots
- Wires it into `ClipMetadata` as an optional `generation_metadata` field, written to `{clip_id}.json`
- Backward-compatible: existing V1 clips without the key still validate (field defaults to `None`)

## Changes

| File | Change |
|------|--------|
| `synthbanshee/labels/schema.py` | New `GenerationMetadata` model; optional field on `ClipMetadata` |
| `synthbanshee/labels/generator.py` | `generate_clip_metadata()` accepts and passes through `generation_metadata` |
| `synthbanshee/labels/__init__.py` | Export `GenerationMetadata` |
| `synthbanshee/cli.py` | Build `GenerationMetadata` from pipeline state (TTS backend, voice family, speaker states) and attach to clip metadata |
| `tests/unit/test_generation_metadata.py` | 8 unit tests: model construction, serialization roundtrip, backward compat, JSON output |

## Test plan

- [x] `pytest tests/unit/test_generation_metadata.py` — 8/8 passed
- [x] `pytest tests/unit/` — 1264/1264 passed
- [x] `ruff check` — all passed
- [x] `mypy synthbanshee/` — no new errors (pre-existing errors in `script/generator.py` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)