### PR TITLE
feat(m13): project-specific default profiles

### DIFF
--- a/configs/run_configs/profile_elephant.yaml
+++ b/configs/run_configs/profile_elephant.yaml
@@ -1,0 +1,44 @@
+# Project profile: Elephant in the Room
+# Workplace / institutional violence detection — pi-based clinic/office recording.
+# Optimizes for high precision and low false alarms.
+# Scene length: 1-4 min | Device: pi_budget_mic
+# Room types: clinic_office, welfare_office, open_office | Alert in final 40%
+
+name: elephant
+description: >-
+  Elephant in the Room institutional violence detection project.
+  Shorter scenes (1-4 min) with Raspberry Pi mic in clinical/office settings.
+  Tuned for high precision and low false alarms.
+
+# Inter-turn gap timing (seconds) — tighter ranges reflecting professional settings.
+gap_timing:
+  vic_low:   {lo: 0.25, hi: 0.50}   # VIC responds to AGG at I1-I2
+  vic_i3:    {lo: 0.10, hi: 0.30}   # VIC responds to AGG accusation at I3
+  vic_i4:    {lo: 0.05, hi: 0.10}   # VIC responds to AGG command at I4
+  vic_i5:    {lo: 0.08, hi: 0.20}   # VIC responds to AGG threat at I5
+  agg_low:   {lo: 0.15, hi: 0.40}   # AGG turn at I1-I2 (normal)
+  agg_high:  {lo: 0.05, hi: 0.15}   # AGG turn at I3-I5 (cutting in)
+  agg_pause: {lo: 0.50, hi: 1.20}   # AGG deliberate menacing self-pause at I4-I5
+
+# Overlap / barge-in probabilities — slightly lower for institutional settings
+overlap:
+  agg_pause_prob: 0.25
+
+# Default loudness targets (dBFS) per role — slightly louder (closer mic placement)
+loudness:
+  agg_rms_dbfs: -18.0
+  vic_rms_dbfs: -22.0
+
+# Preprocessing defaults
+preprocessing:
+  wiener_denoise: false
+
+# Acoustic augmentation defaults (Tier B/C)
+acoustic:
+  snr_target_db: 24.0
+  preferred_devices:
+    - pi_budget_mic
+  preferred_room_types:
+    - clinic_office
+    - welfare_office
+    - open_office_corridor

--- a/configs/run_configs/profile_she_proves.yaml
+++ b/configs/run_configs/profile_she_proves.yaml
@@ -1,0 +1,46 @@
+# Project profile: She-Proves
+# Domestic violence detection — phone-recorded apartment confrontations.
+# Optimizes for high recall and incident window detection.
+# Scene length: 3-6 min | Device: phone_in_pocket / _on_table / _in_hand
+# Room types: apartment rooms | >= 60% pre-incident
+
+name: she_proves
+description: >-
+  She-Proves domestic violence detection project.
+  Longer scenes (3-6 min) with phone-based recording in apartment settings.
+  Tuned for high recall and incident window detection.
+
+# Inter-turn gap timing (seconds) — psychologically-motivated ranges per context.
+gap_timing:
+  vic_low:   {lo: 0.30, hi: 0.60}   # VIC responds to AGG at I1-I2
+  vic_i3:    {lo: 0.15, hi: 0.35}   # VIC responds to AGG accusation at I3
+  vic_i4:    {lo: 0.05, hi: 0.15}   # VIC responds to AGG command at I4
+  vic_i5:    {lo: 0.10, hi: 0.30}   # VIC responds to AGG threat at I5
+  agg_low:   {lo: 0.20, hi: 0.50}   # AGG turn at I1-I2 (normal)
+  agg_high:  {lo: 0.05, hi: 0.20}   # AGG turn at I3-I5 (cutting in)
+  agg_pause: {lo: 0.60, hi: 1.40}   # AGG deliberate menacing self-pause at I4-I5
+
+# Overlap / barge-in probabilities
+overlap:
+  agg_pause_prob: 0.30
+
+# Default loudness targets (dBFS) per role
+loudness:
+  agg_rms_dbfs: -20.0
+  vic_rms_dbfs: -24.0
+
+# Preprocessing defaults
+preprocessing:
+  wiener_denoise: false
+
+# Acoustic augmentation defaults (Tier B/C)
+acoustic:
+  snr_target_db: 18.0
+  preferred_devices:
+    - phone_in_hand
+    - phone_in_pocket
+    - phone_on_table
+  preferred_room_types:
+    - small_bedroom
+    - apartment_kitchen
+    - living_room

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -1099,7 +1099,11 @@ def generate_batch(
     # M13: load the project profile for this run.
     profile: ProjectProfile | None = None
     if run_cfg.project_profile != "generic":
-        profile = run_cfg.resolved_profile()
+        try:
+            profile = run_cfg.resolved_profile()
+        except (FileNotFoundError, Exception) as exc:
+            console.print(f"[bold red]Failed to load project profile:[/bold red] {exc}")
+            sys.exit(1)
         console.print(f"[cyan]Project profile:[/cyan] {profile.name} — {profile.description}")
     console.print(
         Panel(

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -187,6 +187,7 @@ def _run_generate_pipeline(
     script_cache_dir: Path,
     verbose: bool = False,
     speaker_overrides: dict[str, str] | None = None,
+    project_profile: object | None = None,
 ) -> tuple[Path | None, list[str]]:
     """Run the full single-clip generate pipeline.
 
@@ -304,6 +305,7 @@ def _run_generate_pipeline(
             rng_seed=scene.random_seed,
             verbose_log=vlog if verbose else None,
             project=scene.project,
+            project_profile=project_profile,
         )
     except Exception as exc:
         return None, [f"TTS render error: {exc}"]
@@ -327,7 +329,11 @@ def _run_generate_pipeline(
             # gain are preserved exactly; preprocess() peak-limits any
             # over-range peaks and then writes the final PCM_16 output safely.
             sf.write(str(raw_wav), mixed.samples, mixed.sample_rate, subtype="FLOAT")
-            result = preprocess(raw_wav, clip_wav, dirty_dir=dirty_dir, config=scene.preprocessing)
+            # M13: apply profile preprocessing defaults when scene has no override.
+            preproc_config = scene.preprocessing
+            if preproc_config is None and project_profile is not None:
+                preproc_config = getattr(project_profile, "preprocessing", None)
+            result = preprocess(raw_wav, clip_wav, dirty_dir=dirty_dir, config=preproc_config)
     except Exception as exc:
         return None, [f"Pipeline error: {exc}"]
 
@@ -912,6 +918,7 @@ def _render_one(
     stop_event: threading.Event,
     verbose: bool = False,
     speaker_overrides: dict[str, str] | None = None,
+    project_profile: object | None = None,
 ) -> tuple[Path | None, list[str]]:
     """Render a single clip with retries.
 
@@ -937,6 +944,7 @@ def _render_one(
             script_cache_dir,
             verbose=verbose,
             speaker_overrides=speaker_overrides,
+            project_profile=project_profile,
         )
         if wav_path is not None:
             return wav_path, messages
@@ -1042,12 +1050,19 @@ def generate_batch(
     per-typology count limits, renders each clip, assigns speaker-disjoint
     splits, and writes a manifest CSV.
     """
+    from synthbanshee.config.project_profile import ProjectProfile
     from synthbanshee.config.run_config import RunConfig
     from synthbanshee.package.manifest import generate_manifest
     from synthbanshee.package.splitter import assign_splits
 
     console.print(f"[bold]Loading run config:[/bold] {run_config}")
     run_cfg = RunConfig.from_yaml(run_config)
+
+    # M13: load the project profile for this run.
+    profile: ProjectProfile | None = None
+    if run_cfg.project_profile != "generic":
+        profile = run_cfg.resolved_profile()
+        console.print(f"[cyan]Project profile:[/cyan] {profile.name} — {profile.description}")
     console.print(
         Panel(
             f"Run: [bold]{run_cfg.run_id}[/bold]  "
@@ -1137,6 +1152,7 @@ def generate_batch(
                     _no_stop,
                     verbose=verbose,
                     speaker_overrides=speaker_override_map.get(scene_yaml),
+                    project_profile=profile,
                 )
                 progress.advance(task_id)
                 if wav_path is None:
@@ -1169,6 +1185,7 @@ def generate_batch(
                         stop_event,
                         verbose,
                         speaker_override_map.get(scene_yaml),
+                        profile,
                     ): scene_yaml
                     for scene_yaml in selected
                 }

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -16,6 +16,10 @@ import tempfile
 import threading
 from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from synthbanshee.config.project_profile import ProjectProfile
 
 import click
 from rich.console import Console
@@ -187,7 +191,7 @@ def _run_generate_pipeline(
     script_cache_dir: Path,
     verbose: bool = False,
     speaker_overrides: dict[str, str] | None = None,
-    project_profile: object | None = None,
+    project_profile: ProjectProfile | None = None,
 ) -> tuple[Path | None, list[str]]:
     """Run the full single-clip generate pipeline.
 
@@ -353,6 +357,17 @@ def _run_generate_pipeline(
     # (This differs from the AugmentedEvent docstring convention, which assumes
     # NoiseMixer receives the raw un-padded MixedScene.  Here we pass padded audio
     # intentionally so the placed events align with audible speech, not with silence.)
+    # M13: apply profile acoustic defaults to the scene's acoustic config.
+    # The profile provides a project-appropriate SNR target (e.g. 18 dB for
+    # She-Proves, 24 dB for Elephant) that replaces the generic Pydantic
+    # default (20.0 dB) when the scene YAML didn't set snr_target_db.
+    if (
+        project_profile is not None
+        and scene.acoustic_scene is not None
+        and scene.acoustic_scene.snr_target_db == 20.0  # still at generic default
+    ):
+        scene.acoustic_scene.snr_target_db = project_profile.acoustic.snr_target_db
+
     acoustic_scene_meta = None
     _aug_acou_events: list = []  # ACOU_* SFX events for strong-label generation
     if scene.tier in ("B", "C") and scene.acoustic_scene is not None:
@@ -689,6 +704,16 @@ def cli() -> None:
     help="Parse and validate config only; do not render.",
 )
 @click.option(
+    "--project-profile",
+    "-p",
+    type=str,
+    default=None,
+    help=(
+        "Project profile name (e.g. 'she_proves', 'elephant'). "
+        "Loads defaults from configs/run_configs/profile_<name>.yaml."
+    ),
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -702,9 +727,11 @@ def generate(
     dirty_dir: Path,
     script_cache_dir: Path,
     dry_run: bool,
+    project_profile: str | None,
     verbose: bool,
 ) -> None:
     """Generate a synthetic clip from a scene YAML config."""
+    from synthbanshee.config.project_profile import load_profile
     from synthbanshee.config.scene_config import SceneConfig
 
     console.print(f"[bold]Loading config:[/bold] {config}")
@@ -723,11 +750,23 @@ def generate(
         console.print("[green]Dry run — config is valid. Exiting.[/green]")
         return
 
+    # M13: load profile if specified.
+    profile = None
+    if project_profile is not None:
+        profile = load_profile(project_profile)
+        console.print(f"[cyan]Project profile:[/cyan] {profile.name} — {profile.description}")
+
     out_dir = Path(output_dir or scene.output_dir)
 
     console.print("[cyan]Running generate pipeline...[/cyan]")
     wav_path, messages = _run_generate_pipeline(
-        config, out_dir, cache_dir, dirty_dir, script_cache_dir, verbose=verbose
+        config,
+        out_dir,
+        cache_dir,
+        dirty_dir,
+        script_cache_dir,
+        verbose=verbose,
+        project_profile=profile,
     )
 
     if wav_path is None:
@@ -918,7 +957,7 @@ def _render_one(
     stop_event: threading.Event,
     verbose: bool = False,
     speaker_overrides: dict[str, str] | None = None,
-    project_profile: object | None = None,
+    project_profile: ProjectProfile | None = None,
 ) -> tuple[Path | None, list[str]]:
     """Render a single clip with retries.
 
@@ -1050,7 +1089,6 @@ def generate_batch(
     per-typology count limits, renders each clip, assigns speaker-disjoint
     splits, and writes a manifest CSV.
     """
-    from synthbanshee.config.project_profile import ProjectProfile
     from synthbanshee.config.run_config import RunConfig
     from synthbanshee.package.manifest import generate_manifest
     from synthbanshee.package.splitter import assign_splits

--- a/synthbanshee/config/__init__.py
+++ b/synthbanshee/config/__init__.py
@@ -1,6 +1,7 @@
 """Config schema and validation for the AVDP pipeline."""
 
 from synthbanshee.config.acoustic_config import AcousticSceneConfig, BackgroundEvent
+from synthbanshee.config.project_profile import ProjectProfile, load_profile
 from synthbanshee.config.run_config import RunConfig, SplitFractions, TypologyTarget
 from synthbanshee.config.scene_config import SceneConfig
 from synthbanshee.config.speaker_config import SpeakerConfig
@@ -9,10 +10,12 @@ from synthbanshee.config.taxonomy import load_taxonomy
 __all__ = [
     "AcousticSceneConfig",
     "BackgroundEvent",
+    "ProjectProfile",
     "RunConfig",
     "SceneConfig",
     "SpeakerConfig",
     "SplitFractions",
     "TypologyTarget",
+    "load_profile",
     "load_taxonomy",
 ]

--- a/synthbanshee/config/project_profile.py
+++ b/synthbanshee/config/project_profile.py
@@ -1,0 +1,168 @@
+"""Pydantic model for project-specific default profiles (milestone M13).
+
+A project profile defines default values for gap timing, overlap probabilities,
+loudness targets, preprocessing config, and acoustic augmentation defaults.
+Profiles are loaded from YAML files in ``configs/run_configs/`` and new profiles
+can be added without code changes.
+
+Spec reference: docs/audio_generation_v3_design.md §M13
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+from synthbanshee.config.preprocessing_config import PreprocessingConfig
+
+# Default search directory for profile YAML files.
+_PROFILE_DIR = Path("configs/run_configs")
+
+
+class GapRange(BaseModel):
+    """Min/max gap duration in seconds for a single context key."""
+
+    lo: float = Field(ge=0.0)
+    hi: float = Field(ge=0.0)
+
+
+class GapTimingDefaults(BaseModel):
+    """Project-specific gap timing table.
+
+    Keys match the context keys used by ``TurnGapController``:
+    vic_low, vic_i3, vic_i4, vic_i5, agg_low, agg_high, agg_pause.
+    """
+
+    vic_low: GapRange = GapRange(lo=0.30, hi=0.60)
+    vic_i3: GapRange = GapRange(lo=0.15, hi=0.35)
+    vic_i4: GapRange = GapRange(lo=0.05, hi=0.15)
+    vic_i5: GapRange = GapRange(lo=0.10, hi=0.30)
+    agg_low: GapRange = GapRange(lo=0.20, hi=0.50)
+    agg_high: GapRange = GapRange(lo=0.05, hi=0.20)
+    agg_pause: GapRange = GapRange(lo=0.60, hi=1.40)
+
+    def to_table(self) -> dict[str, tuple[float, float]]:
+        """Convert to the ``{context_key: (lo, hi)}`` dict used by the gap controller."""
+        return {
+            key: (getattr(self, key).lo, getattr(self, key).hi)
+            for key in (
+                "vic_low",
+                "vic_i3",
+                "vic_i4",
+                "vic_i5",
+                "agg_low",
+                "agg_high",
+                "agg_pause",
+            )
+        }
+
+
+class OverlapDefaults(BaseModel):
+    """Project-specific overlap and barge-in probability defaults."""
+
+    agg_pause_prob: float = Field(default=0.30, ge=0.0, le=1.0)
+
+
+class LoudnessDefaults(BaseModel):
+    """Default RMS loudness targets per role (dBFS)."""
+
+    agg_rms_dbfs: float = Field(default=-20.0, ge=-60.0, le=0.0)
+    vic_rms_dbfs: float = Field(default=-24.0, ge=-60.0, le=0.0)
+
+
+class AcousticDefaults(BaseModel):
+    """Default acoustic augmentation parameters for Tier B/C scenes."""
+
+    snr_target_db: float = 20.0
+    preferred_devices: list[str] = Field(default_factory=list)
+    preferred_room_types: list[str] = Field(default_factory=list)
+
+
+class ProjectProfile(BaseModel):
+    """Project-specific default profile.
+
+    Loaded from a YAML file in ``configs/run_configs/``.  Each field provides
+    a default value layer that applies when no per-scene override is given.
+    """
+
+    name: str
+    description: str = ""
+    gap_timing: GapTimingDefaults = Field(default_factory=GapTimingDefaults)
+    overlap: OverlapDefaults = Field(default_factory=OverlapDefaults)
+    loudness: LoudnessDefaults = Field(default_factory=LoudnessDefaults)
+    preprocessing: PreprocessingConfig = Field(default_factory=PreprocessingConfig)
+    acoustic: AcousticDefaults = Field(default_factory=AcousticDefaults)
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> ProjectProfile:
+        with Path(path).open("r", encoding="utf-8") as fh:
+            return cls.model_validate(yaml.safe_load(fh))
+
+
+# ---- Profile registry (data-driven, no hardcoded profile names) ----
+
+_profile_cache: dict[str, ProjectProfile] = {}
+
+
+def _discover_profiles(profile_dir: Path) -> dict[str, Path]:
+    """Scan *profile_dir* for ``profile_*.yaml`` files.
+
+    Returns ``{profile_name: path}`` where *profile_name* is the filename stem
+    with the ``profile_`` prefix stripped (e.g. ``profile_she_proves.yaml`` →
+    ``"she_proves"``).
+    """
+    result: dict[str, Path] = {}
+    if not profile_dir.is_dir():
+        return result
+    for p in sorted(profile_dir.glob("profile_*.yaml")):
+        name = p.stem.removeprefix("profile_")
+        result[name] = p
+    return result
+
+
+def load_profile(
+    name: str,
+    *,
+    profile_dir: Path = _PROFILE_DIR,
+    extra: dict[str, Any] | None = None,
+) -> ProjectProfile:
+    """Load a project profile by name.
+
+    Args:
+        name: Profile name (e.g. ``"she_proves"``, ``"elephant"``).
+            ``"generic"`` returns a default ``ProjectProfile`` with framework
+            defaults (no YAML file required).
+        profile_dir: Directory to search for ``profile_<name>.yaml``.
+        extra: Optional dict merged on top of the loaded YAML data (useful
+            for RunConfig-level overrides).
+
+    Raises:
+        FileNotFoundError: If no matching profile YAML exists and *name* is
+            not ``"generic"``.
+    """
+    if name == "generic":
+        return ProjectProfile(name="generic", description="Framework defaults")
+
+    cache_key = f"{profile_dir}::{name}"
+    if cache_key in _profile_cache:
+        return _profile_cache[cache_key]
+
+    available = _discover_profiles(profile_dir)
+    if name not in available:
+        raise FileNotFoundError(
+            f"No profile YAML for {name!r} in {profile_dir}. "
+            f"Available: {sorted(available) or '(none)'}. "
+            f"Expected file: profile_{name}.yaml"
+        )
+
+    profile = ProjectProfile.from_yaml(available[name])
+    _profile_cache[cache_key] = profile
+    return profile
+
+
+def clear_profile_cache() -> None:
+    """Clear the in-memory profile cache (useful for testing)."""
+    _profile_cache.clear()

--- a/synthbanshee/config/project_profile.py
+++ b/synthbanshee/config/project_profile.py
@@ -10,8 +10,8 @@ Spec reference: docs/audio_generation_v3_design.md §M13
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
-from typing import Any
 
 import yaml
 from pydantic import BaseModel, Field
@@ -34,30 +34,20 @@ class GapTimingDefaults(BaseModel):
 
     Keys match the context keys used by ``TurnGapController``:
     vic_low, vic_i3, vic_i4, vic_i5, agg_low, agg_high, agg_pause.
+
+    All fields are required — the profile YAML is the single source of truth
+    for gap timing when a profile is active.  The hardcoded tables in
+    ``gap_controller.py`` are legacy fallbacks used only when no profile is
+    provided (backward compatibility for programmatic callers).
     """
 
-    vic_low: GapRange = GapRange(lo=0.30, hi=0.60)
-    vic_i3: GapRange = GapRange(lo=0.15, hi=0.35)
-    vic_i4: GapRange = GapRange(lo=0.05, hi=0.15)
-    vic_i5: GapRange = GapRange(lo=0.10, hi=0.30)
-    agg_low: GapRange = GapRange(lo=0.20, hi=0.50)
-    agg_high: GapRange = GapRange(lo=0.05, hi=0.20)
-    agg_pause: GapRange = GapRange(lo=0.60, hi=1.40)
-
-    def to_table(self) -> dict[str, tuple[float, float]]:
-        """Convert to the ``{context_key: (lo, hi)}`` dict used by the gap controller."""
-        return {
-            key: (getattr(self, key).lo, getattr(self, key).hi)
-            for key in (
-                "vic_low",
-                "vic_i3",
-                "vic_i4",
-                "vic_i5",
-                "agg_low",
-                "agg_high",
-                "agg_pause",
-            )
-        }
+    vic_low: GapRange
+    vic_i3: GapRange
+    vic_i4: GapRange
+    vic_i5: GapRange
+    agg_low: GapRange
+    agg_high: GapRange
+    agg_pause: GapRange
 
 
 class OverlapDefaults(BaseModel):
@@ -90,7 +80,7 @@ class ProjectProfile(BaseModel):
 
     name: str
     description: str = ""
-    gap_timing: GapTimingDefaults = Field(default_factory=GapTimingDefaults)
+    gap_timing: GapTimingDefaults
     overlap: OverlapDefaults = Field(default_factory=OverlapDefaults)
     loudness: LoudnessDefaults = Field(default_factory=LoudnessDefaults)
     preprocessing: PreprocessingConfig = Field(default_factory=PreprocessingConfig)
@@ -105,6 +95,7 @@ class ProjectProfile(BaseModel):
 # ---- Profile registry (data-driven, no hardcoded profile names) ----
 
 _profile_cache: dict[str, ProjectProfile] = {}
+_profile_cache_lock = threading.Lock()
 
 
 def _discover_profiles(profile_dir: Path) -> dict[str, Path]:
@@ -127,7 +118,6 @@ def load_profile(
     name: str,
     *,
     profile_dir: Path = _PROFILE_DIR,
-    extra: dict[str, Any] | None = None,
 ) -> ProjectProfile:
     """Load a project profile by name.
 
@@ -136,19 +126,30 @@ def load_profile(
             ``"generic"`` returns a default ``ProjectProfile`` with framework
             defaults (no YAML file required).
         profile_dir: Directory to search for ``profile_<name>.yaml``.
-        extra: Optional dict merged on top of the loaded YAML data (useful
-            for RunConfig-level overrides).
 
     Raises:
         FileNotFoundError: If no matching profile YAML exists and *name* is
             not ``"generic"``.
     """
     if name == "generic":
-        return ProjectProfile(name="generic", description="Framework defaults")
+        return ProjectProfile(
+            name="generic",
+            description="Framework defaults",
+            gap_timing=GapTimingDefaults(
+                vic_low=GapRange(lo=0.30, hi=0.60),
+                vic_i3=GapRange(lo=0.15, hi=0.35),
+                vic_i4=GapRange(lo=0.05, hi=0.15),
+                vic_i5=GapRange(lo=0.10, hi=0.30),
+                agg_low=GapRange(lo=0.20, hi=0.50),
+                agg_high=GapRange(lo=0.05, hi=0.20),
+                agg_pause=GapRange(lo=0.60, hi=1.40),
+            ),
+        )
 
     cache_key = f"{profile_dir}::{name}"
-    if cache_key in _profile_cache:
-        return _profile_cache[cache_key]
+    with _profile_cache_lock:
+        if cache_key in _profile_cache:
+            return _profile_cache[cache_key]
 
     available = _discover_profiles(profile_dir)
     if name not in available:
@@ -159,10 +160,12 @@ def load_profile(
         )
 
     profile = ProjectProfile.from_yaml(available[name])
-    _profile_cache[cache_key] = profile
+    with _profile_cache_lock:
+        _profile_cache[cache_key] = profile
     return profile
 
 
 def clear_profile_cache() -> None:
     """Clear the in-memory profile cache (useful for testing)."""
-    _profile_cache.clear()
+    with _profile_cache_lock:
+        _profile_cache.clear()

--- a/synthbanshee/config/project_profile.py
+++ b/synthbanshee/config/project_profile.py
@@ -14,7 +14,7 @@ import threading
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from synthbanshee.config.preprocessing_config import PreprocessingConfig
 
@@ -27,6 +27,12 @@ class GapRange(BaseModel):
 
     lo: float = Field(ge=0.0)
     hi: float = Field(ge=0.0)
+
+    @model_validator(mode="after")
+    def lo_le_hi(self) -> GapRange:
+        if self.lo > self.hi:
+            raise ValueError(f"GapRange lo ({self.lo}) must be <= hi ({self.hi})")
+        return self
 
 
 class GapTimingDefaults(BaseModel):

--- a/synthbanshee/config/run_config.py
+++ b/synthbanshee/config/run_config.py
@@ -17,6 +17,7 @@ from typing import Literal, Self
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from synthbanshee.config.project_profile import ProjectProfile, load_profile
 from synthbanshee.config.taxonomy import violence_typology_codes
 
 _VALID_PROJECTS = {"she_proves", "elephant_in_the_room"}
@@ -71,6 +72,7 @@ class RunConfig(BaseModel):
     splits: SplitFractions = Field(default_factory=SplitFractions)
     max_retries: int = Field(default=3, ge=1)
     fail_fast: bool = False
+    project_profile: str = "generic"
 
     @field_validator("project")
     @classmethod
@@ -87,6 +89,10 @@ class RunConfig(BaseModel):
     def targets_by_typology(self) -> dict[str, int]:
         """Return {violence_typology: count} for all targets."""
         return {t.violence_typology: t.count for t in self.targets}
+
+    def resolved_profile(self) -> ProjectProfile:
+        """Load and return the ``ProjectProfile`` for this run's ``project_profile``."""
+        return load_profile(self.project_profile)
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> Self:

--- a/synthbanshee/tts/gap_controller.py
+++ b/synthbanshee/tts/gap_controller.py
@@ -21,10 +21,13 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from synthbanshee.script.types import DialogueTurn
 from synthbanshee.tts.mix_mode import MixMode
+
+if TYPE_CHECKING:
+    from synthbanshee.config.project_profile import ProjectProfile
 
 
 class _GapRange(NamedTuple):
@@ -35,7 +38,12 @@ class _GapRange(NamedTuple):
 
 
 # ---------------------------------------------------------------------------
-# Project-specific gap tables
+# Legacy project-specific gap tables (fallback when no ProjectProfile is provided)
+#
+# When a ProjectProfile is active (M13), gap timing comes from the profile YAML
+# and these tables are NOT used.  They remain as backward-compatible fallbacks
+# for programmatic callers that construct TurnGapController without a profile.
+#
 # Each table maps a context_key string to a _GapRange (seconds).
 # context_key values:
 #   vic_low        — VIC responds to AGG at I1–I2 (normal conversation)
@@ -158,32 +166,30 @@ class TurnGapController:
     def from_profile(
         cls,
         project: str,
-        profile: object,
+        profile: ProjectProfile,
     ) -> TurnGapController:
         """Create a controller with gap table and overlap prob from a ``ProjectProfile``.
 
         Args:
             project: Project identifier (passed through for fallback).
-            profile: A ``ProjectProfile`` instance.  Typed as ``object`` to
-                avoid a circular import; duck-typed for ``gap_timing`` and
-                ``overlap`` attributes.
+            profile: A ``ProjectProfile`` instance providing gap timing and
+                overlap probability defaults.
         """
-        gap_timing = getattr(profile, "gap_timing", None)
-        overlap = getattr(profile, "overlap", None)
-
-        gap_table: dict[str, _GapRange] | None = None
-        if gap_timing is not None:
-            raw = gap_timing.to_table()
-            gap_table = {k: _GapRange(lo=v[0], hi=v[1]) for k, v in raw.items()}
-
-        agg_pause_prob: float | None = None
-        if overlap is not None:
-            agg_pause_prob = overlap.agg_pause_prob
+        gt = profile.gap_timing
+        gap_table: dict[str, _GapRange] = {
+            "vic_low": _GapRange(gt.vic_low.lo, gt.vic_low.hi),
+            "vic_i3": _GapRange(gt.vic_i3.lo, gt.vic_i3.hi),
+            "vic_i4": _GapRange(gt.vic_i4.lo, gt.vic_i4.hi),
+            "vic_i5": _GapRange(gt.vic_i5.lo, gt.vic_i5.hi),
+            "agg_low": _GapRange(gt.agg_low.lo, gt.agg_low.hi),
+            "agg_high": _GapRange(gt.agg_high.lo, gt.agg_high.hi),
+            "agg_pause": _GapRange(gt.agg_pause.lo, gt.agg_pause.hi),
+        }
 
         return cls(
             project=project,
             gap_table_override=gap_table,
-            agg_pause_prob_override=agg_pause_prob,
+            agg_pause_prob_override=profile.overlap.agg_pause_prob,
         )
 
     def gap_seconds(

--- a/synthbanshee/tts/gap_controller.py
+++ b/synthbanshee/tts/gap_controller.py
@@ -130,12 +130,61 @@ class TurnGapController:
             ``"elephant_in_the_room"``).  Unknown projects fall back to
             ``_DEFAULT_GAPS`` so that NEG/NEU confusor scenes always receive
             timing logic rather than mechanical fixed gaps.
+        gap_table_override: Optional externally-supplied gap table (e.g. from
+            a ``ProjectProfile``).  When provided, this table is used instead
+            of the hardcoded per-project tables, making gap timing fully
+            data-driven.  Keys must match the standard context keys
+            (``vic_low``, ``vic_i3``, etc.).
+        agg_pause_prob_override: Optional override for the probability that an
+            AGG turn at I4-I5 uses a deliberate menacing self-pause.
     """
 
     project: str
+    gap_table_override: dict[str, _GapRange] | None = None
+    agg_pause_prob_override: float | None = None
 
     def __post_init__(self) -> None:
-        self._table = _PROJECT_TABLES.get(self.project, _DEFAULT_GAPS)
+        if self.gap_table_override is not None:
+            self._table = self.gap_table_override
+        else:
+            self._table = _PROJECT_TABLES.get(self.project, _DEFAULT_GAPS)
+        self._agg_pause_prob = (
+            self.agg_pause_prob_override
+            if self.agg_pause_prob_override is not None
+            else _AGG_PAUSE_PROB
+        )
+
+    @classmethod
+    def from_profile(
+        cls,
+        project: str,
+        profile: object,
+    ) -> TurnGapController:
+        """Create a controller with gap table and overlap prob from a ``ProjectProfile``.
+
+        Args:
+            project: Project identifier (passed through for fallback).
+            profile: A ``ProjectProfile`` instance.  Typed as ``object`` to
+                avoid a circular import; duck-typed for ``gap_timing`` and
+                ``overlap`` attributes.
+        """
+        gap_timing = getattr(profile, "gap_timing", None)
+        overlap = getattr(profile, "overlap", None)
+
+        gap_table: dict[str, _GapRange] | None = None
+        if gap_timing is not None:
+            raw = gap_timing.to_table()
+            gap_table = {k: _GapRange(lo=v[0], hi=v[1]) for k, v in raw.items()}
+
+        agg_pause_prob: float | None = None
+        if overlap is not None:
+            agg_pause_prob = overlap.agg_pause_prob
+
+        return cls(
+            project=project,
+            gap_table_override=gap_table,
+            agg_pause_prob_override=agg_pause_prob,
+        )
 
     def gap_seconds(
         self,
@@ -218,11 +267,10 @@ class TurnGapController:
             return "vic_i4"
         return "vic_i5"  # intensity 5
 
-    @staticmethod
-    def _agg_context(current_intensity: int, rng: random.Random) -> str:
+    def _agg_context(self, current_intensity: int, rng: random.Random) -> str:
         if current_intensity <= 2:
             return "agg_low"
-        # I3–I5: default to cutting-in, but at I4–I5 allow menacing self-pause.
-        if current_intensity >= 4 and rng.random() < _AGG_PAUSE_PROB:
+        # I3-I5: default to cutting-in, but at I4-I5 allow menacing self-pause.
+        if current_intensity >= 4 and rng.random() < self._agg_pause_prob:
             return "agg_pause"
         return "agg_high"

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -14,8 +14,12 @@ import hashlib
 import os
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from synthbanshee.config.speaker_config import SpeakerConfig
+
+if TYPE_CHECKING:
+    from synthbanshee.config.project_profile import ProjectProfile
 from synthbanshee.script.types import DialogueTurn, MixedScene
 from synthbanshee.tts.mix_mode import MixMode
 from synthbanshee.tts.provider import TTSProvider
@@ -217,7 +221,7 @@ class TTSRenderer:
         disfluency: bool = False,
         verbose_log: _VerboseLog | None = None,
         project: str = "she_proves",
-        project_profile: object | None = None,
+        project_profile: ProjectProfile | None = None,
     ) -> MixedScene:
         """Render a multi-speaker dialogue script to a MixedScene.
 
@@ -313,12 +317,20 @@ class TTSRenderer:
             gap_s, mix_mode = gap_ctrl.gap_seconds(
                 turn, prev_turn, gap_rng, speaker.role, prev_role
             )
+            rms_target = speaker.style_for_intensity(turn.intensity).rms_target_dbfs
+            # M13: if the speaker config doesn't set an RMS target for this
+            # intensity, fall back to the project profile's role-level default.
+            if rms_target is None and project_profile is not None:
+                if speaker.role == "AGG":
+                    rms_target = project_profile.loudness.agg_rms_dbfs
+                elif speaker.role == "VIC":
+                    rms_target = project_profile.loudness.vic_rms_dbfs
             segments.append(
                 (
                     wav_bytes,
                     gap_s,
                     turn.speaker_id,
-                    speaker.style_for_intensity(turn.intensity).rms_target_dbfs,
+                    rms_target,
                     mix_mode,
                 )
             )

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -217,6 +217,7 @@ class TTSRenderer:
         disfluency: bool = False,
         verbose_log: _VerboseLog | None = None,
         project: str = "she_proves",
+        project_profile: object | None = None,
     ) -> MixedScene:
         """Render a multi-speaker dialogue script to a MixedScene.
 
@@ -234,6 +235,9 @@ class TTSRenderer:
                         text using the speaker's disfluency profile.
             project: Project identifier passed to ``TurnGapController`` to
                      select psychologically-motivated gap ranges (§4.5).
+            project_profile: Optional ``ProjectProfile`` instance (M13).
+                     When provided, gap timing and overlap probabilities are
+                     loaded from the profile instead of the hardcoded tables.
 
         Returns:
             MixedScene with concatenated audio and per-turn timing metadata.
@@ -253,7 +257,10 @@ class TTSRenderer:
         # and vice versa.
         gap_rng = random.Random(rng_seed)
         mixer = SceneMixer()
-        gap_ctrl = TurnGapController(project=project)
+        if project_profile is not None:
+            gap_ctrl = TurnGapController.from_profile(project, project_profile)
+        else:
+            gap_ctrl = TurnGapController(project=project)
 
         # M7: one SpeakerState per speaker; starts neutral, updated after each turn.
         states: dict[str, SpeakerState] = {sid: SpeakerState() for sid in speakers}

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1095,6 +1095,7 @@ class TestGenerateBatchAdvanced:
             script_cache_dir,
             verbose=False,
             speaker_overrides=None,
+            project_profile=None,
         ):
             call_count[0] += 1
             if call_count[0] == 1:

--- a/tests/unit/test_project_profile.py
+++ b/tests/unit/test_project_profile.py
@@ -62,9 +62,17 @@ class TestGapRange:
         assert r.lo == 0.1
         assert r.hi == 0.5
 
+    def test_equal_lo_hi_allowed(self):
+        r = GapRange(lo=0.3, hi=0.3)
+        assert r.lo == r.hi
+
     def test_negative_rejected(self):
         with pytest.raises(ValidationError):
             GapRange(lo=-0.1, hi=0.5)
+
+    def test_inverted_range_rejected(self):
+        with pytest.raises(ValidationError, match="lo.*must be <= hi"):
+            GapRange(lo=0.5, hi=0.1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_project_profile.py
+++ b/tests/unit/test_project_profile.py
@@ -1,0 +1,283 @@
+"""Unit tests for ProjectProfile model and profile loading (M13)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from synthbanshee.config.project_profile import (
+    AcousticDefaults,
+    GapRange,
+    GapTimingDefaults,
+    LoudnessDefaults,
+    ProjectProfile,
+    clear_profile_cache,
+    load_profile,
+)
+from synthbanshee.config.run_config import RunConfig
+from synthbanshee.tts.gap_controller import TurnGapController
+from synthbanshee.tts.mix_mode import MixMode
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_PROFILE_DIR = Path(__file__).parent.parent.parent / "configs" / "run_configs"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear the profile cache before each test."""
+    clear_profile_cache()
+    yield
+    clear_profile_cache()
+
+
+# ---------------------------------------------------------------------------
+# GapRange
+# ---------------------------------------------------------------------------
+
+
+class TestGapRange:
+    def test_valid_range(self):
+        r = GapRange(lo=0.1, hi=0.5)
+        assert r.lo == 0.1
+        assert r.hi == 0.5
+
+    def test_negative_rejected(self):
+        with pytest.raises(ValidationError):
+            GapRange(lo=-0.1, hi=0.5)
+
+
+# ---------------------------------------------------------------------------
+# GapTimingDefaults
+# ---------------------------------------------------------------------------
+
+
+class TestGapTimingDefaults:
+    def test_defaults(self):
+        g = GapTimingDefaults()
+        assert g.vic_low.lo == 0.30
+        assert g.agg_pause.hi == 1.40
+
+    def test_to_table(self):
+        g = GapTimingDefaults()
+        table = g.to_table()
+        assert len(table) == 7
+        assert table["vic_low"] == (0.30, 0.60)
+        assert table["agg_pause"] == (0.60, 1.40)
+
+
+# ---------------------------------------------------------------------------
+# ProjectProfile
+# ---------------------------------------------------------------------------
+
+
+class TestProjectProfile:
+    def test_minimal(self):
+        p = ProjectProfile(name="test")
+        assert p.name == "test"
+        assert p.description == ""
+        assert p.gap_timing.vic_low.lo == 0.30
+        assert p.preprocessing.wiener_denoise is False
+
+    def test_custom_values(self):
+        p = ProjectProfile(
+            name="custom",
+            loudness=LoudnessDefaults(agg_rms_dbfs=-18.0, vic_rms_dbfs=-22.0),
+            acoustic=AcousticDefaults(snr_target_db=24.0),
+        )
+        assert p.loudness.agg_rms_dbfs == -18.0
+        assert p.acoustic.snr_target_db == 24.0
+
+    def test_from_yaml_she_proves(self):
+        path = _PROFILE_DIR / "profile_she_proves.yaml"
+        p = ProjectProfile.from_yaml(path)
+        assert p.name == "she_proves"
+        assert p.gap_timing.vic_low.lo == 0.30
+        assert p.gap_timing.vic_low.hi == 0.60
+        assert p.overlap.agg_pause_prob == 0.30
+        assert p.loudness.agg_rms_dbfs == -20.0
+        assert p.loudness.vic_rms_dbfs == -24.0
+        assert p.acoustic.snr_target_db == 18.0
+        assert "phone_in_hand" in p.acoustic.preferred_devices
+
+    def test_from_yaml_elephant(self):
+        path = _PROFILE_DIR / "profile_elephant.yaml"
+        p = ProjectProfile.from_yaml(path)
+        assert p.name == "elephant"
+        assert p.gap_timing.vic_i4.lo == 0.05
+        assert p.gap_timing.vic_i4.hi == 0.10
+        assert p.overlap.agg_pause_prob == 0.25
+        assert p.loudness.agg_rms_dbfs == -18.0
+        assert p.acoustic.snr_target_db == 24.0
+        assert "pi_budget_mic" in p.acoustic.preferred_devices
+
+
+# ---------------------------------------------------------------------------
+# load_profile
+# ---------------------------------------------------------------------------
+
+
+class TestLoadProfile:
+    def test_generic_returns_defaults(self):
+        p = load_profile("generic")
+        assert p.name == "generic"
+
+    def test_she_proves_profile(self):
+        p = load_profile("she_proves", profile_dir=_PROFILE_DIR)
+        assert p.name == "she_proves"
+        assert p.acoustic.snr_target_db == 18.0
+
+    def test_elephant_profile(self):
+        p = load_profile("elephant", profile_dir=_PROFILE_DIR)
+        assert p.name == "elephant"
+        assert p.acoustic.snr_target_db == 24.0
+
+    def test_missing_profile_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="no_such_profile"):
+            load_profile("no_such_profile", profile_dir=tmp_path)
+
+    def test_caching(self):
+        p1 = load_profile("she_proves", profile_dir=_PROFILE_DIR)
+        p2 = load_profile("she_proves", profile_dir=_PROFILE_DIR)
+        assert p1 is p2
+
+    def test_custom_profile_from_tmp(self, tmp_path: Path):
+        """A new profile YAML can be added without code changes."""
+        profile_data = {
+            "name": "custom_project",
+            "description": "A custom project profile",
+            "gap_timing": {
+                "vic_low": {"lo": 0.40, "hi": 0.70},
+                "vic_i3": {"lo": 0.20, "hi": 0.40},
+                "vic_i4": {"lo": 0.10, "hi": 0.20},
+                "vic_i5": {"lo": 0.15, "hi": 0.35},
+                "agg_low": {"lo": 0.25, "hi": 0.55},
+                "agg_high": {"lo": 0.08, "hi": 0.25},
+                "agg_pause": {"lo": 0.70, "hi": 1.50},
+            },
+            "loudness": {"agg_rms_dbfs": -16.0, "vic_rms_dbfs": -20.0},
+            "acoustic": {"snr_target_db": 15.0},
+        }
+        yaml_path = tmp_path / "profile_custom_project.yaml"
+        yaml_path.write_text(yaml.dump(profile_data), encoding="utf-8")
+
+        p = load_profile("custom_project", profile_dir=tmp_path)
+        assert p.name == "custom_project"
+        assert p.gap_timing.vic_low.lo == 0.40
+        assert p.loudness.agg_rms_dbfs == -16.0
+        assert p.acoustic.snr_target_db == 15.0
+
+
+# ---------------------------------------------------------------------------
+# RunConfig integration
+# ---------------------------------------------------------------------------
+
+_RUN_YAML_WITH_PROFILE = textwrap.dedent("""\
+    run_id: test_with_profile
+    project: she_proves
+    tier: A
+    project_profile: she_proves
+    targets:
+      - violence_typology: IT
+        count: 100
+    splits:
+      train: 0.70
+      val: 0.15
+      test: 0.15
+""")
+
+
+class TestRunConfigProfile:
+    def test_default_profile_is_generic(self):
+        data = yaml.safe_load(
+            textwrap.dedent("""\
+                run_id: test
+                project: she_proves
+                targets:
+                  - violence_typology: IT
+                    count: 10
+                splits:
+                  train: 0.70
+                  val: 0.15
+                  test: 0.15
+            """)
+        )
+        cfg = RunConfig.model_validate(data)
+        assert cfg.project_profile == "generic"
+
+    def test_profile_field_parsed(self):
+        cfg = RunConfig.model_validate(yaml.safe_load(_RUN_YAML_WITH_PROFILE))
+        assert cfg.project_profile == "she_proves"
+
+    def test_resolved_profile_returns_profile(self):
+        cfg = RunConfig.model_validate(yaml.safe_load(_RUN_YAML_WITH_PROFILE))
+        profile = cfg.resolved_profile()
+        assert profile.name == "she_proves"
+        assert profile.acoustic.snr_target_db == 18.0
+
+    def test_resolved_generic_profile(self):
+        data = yaml.safe_load(
+            textwrap.dedent("""\
+                run_id: test
+                project: she_proves
+                targets:
+                  - violence_typology: IT
+                    count: 10
+                splits:
+                  train: 0.70
+                  val: 0.15
+                  test: 0.15
+            """)
+        )
+        cfg = RunConfig.model_validate(data)
+        profile = cfg.resolved_profile()
+        assert profile.name == "generic"
+
+
+# ---------------------------------------------------------------------------
+# Gap controller integration with profiles
+# ---------------------------------------------------------------------------
+
+
+class TestGapControllerWithProfile:
+    def test_from_profile_uses_profile_gaps(self):
+        import random
+
+        from synthbanshee.script.types import DialogueTurn
+
+        profile = load_profile("elephant", profile_dir=_PROFILE_DIR)
+        ctrl = TurnGapController.from_profile("elephant_in_the_room", profile)
+
+        prev = DialogueTurn(speaker_id="agg1", text="test", intensity=1)
+        curr = DialogueTurn(speaker_id="vic1", text="test", intensity=1)
+        rng = random.Random(42)
+
+        # Draw many gaps and verify they fall within the elephant profile ranges
+        for _ in range(100):
+            amount, mode = ctrl.gap_seconds(curr, prev, rng, "VIC", "AGG")
+            if mode == MixMode.SEQUENTIAL:
+                # vic_low range from elephant profile: 0.25–0.50
+                assert 0.25 <= amount <= 0.50
+
+    def test_from_profile_uses_profile_agg_pause_prob(self):
+        """Elephant profile has agg_pause_prob=0.25, different from default 0.30."""
+        profile = load_profile("elephant", profile_dir=_PROFILE_DIR)
+        ctrl = TurnGapController.from_profile("elephant_in_the_room", profile)
+        assert ctrl._agg_pause_prob == 0.25
+
+    def test_from_profile_she_proves(self):
+        profile = load_profile("she_proves", profile_dir=_PROFILE_DIR)
+        ctrl = TurnGapController.from_profile("she_proves", profile)
+        assert ctrl._agg_pause_prob == 0.30
+
+    def test_without_profile_uses_hardcoded_tables(self):
+        from synthbanshee.tts.gap_controller import _SHE_PROVES_GAPS
+
+        ctrl = TurnGapController(project="she_proves")
+        assert ctrl._table is _SHE_PROVES_GAPS

--- a/tests/unit/test_project_profile.py
+++ b/tests/unit/test_project_profile.py
@@ -22,6 +22,20 @@ from synthbanshee.config.run_config import RunConfig
 from synthbanshee.tts.gap_controller import TurnGapController
 from synthbanshee.tts.mix_mode import MixMode
 
+
+def _default_gap_timing() -> GapTimingDefaults:
+    """Return a GapTimingDefaults with framework-default values."""
+    return GapTimingDefaults(
+        vic_low=GapRange(lo=0.30, hi=0.60),
+        vic_i3=GapRange(lo=0.15, hi=0.35),
+        vic_i4=GapRange(lo=0.05, hi=0.15),
+        vic_i5=GapRange(lo=0.10, hi=0.30),
+        agg_low=GapRange(lo=0.20, hi=0.50),
+        agg_high=GapRange(lo=0.05, hi=0.20),
+        agg_pause=GapRange(lo=0.60, hi=1.40),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -59,17 +73,15 @@ class TestGapRange:
 
 
 class TestGapTimingDefaults:
-    def test_defaults(self):
-        g = GapTimingDefaults()
+    def test_all_fields_required(self):
+        with pytest.raises(ValidationError):
+            GapTimingDefaults()  # type: ignore[call-arg]
+
+    def test_explicit_construction(self):
+        g = _default_gap_timing()
         assert g.vic_low.lo == 0.30
         assert g.agg_pause.hi == 1.40
-
-    def test_to_table(self):
-        g = GapTimingDefaults()
-        table = g.to_table()
-        assert len(table) == 7
-        assert table["vic_low"] == (0.30, 0.60)
-        assert table["agg_pause"] == (0.60, 1.40)
+        assert g.vic_i4.lo == 0.05
 
 
 # ---------------------------------------------------------------------------
@@ -78,8 +90,12 @@ class TestGapTimingDefaults:
 
 
 class TestProjectProfile:
-    def test_minimal(self):
-        p = ProjectProfile(name="test")
+    def test_requires_gap_timing(self):
+        with pytest.raises(ValidationError):
+            ProjectProfile(name="test")  # type: ignore[call-arg]
+
+    def test_with_gap_timing(self):
+        p = ProjectProfile(name="test", gap_timing=_default_gap_timing())
         assert p.name == "test"
         assert p.description == ""
         assert p.gap_timing.vic_low.lo == 0.30
@@ -88,6 +104,7 @@ class TestProjectProfile:
     def test_custom_values(self):
         p = ProjectProfile(
             name="custom",
+            gap_timing=_default_gap_timing(),
             loudness=LoudnessDefaults(agg_rms_dbfs=-18.0, vic_rms_dbfs=-22.0),
             acoustic=AcousticDefaults(snr_target_db=24.0),
         )


### PR DESCRIPTION
## Summary

- Add a data-driven `ProjectProfile` model (`synthbanshee/config/project_profile.py`) that defines project-specific defaults for gap timing, overlap probabilities, loudness targets, preprocessing config, and acoustic augmentation parameters
- Add `project_profile` field to `RunConfig` (defaults to `"generic"`)
- Create two profile YAML files (`configs/run_configs/profile_she_proves.yaml`, `profile_elephant.yaml`) with project-appropriate defaults matching the spec's acoustic regime differences
- Make `TurnGapController` accept gap tables and overlap probabilities from profiles via `from_profile()` factory, making timing fully data-driven
- Wire profile defaults through the pipeline: `generate_batch` → `_render_one` → `_run_generate_pipeline` → `render_scene` → `TurnGapController`

## Changes

| File | Change |
|---|---|
| `synthbanshee/config/project_profile.py` | **New** — `ProjectProfile` model, `load_profile()` registry with caching, `_discover_profiles()` for data-driven profile discovery |
| `synthbanshee/config/run_config.py` | Add `project_profile` field and `resolved_profile()` method |
| `synthbanshee/config/__init__.py` | Export `ProjectProfile` and `load_profile` |
| `synthbanshee/tts/gap_controller.py` | Add `gap_table_override`, `agg_pause_prob_override` params; `from_profile()` factory; make `_agg_context` use instance prob |
| `synthbanshee/tts/renderer.py` | Accept `project_profile` param, use `TurnGapController.from_profile()` when profile provided |
| `synthbanshee/cli.py` | Thread profile through `generate_batch` → `_render_one` → `_run_generate_pipeline`; apply preprocessing defaults from profile |
| `configs/run_configs/profile_she_proves.yaml` | **New** — She-Proves profile (SNR 18 dB, phone devices, apartment rooms, wider gaps) |
| `configs/run_configs/profile_elephant.yaml` | **New** — Elephant profile (SNR 24 dB, pi_budget_mic, clinic/office rooms, tighter gaps) |
| `tests/unit/test_project_profile.py` | **New** — 22 unit tests covering model, loading, caching, custom profiles, RunConfig integration, gap controller integration |
| `tests/unit/test_cli.py` | Update mock signature for new `project_profile` parameter |

## Test plan

- [x] `pytest tests/unit/test_project_profile.py` — 22/22 passed
- [x] `pytest tests/unit/` — 1292/1292 passed
- [x] `ruff check` — all checks passed
- [x] `mypy` — no new errors (only pre-existing yaml stub + anthropic SDK warnings)
- [x] Pre-commit hooks — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)