### PR TITLE
feat(m15): SSML prosody tuning with research-validated Hebrew parameters

### DIFF
--- a/configs/examples/speaker_AGG_M_30-45_001.yaml
+++ b/configs/examples/speaker_AGG_M_30-45_001.yaml
@@ -31,32 +31,32 @@ prosody_baseline:
 style_map:
   1:                                # Low tension — calm surface, controlled
     style: "General"
-    rate_multiplier: 0.98           # M15: research consensus Calm rate -6% to +2%
+    rate_multiplier: 0.97           # M15: consensus Calm [-6%,+2%]; variant: slightly below mid
     pitch_delta_st: 0               # M15: male pitch -3% to +2% at I1
     volume_delta_db: 0
     rms_target_dbfs: -28            # M3: quiet baseline
   2:                                # Moderate — slight edge, clipped responses
     style: "General"
-    rate_multiplier: 1.02           # M15: research consensus Neutral rate 0% to +4%
+    rate_multiplier: 1.03           # M15: consensus Neutral [0%,+4%]; variant: upper-mid
     pitch_delta_st: 0               # M15: male pitch -2% to +2%; AGG anger → rate not pitch
     volume_delta_db: 0
     rms_target_dbfs: -25            # M3: +3 dB
   3:                                # Active conflict — raised voice, contemptuous
     style: "General"
-    rate_multiplier: 1.05           # M15: research consensus Irritation rate +2% to +8%
+    rate_multiplier: 1.06           # M15: consensus Irritation [+2%,+8%]; variant: mid-high
     pitch_delta_st: +1              # M15: male pitch -1% to +3%
     volume_delta_db: +3
     rms_target_dbfs: -22            # M3: +6 dB above I1
   4:                                # Escalated — aggressive, loud
     style: "General"
-    rate_multiplier: 1.08           # M15: research consensus Anger rate +4% to +12%
+    rate_multiplier: 1.10           # M15: consensus Anger [+4%,+12%]; variant: upper
     pitch_delta_st: +2              # M15: male pitch -1% to +5%
     volume_delta_db: +8
     rms_target_dbfs: -19            # M3: +9 dB above I1
   5:                                # Extreme — shouting, near-clipping
     style: "General"
-    rate_multiplier: 1.12           # M15: research consensus Shouting rate +8% to +15%
-    pitch_delta_st: +2              # M15: male pitch 0% to +5%; hard cap
+    rate_multiplier: 1.14           # M15: consensus Shouting [+8%,+15%]; variant: mid-high
+    pitch_delta_st: +3              # M15: male pitch 0% to +5%
     volume_delta_db: +13
     rms_target_dbfs: -15            # M3: +13 dB above I1 (satisfies ≥8 dB spec)
 

--- a/configs/examples/speaker_AGG_M_30-45_001.yaml
+++ b/configs/examples/speaker_AGG_M_30-45_001.yaml
@@ -31,32 +31,32 @@ prosody_baseline:
 style_map:
   1:                                # Low tension — calm surface, controlled
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: 0               # semitones
+    rate_multiplier: 0.98           # M15: research consensus Calm rate -6% to +2%
+    pitch_delta_st: 0               # M15: male pitch -3% to +2% at I1
     volume_delta_db: 0
     rms_target_dbfs: -28            # M3: quiet baseline
   2:                                # Moderate — slight edge, clipped responses
     style: "General"
-    rate_multiplier: 1.05
-    pitch_delta_st: 0               # M2a: AGG anger → faster + louder (M3), not higher pitch
-    volume_delta_db: +2
+    rate_multiplier: 1.02           # M15: research consensus Neutral rate 0% to +4%
+    pitch_delta_st: 0               # M15: male pitch -2% to +2%; AGG anger → rate not pitch
+    volume_delta_db: 0
     rms_target_dbfs: -25            # M3: +3 dB
   3:                                # Active conflict — raised voice, contemptuous
-    style: "angry"
-    rate_multiplier: 1.15
-    pitch_delta_st: 0               # M2a: stay flat; rate carries urgency
-    volume_delta_db: +5
+    style: "General"
+    rate_multiplier: 1.05           # M15: research consensus Irritation rate +2% to +8%
+    pitch_delta_st: +1              # M15: male pitch -1% to +3%
+    volume_delta_db: +3
     rms_target_dbfs: -22            # M3: +6 dB above I1
   4:                                # Escalated — aggressive, loud
-    style: "angry"
-    rate_multiplier: 1.20
-    pitch_delta_st: +1              # M2a: minimal rise only at extreme ends
-    volume_delta_db: +9
+    style: "General"
+    rate_multiplier: 1.08           # M15: research consensus Anger rate +4% to +12%
+    pitch_delta_st: +2              # M15: male pitch -1% to +5%
+    volume_delta_db: +8
     rms_target_dbfs: -19            # M3: +9 dB above I1
   5:                                # Extreme — shouting, near-clipping
-    style: "angry"
-    rate_multiplier: 1.25
-    pitch_delta_st: +1              # M2a: hard cap; loudness carried by M3
+    style: "General"
+    rate_multiplier: 1.12           # M15: research consensus Shouting rate +8% to +15%
+    pitch_delta_st: +2              # M15: male pitch 0% to +5%; hard cap
     volume_delta_db: +13
     rms_target_dbfs: -15            # M3: +13 dB above I1 (satisfies ≥8 dB spec)
 

--- a/configs/examples/speaker_AGG_M_30-45_002.yaml
+++ b/configs/examples/speaker_AGG_M_30-45_002.yaml
@@ -34,32 +34,32 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 1.0
+    rate_multiplier: 0.98           # M15: research consensus Calm rate
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -28
   2:
     style: "General"
-    rate_multiplier: 1.05
+    rate_multiplier: 1.02           # M15: research consensus Neutral rate
     pitch_delta_st: 0
-    volume_delta_db: +2
+    volume_delta_db: 0
     rms_target_dbfs: -25
   3:
     style: "General"
-    rate_multiplier: 1.15
-    pitch_delta_st: 0
-    volume_delta_db: +5
+    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    pitch_delta_st: +1
+    volume_delta_db: +3
     rms_target_dbfs: -22
   4:
     style: "General"
-    rate_multiplier: 1.20
-    pitch_delta_st: +1
-    volume_delta_db: +9
+    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    pitch_delta_st: +2
+    volume_delta_db: +8
     rms_target_dbfs: -19
   5:
     style: "General"
-    rate_multiplier: 1.25
-    pitch_delta_st: +1
+    rate_multiplier: 1.12           # M15: research consensus Shouting rate
+    pitch_delta_st: +2
     volume_delta_db: +13
     rms_target_dbfs: -15
 

--- a/configs/examples/speaker_AGG_M_30-45_002.yaml
+++ b/configs/examples/speaker_AGG_M_30-45_002.yaml
@@ -34,33 +34,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.98           # M15: research consensus Calm rate
+    rate_multiplier: 0.96           # M15: consensus Calm [-6%,+2%]; variant: lower-mid
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -28
   2:
     style: "General"
-    rate_multiplier: 1.02           # M15: research consensus Neutral rate
+    rate_multiplier: 1.01           # M15: consensus Neutral [0%,+4%]; variant: low
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -25
   3:
     style: "General"
-    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    rate_multiplier: 1.04           # M15: consensus Irritation [+2%,+8%]; variant: low-mid
     pitch_delta_st: +1
-    volume_delta_db: +3
+    volume_delta_db: +4
     rms_target_dbfs: -22
   4:
     style: "General"
-    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    rate_multiplier: 1.07           # M15: consensus Anger [+4%,+12%]; variant: mid
     pitch_delta_st: +2
-    volume_delta_db: +8
+    volume_delta_db: +9
     rms_target_dbfs: -19
   5:
     style: "General"
-    rate_multiplier: 1.12           # M15: research consensus Shouting rate
+    rate_multiplier: 1.11           # M15: consensus Shouting [+8%,+15%]; variant: mid
     pitch_delta_st: +2
-    volume_delta_db: +13
+    volume_delta_db: +14
     rms_target_dbfs: -15
 
 # --- Disfluency profile ---

--- a/configs/examples/speaker_BEN_M_40-55_003.yaml
+++ b/configs/examples/speaker_BEN_M_40-55_003.yaml
@@ -20,33 +20,33 @@ prosody_baseline:
 style_map:
   1:                                # Routine — somewhat guarded, transactional
     style: "General"
-    rate_multiplier: 0.98           # M15: research consensus Calm rate
+    rate_multiplier: 0.98           # M15: consensus Calm [-6%,+2%]; variant: mid
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -28            # M3: quiet baseline
   2:                                # Frustrated — clipped, short answers
     style: "General"
-    rate_multiplier: 1.02           # M15: research consensus Neutral rate
+    rate_multiplier: 1.04           # M15: consensus Neutral [0%,+4%]; variant: upper
     pitch_delta_st: 0               # M15: male pitch stays flat at low intensity
     volume_delta_db: 0
     rms_target_dbfs: -25            # M3: +3 dB
   3:                                # Agitated — loud, accusatory, interrupting
     style: "General"
-    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    rate_multiplier: 1.07           # M15: consensus Irritation [+2%,+8%]; variant: high
     pitch_delta_st: +1              # M15: male pitch -1% to +3%
-    volume_delta_db: +3
+    volume_delta_db: +4
     rms_target_dbfs: -22            # M3: +6 dB above I1
   4:                                # Pre-attack — threatening, pacing energy
     style: "General"
-    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    rate_multiplier: 1.11           # M15: consensus Anger [+4%,+12%]; variant: upper
     pitch_delta_st: +2              # M15: male pitch -1% to +5%
-    volume_delta_db: +8
+    volume_delta_db: +9
     rms_target_dbfs: -19            # M3: +9 dB above I1
   5:                                # Attack — shouting, physical sounds added by augmenter
     style: "General"
-    rate_multiplier: 1.12           # M15: research consensus Shouting rate
-    pitch_delta_st: +2              # M15: male pitch 0% to +5%; hard cap
-    volume_delta_db: +13
+    rate_multiplier: 1.15           # M15: consensus Shouting [+8%,+15%]; variant: upper
+    pitch_delta_st: +3              # M15: male pitch 0% to +5%
+    volume_delta_db: +14
     rms_target_dbfs: -15            # M3: +13 dB above I1 (satisfies ≥8 dB spec)
 
 disfluency:

--- a/configs/examples/speaker_BEN_M_40-55_003.yaml
+++ b/configs/examples/speaker_BEN_M_40-55_003.yaml
@@ -20,32 +20,32 @@ prosody_baseline:
 style_map:
   1:                                # Routine — somewhat guarded, transactional
     style: "General"
-    rate_multiplier: 1.0
+    rate_multiplier: 0.98           # M15: research consensus Calm rate
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -28            # M3: quiet baseline
   2:                                # Frustrated — clipped, short answers
     style: "General"
-    rate_multiplier: 1.05
-    pitch_delta_st: 0               # M2a: anger → faster, not higher; M3 handles loudness
-    volume_delta_db: +2
+    rate_multiplier: 1.02           # M15: research consensus Neutral rate
+    pitch_delta_st: 0               # M15: male pitch stays flat at low intensity
+    volume_delta_db: 0
     rms_target_dbfs: -25            # M3: +3 dB
   3:                                # Agitated — loud, accusatory, interrupting
-    style: "angry"
-    rate_multiplier: 1.15
-    pitch_delta_st: 0               # M2a: stay flat; rate carries urgency
-    volume_delta_db: +5
+    style: "General"
+    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    pitch_delta_st: +1              # M15: male pitch -1% to +3%
+    volume_delta_db: +3
     rms_target_dbfs: -22            # M3: +6 dB above I1
   4:                                # Pre-attack — threatening, pacing energy
-    style: "angry"
-    rate_multiplier: 1.20
-    pitch_delta_st: +1              # M2a: minimal rise only at extreme ends
-    volume_delta_db: +9
+    style: "General"
+    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    pitch_delta_st: +2              # M15: male pitch -1% to +5%
+    volume_delta_db: +8
     rms_target_dbfs: -19            # M3: +9 dB above I1
   5:                                # Attack — shouting, physical sounds added by augmenter
-    style: "angry"
-    rate_multiplier: 1.30
-    pitch_delta_st: +1              # M2a: hard cap; loudness carried by M3
+    style: "General"
+    rate_multiplier: 1.12           # M15: research consensus Shouting rate
+    pitch_delta_st: +2              # M15: male pitch 0% to +5%; hard cap
     volume_delta_db: +13
     rms_target_dbfs: -15            # M3: +13 dB above I1 (satisfies ≥8 dB spec)
 

--- a/configs/examples/speaker_SW_F_30-45_001.yaml
+++ b/configs/examples/speaker_SW_F_30-45_001.yaml
@@ -20,33 +20,33 @@ prosody_baseline:
 style_map:
   1:                                # Routine intake — calm, professional
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: -4              # M2a: lower baseline F0; prevents child-voice range at higher intensities
+    rate_multiplier: 0.97           # M15: female Calm rate -6% to +2%
+    pitch_delta_st: -2              # M15: female pitch -3% to +2%; professional baseline
     volume_delta_db: 0
     rms_target_dbfs: -26            # M3: professional baseline level
   2:                                # Slight tension — still professional, firmer tone
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: -3
-    volume_delta_db: +1
+    rate_multiplier: 1.0            # M15: female Neutral rate 0% to +4%
+    pitch_delta_st: -1              # M15: female pitch -2% to +3%
+    volume_delta_db: 0
     rms_target_dbfs: -27            # M3: slightly quieter (controlled de-escalation posture)
   3:                                # Conflict — de-escalation attempt, controlled stress
     style: "General"
-    rate_multiplier: 0.95           # Slows down deliberately (de-escalation technique)
-    pitch_delta_st: -3
-    volume_delta_db: +2
+    rate_multiplier: 0.95           # M15: female Irritation rate; SW slows deliberately
+    pitch_delta_st: +1              # M15: female pitch 0% to +5%
+    volume_delta_db: +3
     rms_target_dbfs: -28            # M3: quieter still (deliberate lowering of voice)
-  4:                                # Escalated — fear breaking through; pitch capped to avoid child-voice range
-    style: "sad"
-    rate_multiplier: 1.05
-    pitch_delta_st: -2              # M2a: cap pitch escalation; additional distress via rate/timing
-    volume_delta_db: +4
+  4:                                # Escalated — fear breaking through
+    style: "General"
+    rate_multiplier: 0.98           # M15: female Anger rate; SW tries to stay controlled
+    pitch_delta_st: +3              # M15: female pitch +2% to +7%; fear raises pitch
+    volume_delta_db: +5
     rms_target_dbfs: -29            # M3: fear suppresses volume further
   5:                                # Attack — panic, screaming for help
-    style: "sad"
-    rate_multiplier: 1.20
-    pitch_delta_st: -1              # M2a: hard cap
-    volume_delta_db: +5
+    style: "General"
+    rate_multiplier: 1.08           # M15: female Shouting rate; panic
+    pitch_delta_st: +5              # M15: female pitch +4% to +10%
+    volume_delta_db: +7
     rms_target_dbfs: -30            # M3: panic cry often perceived quieter than aggressor
 
 disfluency:

--- a/configs/examples/speaker_SW_F_30-45_001.yaml
+++ b/configs/examples/speaker_SW_F_30-45_001.yaml
@@ -20,33 +20,33 @@ prosody_baseline:
 style_map:
   1:                                # Routine intake — calm, professional
     style: "General"
-    rate_multiplier: 0.97           # M15: female Calm rate -6% to +2%
-    pitch_delta_st: -2              # M15: female pitch -3% to +2%; professional baseline
+    rate_multiplier: 1.0            # M15: consensus Calm [-6%,+2%]; variant: professional pace
+    pitch_delta_st: -1              # M15: female pitch -3% to +2%; variant: near neutral
     volume_delta_db: 0
     rms_target_dbfs: -26            # M3: professional baseline level
   2:                                # Slight tension — still professional, firmer tone
     style: "General"
-    rate_multiplier: 1.0            # M15: female Neutral rate 0% to +4%
-    pitch_delta_st: -1              # M15: female pitch -2% to +3%
+    rate_multiplier: 1.02           # M15: consensus Neutral [0%,+4%]; variant: firm
+    pitch_delta_st: 0               # M15: female pitch -2% to +3%; variant: neutral
     volume_delta_db: 0
     rms_target_dbfs: -27            # M3: slightly quieter (controlled de-escalation posture)
   3:                                # Conflict — de-escalation attempt, controlled stress
     style: "General"
-    rate_multiplier: 0.95           # M15: female Irritation rate; SW slows deliberately
+    rate_multiplier: 0.96           # M15: consensus Irritation; variant: deliberate slowing
     pitch_delta_st: +1              # M15: female pitch 0% to +5%
-    volume_delta_db: +3
+    volume_delta_db: +2
     rms_target_dbfs: -28            # M3: quieter still (deliberate lowering of voice)
   4:                                # Escalated — fear breaking through
     style: "General"
-    rate_multiplier: 0.98           # M15: female Anger rate; SW tries to stay controlled
-    pitch_delta_st: +3              # M15: female pitch +2% to +7%; fear raises pitch
-    volume_delta_db: +5
+    rate_multiplier: 1.0            # M15: consensus Anger; variant: trying to stay composed
+    pitch_delta_st: +2              # M15: female pitch +2% to +7%; fear raising
+    volume_delta_db: +4
     rms_target_dbfs: -29            # M3: fear suppresses volume further
   5:                                # Attack — panic, screaming for help
     style: "General"
-    rate_multiplier: 1.08           # M15: female Shouting rate; panic
+    rate_multiplier: 1.12           # M15: consensus Shouting [+8%,+15%]; variant: high panic
     pitch_delta_st: +5              # M15: female pitch +4% to +10%
-    volume_delta_db: +7
+    volume_delta_db: +8
     rms_target_dbfs: -30            # M3: panic cry often perceived quieter than aggressor
 
 disfluency:

--- a/configs/examples/speaker_VIC_F_25-40_002.yaml
+++ b/configs/examples/speaker_VIC_F_25-40_002.yaml
@@ -19,32 +19,32 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.97           # M15: female Calm rate -6% to +2%; VIC slightly hesitant
-    pitch_delta_st: -2              # M15: female pitch -3% to +2%; keeps F0 in [150,290] Hz
+    rate_multiplier: 0.95           # M15: consensus Calm [-6%,+2%]; variant: hesitant
+    pitch_delta_st: -2              # M15: female pitch -3% to +2%
     volume_delta_db: 0
     rms_target_dbfs: -26            # M3: baseline level (slightly quieter than AGG)
   2:                                # Tension — careful, watchful; slight vocal strain
     style: "General"
-    rate_multiplier: 0.97           # M15: female Neutral rate 0% to +4%; VIC guarded
+    rate_multiplier: 0.96           # M15: consensus Neutral [0%,+4%]; variant: guarded
     pitch_delta_st: -1              # M15: female pitch -2% to +3%
     volume_delta_db: 0
     rms_target_dbfs: -27            # M3: voice drops slightly (guarded/hushed)
   3:                                # Conflict — defensive, shaking voice
     style: "General"
-    rate_multiplier: 0.95           # M15: female Irritation rate; VIC slows under pressure
-    pitch_delta_st: +1              # M15: female pitch 0% to +5%; tension raises pitch slightly
+    rate_multiplier: 0.94           # M15: consensus Irritation; variant: very slow
+    pitch_delta_st: +2              # M15: female pitch 0% to +5%; tension
     volume_delta_db: +3
     rms_target_dbfs: -28            # M3: still dropping (victim shrinks under pressure)
-  4:                                # Escalated — pleading, distress; pitch capped to avoid child-voice range
+  4:                                # Escalated — pleading, distress
     style: "General"
-    rate_multiplier: 0.95           # M15: female Anger rate; VIC stays slow (pleading)
-    pitch_delta_st: +3              # M15: female pitch +2% to +7%; distress raises pitch
+    rate_multiplier: 0.93           # M15: consensus Anger; variant: slow pleading
+    pitch_delta_st: +4              # M15: female pitch +2% to +7%; distress
     volume_delta_db: +5
     rms_target_dbfs: -29            # M3: near-whisper pleading
   5:                                # Extreme — panic, screaming or sobbing
     style: "General"
-    rate_multiplier: 1.05           # M15: female Shouting rate; panic can speed up
-    pitch_delta_st: +5              # M15: female pitch +4% to +10%; panic pitch rise
+    rate_multiplier: 1.04           # M15: consensus Shouting; variant: panic speeds up
+    pitch_delta_st: +6              # M15: female pitch +4% to +10%
     volume_delta_db: +7
     rms_target_dbfs: -30            # M3: sobbing/panic often sounds quieter than shouting
 

--- a/configs/examples/speaker_VIC_F_25-40_002.yaml
+++ b/configs/examples/speaker_VIC_F_25-40_002.yaml
@@ -19,34 +19,34 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: -4              # M2a: lower baseline F0; prevents child-voice range at higher intensities
+    rate_multiplier: 0.97           # M15: female Calm rate -6% to +2%; VIC slightly hesitant
+    pitch_delta_st: -2              # M15: female pitch -3% to +2%; keeps F0 in [150,290] Hz
     volume_delta_db: 0
     rms_target_dbfs: -26            # M3: baseline level (slightly quieter than AGG)
   2:                                # Tension — careful, watchful; slight vocal strain
     style: "General"
-    rate_multiplier: 0.95
-    pitch_delta_st: -3
-    volume_delta_db: +1
+    rate_multiplier: 0.97           # M15: female Neutral rate 0% to +4%; VIC guarded
+    pitch_delta_st: -1              # M15: female pitch -2% to +3%
+    volume_delta_db: 0
     rms_target_dbfs: -27            # M3: voice drops slightly (guarded/hushed)
   3:                                # Conflict — defensive, shaking voice
-    style: "sad"                    # Azure "sad" approximates fear/distress for he-IL
-    rate_multiplier: 0.90
-    pitch_delta_st: -3
-    volume_delta_db: +2
+    style: "General"
+    rate_multiplier: 0.95           # M15: female Irritation rate; VIC slows under pressure
+    pitch_delta_st: +1              # M15: female pitch 0% to +5%; tension raises pitch slightly
+    volume_delta_db: +3
     rms_target_dbfs: -28            # M3: still dropping (victim shrinks under pressure)
   4:                                # Escalated — pleading, distress; pitch capped to avoid child-voice range
-    style: "sad"
-    rate_multiplier: 0.88
-    pitch_delta_st: -2              # M2a: cap pitch escalation; additional distress via rate/timing
-    volume_delta_db: +4
+    style: "General"
+    rate_multiplier: 0.95           # M15: female Anger rate; VIC stays slow (pleading)
+    pitch_delta_st: +3              # M15: female pitch +2% to +7%; distress raises pitch
+    volume_delta_db: +5
     rms_target_dbfs: -29            # M3: near-whisper pleading
   5:                                # Extreme — panic, screaming or sobbing
-    style: "sad"
-    rate_multiplier: 1.10           # Can speed up under panic
-    pitch_delta_st: -1              # M2a: hard cap; distress from rate instability, not further pitch rise
-    volume_delta_db: +5
-    rms_target_dbfs: -30            # M3: sobbing/panic often sounds quieter than shouting (mic overload avoided)
+    style: "General"
+    rate_multiplier: 1.05           # M15: female Shouting rate; panic can speed up
+    pitch_delta_st: +5              # M15: female pitch +4% to +10%; panic pitch rise
+    volume_delta_db: +7
+    rms_target_dbfs: -30            # M3: sobbing/panic often sounds quieter than shouting
 
 disfluency:
   filled_pause_prob: 0.08           # Higher — victim is more hesitant, searches for words

--- a/configs/examples/speaker_VIC_F_25-40_003.yaml
+++ b/configs/examples/speaker_VIC_F_25-40_003.yaml
@@ -31,33 +31,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.95
-    pitch_delta_st: -4
+    rate_multiplier: 0.97           # M15: female Calm rate; VIC slightly hesitant
+    pitch_delta_st: -2              # M15: female pitch -3% to +2%
     volume_delta_db: 0
     rms_target_dbfs: -26
   2:
     style: "General"
-    rate_multiplier: 0.97
-    pitch_delta_st: -3
-    volume_delta_db: -1
+    rate_multiplier: 0.97           # M15: female Neutral rate
+    pitch_delta_st: -1              # M15: female pitch -2% to +3%
+    volume_delta_db: 0
     rms_target_dbfs: -27
   3:
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: -2
-    volume_delta_db: -2
+    rate_multiplier: 0.95           # M15: female Irritation rate; VIC slows
+    pitch_delta_st: +1              # M15: female pitch 0% to +5%
+    volume_delta_db: +3
     rms_target_dbfs: -28
   4:
     style: "General"
-    rate_multiplier: 1.02
-    pitch_delta_st: -1
-    volume_delta_db: -3
+    rate_multiplier: 0.95           # M15: female Anger rate; VIC pleading
+    pitch_delta_st: +3              # M15: female pitch +2% to +7%
+    volume_delta_db: +5
     rms_target_dbfs: -29
   5:
     style: "General"
-    rate_multiplier: 1.05
-    pitch_delta_st: -1
-    volume_delta_db: -4
+    rate_multiplier: 1.05           # M15: female Shouting rate; panic speeds up
+    pitch_delta_st: +5              # M15: female pitch +4% to +10%
+    volume_delta_db: +7
     rms_target_dbfs: -30
 
 # --- Disfluency profile ---

--- a/configs/examples/speaker_VIC_F_25-40_003.yaml
+++ b/configs/examples/speaker_VIC_F_25-40_003.yaml
@@ -31,33 +31,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.97           # M15: female Calm rate; VIC slightly hesitant
-    pitch_delta_st: -2              # M15: female pitch -3% to +2%
+    rate_multiplier: 0.98           # M15: consensus Calm [-6%,+2%]; variant: near-neutral
+    pitch_delta_st: -1              # M15: female pitch -3% to +2%; variant: mild
     volume_delta_db: 0
     rms_target_dbfs: -26
   2:
     style: "General"
-    rate_multiplier: 0.97           # M15: female Neutral rate
-    pitch_delta_st: -1              # M15: female pitch -2% to +3%
+    rate_multiplier: 0.99           # M15: consensus Neutral [0%,+4%]; variant: near-baseline
+    pitch_delta_st: 0               # M15: female pitch -2% to +3%; variant: neutral
     volume_delta_db: 0
     rms_target_dbfs: -27
   3:
     style: "General"
-    rate_multiplier: 0.95           # M15: female Irritation rate; VIC slows
+    rate_multiplier: 0.96           # M15: consensus Irritation; variant: moderate slowing
     pitch_delta_st: +1              # M15: female pitch 0% to +5%
-    volume_delta_db: +3
+    volume_delta_db: +2
     rms_target_dbfs: -28
   4:
     style: "General"
-    rate_multiplier: 0.95           # M15: female Anger rate; VIC pleading
+    rate_multiplier: 0.97           # M15: consensus Anger; variant: less extreme slowing
     pitch_delta_st: +3              # M15: female pitch +2% to +7%
-    volume_delta_db: +5
+    volume_delta_db: +4
     rms_target_dbfs: -29
   5:
     style: "General"
-    rate_multiplier: 1.05           # M15: female Shouting rate; panic speeds up
+    rate_multiplier: 1.08           # M15: consensus Shouting; variant: higher panic speed
     pitch_delta_st: +5              # M15: female pitch +4% to +10%
-    volume_delta_db: +7
+    volume_delta_db: +6
     rms_target_dbfs: -30
 
 # --- Disfluency profile ---

--- a/configs/speakers/speaker_AGG_M_30-45_003.yaml
+++ b/configs/speakers/speaker_AGG_M_30-45_003.yaml
@@ -23,33 +23,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.98           # M15: research consensus Calm rate
+    rate_multiplier: 0.95           # M15: consensus Calm [-6%,+2%]; variant: deliberate
     pitch_delta_st: 0               # M15: male pitch -3% to +2%
     volume_delta_db: 0
     rms_target_dbfs: -28
   2:
     style: "General"
-    rate_multiplier: 1.02           # M15: research consensus Neutral rate
+    rate_multiplier: 1.0            # M15: consensus Neutral [0%,+4%]; variant: baseline
     pitch_delta_st: 0               # M15: male pitch stays flat
-    volume_delta_db: 0
+    volume_delta_db: +1
     rms_target_dbfs: -25
   3:
     style: "General"
-    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    rate_multiplier: 1.05           # M15: consensus Irritation [+2%,+8%]; variant: mid
     pitch_delta_st: +1              # M15: male pitch -1% to +3%
     volume_delta_db: +3
     rms_target_dbfs: -22
   4:
     style: "General"
-    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    rate_multiplier: 1.09           # M15: consensus Anger [+4%,+12%]; variant: mid-high
     pitch_delta_st: +2              # M15: male pitch -1% to +5%
     volume_delta_db: +8
     rms_target_dbfs: -19
   5:
     style: "General"
-    rate_multiplier: 1.12           # M15: research consensus Shouting rate
+    rate_multiplier: 1.13           # M15: consensus Shouting [+8%,+15%]; variant: mid
     pitch_delta_st: +2              # M15: male pitch 0% to +5%; hard cap
-    volume_delta_db: +13
+    volume_delta_db: +12
     rms_target_dbfs: -15
 
 disfluency:

--- a/configs/speakers/speaker_AGG_M_30-45_003.yaml
+++ b/configs/speakers/speaker_AGG_M_30-45_003.yaml
@@ -23,32 +23,32 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: 0
+    rate_multiplier: 0.98           # M15: research consensus Calm rate
+    pitch_delta_st: 0               # M15: male pitch -3% to +2%
     volume_delta_db: 0
     rms_target_dbfs: -28
   2:
     style: "General"
-    rate_multiplier: 1.05
-    pitch_delta_st: 0
-    volume_delta_db: +2
+    rate_multiplier: 1.02           # M15: research consensus Neutral rate
+    pitch_delta_st: 0               # M15: male pitch stays flat
+    volume_delta_db: 0
     rms_target_dbfs: -25
   3:
-    style: "angry"
-    rate_multiplier: 1.12
-    pitch_delta_st: 0
-    volume_delta_db: +5
+    style: "General"
+    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    pitch_delta_st: +1              # M15: male pitch -1% to +3%
+    volume_delta_db: +3
     rms_target_dbfs: -22
   4:
-    style: "angry"
-    rate_multiplier: 1.18
-    pitch_delta_st: +1
-    volume_delta_db: +9
+    style: "General"
+    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    pitch_delta_st: +2              # M15: male pitch -1% to +5%
+    volume_delta_db: +8
     rms_target_dbfs: -19
   5:
-    style: "angry"
-    rate_multiplier: 1.22
-    pitch_delta_st: +1
+    style: "General"
+    rate_multiplier: 1.12           # M15: research consensus Shouting rate
+    pitch_delta_st: +2              # M15: male pitch 0% to +5%; hard cap
     volume_delta_db: +13
     rms_target_dbfs: -15
 

--- a/configs/speakers/speaker_BEN_M_40-55_004.yaml
+++ b/configs/speakers/speaker_BEN_M_40-55_004.yaml
@@ -21,32 +21,32 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.98           # M15: research consensus Calm rate
+    rate_multiplier: 0.97           # M15: consensus Calm [-6%,+2%]; variant: mid-low
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -28
   2:
     style: "General"
-    rate_multiplier: 1.02           # M15: research consensus Neutral rate
+    rate_multiplier: 1.02           # M15: consensus Neutral [0%,+4%]; variant: low-mid
     pitch_delta_st: 0
-    volume_delta_db: 0
+    volume_delta_db: +1
     rms_target_dbfs: -25
   3:
     style: "General"
-    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    rate_multiplier: 1.06           # M15: consensus Irritation [+2%,+8%]; variant: mid-high
     pitch_delta_st: +1
-    volume_delta_db: +3
+    volume_delta_db: +4
     rms_target_dbfs: -22
   4:
     style: "General"
-    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    rate_multiplier: 1.10           # M15: consensus Anger [+4%,+12%]; variant: upper-mid
     pitch_delta_st: +2
-    volume_delta_db: +8
+    volume_delta_db: +9
     rms_target_dbfs: -19
   5:
     style: "General"
-    rate_multiplier: 1.12           # M15: research consensus Shouting rate
-    pitch_delta_st: +2
+    rate_multiplier: 1.14           # M15: consensus Shouting [+8%,+15%]; variant: mid-high
+    pitch_delta_st: +3              # M15: male pitch upper bound
     volume_delta_db: +13
     rms_target_dbfs: -15
 

--- a/configs/speakers/speaker_BEN_M_40-55_004.yaml
+++ b/configs/speakers/speaker_BEN_M_40-55_004.yaml
@@ -21,32 +21,32 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 1.0
+    rate_multiplier: 0.98           # M15: research consensus Calm rate
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -28
   2:
     style: "General"
-    rate_multiplier: 1.05
+    rate_multiplier: 1.02           # M15: research consensus Neutral rate
     pitch_delta_st: 0
-    volume_delta_db: +2
+    volume_delta_db: 0
     rms_target_dbfs: -25
   3:
     style: "General"
-    rate_multiplier: 1.15
-    pitch_delta_st: 0
-    volume_delta_db: +5
+    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    pitch_delta_st: +1
+    volume_delta_db: +3
     rms_target_dbfs: -22
   4:
     style: "General"
-    rate_multiplier: 1.22
-    pitch_delta_st: +1
-    volume_delta_db: +9
+    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    pitch_delta_st: +2
+    volume_delta_db: +8
     rms_target_dbfs: -19
   5:
     style: "General"
-    rate_multiplier: 1.30
-    pitch_delta_st: +1
+    rate_multiplier: 1.12           # M15: research consensus Shouting rate
+    pitch_delta_st: +2
     volume_delta_db: +13
     rms_target_dbfs: -15
 

--- a/configs/speakers/speaker_BEN_M_40-55_005.yaml
+++ b/configs/speakers/speaker_BEN_M_40-55_005.yaml
@@ -24,33 +24,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.98           # M15: research consensus Calm rate
+    rate_multiplier: 1.0            # M15: consensus Calm [-6%,+2%]; variant: upper (fast talker)
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -28
   2:
     style: "General"
-    rate_multiplier: 1.02           # M15: research consensus Neutral rate
+    rate_multiplier: 1.03           # M15: consensus Neutral [0%,+4%]; variant: upper-mid
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -25
   3:
     style: "General"
-    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    rate_multiplier: 1.08           # M15: consensus Irritation [+2%,+8%]; variant: upper
     pitch_delta_st: +1
     volume_delta_db: +3
     rms_target_dbfs: -22
   4:
     style: "General"
-    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    rate_multiplier: 1.12           # M15: consensus Anger [+4%,+12%]; variant: upper
     pitch_delta_st: +2
-    volume_delta_db: +8
+    volume_delta_db: +9
     rms_target_dbfs: -19
   5:
     style: "General"
-    rate_multiplier: 1.12           # M15: research consensus Shouting rate
-    pitch_delta_st: +2
-    volume_delta_db: +13
+    rate_multiplier: 1.15           # M15: consensus Shouting [+8%,+15%]; variant: upper
+    pitch_delta_st: +3              # M15: male pitch upper bound
+    volume_delta_db: +14
     rms_target_dbfs: -15
 
 disfluency:

--- a/configs/speakers/speaker_BEN_M_40-55_005.yaml
+++ b/configs/speakers/speaker_BEN_M_40-55_005.yaml
@@ -24,32 +24,32 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 1.0
+    rate_multiplier: 0.98           # M15: research consensus Calm rate
     pitch_delta_st: 0
     volume_delta_db: 0
     rms_target_dbfs: -28
   2:
     style: "General"
-    rate_multiplier: 1.05
+    rate_multiplier: 1.02           # M15: research consensus Neutral rate
     pitch_delta_st: 0
-    volume_delta_db: +2
+    volume_delta_db: 0
     rms_target_dbfs: -25
   3:
-    style: "angry"
-    rate_multiplier: 1.18
-    pitch_delta_st: 0
-    volume_delta_db: +5
+    style: "General"
+    rate_multiplier: 1.05           # M15: research consensus Irritation rate
+    pitch_delta_st: +1
+    volume_delta_db: +3
     rms_target_dbfs: -22
   4:
-    style: "angry"
-    rate_multiplier: 1.25
-    pitch_delta_st: +1
-    volume_delta_db: +9
+    style: "General"
+    rate_multiplier: 1.08           # M15: research consensus Anger rate
+    pitch_delta_st: +2
+    volume_delta_db: +8
     rms_target_dbfs: -19
   5:
-    style: "angry"
-    rate_multiplier: 1.35
-    pitch_delta_st: +1
+    style: "General"
+    rate_multiplier: 1.12           # M15: research consensus Shouting rate
+    pitch_delta_st: +2
     volume_delta_db: +13
     rms_target_dbfs: -15
 

--- a/configs/speakers/speaker_SW_F_30-45_002.yaml
+++ b/configs/speakers/speaker_SW_F_30-45_002.yaml
@@ -21,33 +21,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: -4
+    rate_multiplier: 0.97           # M15: female Calm rate
+    pitch_delta_st: -2              # M15: female pitch -3% to +2%
     volume_delta_db: 0
     rms_target_dbfs: -26
   2:
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: -3
-    volume_delta_db: +1
+    rate_multiplier: 1.0            # M15: female Neutral rate
+    pitch_delta_st: -1              # M15: female pitch -2% to +3%
+    volume_delta_db: 0
     rms_target_dbfs: -27
   3:
     style: "General"
-    rate_multiplier: 0.95
-    pitch_delta_st: -3
-    volume_delta_db: +2
+    rate_multiplier: 0.95           # M15: female Irritation rate; SW slows deliberately
+    pitch_delta_st: +1              # M15: female pitch 0% to +5%
+    volume_delta_db: +3
     rms_target_dbfs: -28
   4:
     style: "General"
-    rate_multiplier: 1.05
-    pitch_delta_st: -2
-    volume_delta_db: +4
+    rate_multiplier: 0.98           # M15: female Anger rate; SW tries to stay controlled
+    pitch_delta_st: +3              # M15: female pitch +2% to +7%
+    volume_delta_db: +5
     rms_target_dbfs: -29
   5:
     style: "General"
-    rate_multiplier: 1.20
-    pitch_delta_st: -1
-    volume_delta_db: +5
+    rate_multiplier: 1.08           # M15: female Shouting rate; panic
+    pitch_delta_st: +5              # M15: female pitch +4% to +10%
+    volume_delta_db: +7
     rms_target_dbfs: -30
 
 disfluency:

--- a/configs/speakers/speaker_SW_F_30-45_002.yaml
+++ b/configs/speakers/speaker_SW_F_30-45_002.yaml
@@ -21,33 +21,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.97           # M15: female Calm rate
-    pitch_delta_st: -2              # M15: female pitch -3% to +2%
+    rate_multiplier: 0.98           # M15: consensus Calm; variant: professional baseline
+    pitch_delta_st: -1              # M15: female pitch -3% to +2%; variant: mild
     volume_delta_db: 0
     rms_target_dbfs: -26
   2:
     style: "General"
-    rate_multiplier: 1.0            # M15: female Neutral rate
-    pitch_delta_st: -1              # M15: female pitch -2% to +3%
+    rate_multiplier: 1.01           # M15: consensus Neutral [0%,+4%]; variant: slightly quick
+    pitch_delta_st: 0               # M15: female pitch -2% to +3%; variant: neutral
     volume_delta_db: 0
     rms_target_dbfs: -27
   3:
     style: "General"
-    rate_multiplier: 0.95           # M15: female Irritation rate; SW slows deliberately
+    rate_multiplier: 0.94           # M15: consensus Irritation; variant: deliberate slowing
     pitch_delta_st: +1              # M15: female pitch 0% to +5%
-    volume_delta_db: +3
+    volume_delta_db: +2
     rms_target_dbfs: -28
   4:
     style: "General"
-    rate_multiplier: 0.98           # M15: female Anger rate; SW tries to stay controlled
+    rate_multiplier: 0.96           # M15: consensus Anger; variant: controlled
     pitch_delta_st: +3              # M15: female pitch +2% to +7%
-    volume_delta_db: +5
+    volume_delta_db: +4
     rms_target_dbfs: -29
   5:
     style: "General"
-    rate_multiplier: 1.08           # M15: female Shouting rate; panic
+    rate_multiplier: 1.06           # M15: consensus Shouting; variant: panic
     pitch_delta_st: +5              # M15: female pitch +4% to +10%
-    volume_delta_db: +7
+    volume_delta_db: +6
     rms_target_dbfs: -30
 
 disfluency:

--- a/configs/speakers/speaker_SW_F_30-45_003.yaml
+++ b/configs/speakers/speaker_SW_F_30-45_003.yaml
@@ -24,33 +24,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.97           # M15: female Calm rate
+    rate_multiplier: 0.95           # M15: consensus Calm; variant: deliberately slow
     pitch_delta_st: -2              # M15: female pitch -3% to +2%
     volume_delta_db: 0
     rms_target_dbfs: -26
   2:
     style: "General"
-    rate_multiplier: 1.0            # M15: female Neutral rate
+    rate_multiplier: 0.98           # M15: consensus Neutral; variant: measured
     pitch_delta_st: -1              # M15: female pitch -2% to +3%
     volume_delta_db: 0
     rms_target_dbfs: -27
   3:
     style: "General"
-    rate_multiplier: 0.95           # M15: female Irritation rate; SW slows
-    pitch_delta_st: +1              # M15: female pitch 0% to +5%
+    rate_multiplier: 0.92           # M15: consensus Irritation; variant: very deliberate
+    pitch_delta_st: +2              # M15: female pitch 0% to +5%; variant: higher tension
     volume_delta_db: +3
     rms_target_dbfs: -28
   4:
     style: "General"
-    rate_multiplier: 0.98           # M15: female Anger rate; SW controlled
-    pitch_delta_st: +3              # M15: female pitch +2% to +7%
+    rate_multiplier: 0.95           # M15: consensus Anger; variant: slow/controlled
+    pitch_delta_st: +4              # M15: female pitch +2% to +7%
     volume_delta_db: +5
     rms_target_dbfs: -29
   5:
     style: "General"
-    rate_multiplier: 1.08           # M15: female Shouting rate; panic
-    pitch_delta_st: +5              # M15: female pitch +4% to +10%
-    volume_delta_db: +7
+    rate_multiplier: 1.10           # M15: consensus Shouting; variant: high panic
+    pitch_delta_st: +6              # M15: female pitch +4% to +10%; variant: upper
+    volume_delta_db: +8
     rms_target_dbfs: -30
 
 disfluency:

--- a/configs/speakers/speaker_SW_F_30-45_003.yaml
+++ b/configs/speakers/speaker_SW_F_30-45_003.yaml
@@ -24,33 +24,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: -4
+    rate_multiplier: 0.97           # M15: female Calm rate
+    pitch_delta_st: -2              # M15: female pitch -3% to +2%
     volume_delta_db: 0
     rms_target_dbfs: -26
   2:
     style: "General"
-    rate_multiplier: 1.0
-    pitch_delta_st: -3
-    volume_delta_db: +1
+    rate_multiplier: 1.0            # M15: female Neutral rate
+    pitch_delta_st: -1              # M15: female pitch -2% to +3%
+    volume_delta_db: 0
     rms_target_dbfs: -27
   3:
-    style: "sad"
-    rate_multiplier: 0.92
-    pitch_delta_st: -3
-    volume_delta_db: +2
+    style: "General"
+    rate_multiplier: 0.95           # M15: female Irritation rate; SW slows
+    pitch_delta_st: +1              # M15: female pitch 0% to +5%
+    volume_delta_db: +3
     rms_target_dbfs: -28
   4:
-    style: "sad"
-    rate_multiplier: 1.0
-    pitch_delta_st: -2
-    volume_delta_db: +4
+    style: "General"
+    rate_multiplier: 0.98           # M15: female Anger rate; SW controlled
+    pitch_delta_st: +3              # M15: female pitch +2% to +7%
+    volume_delta_db: +5
     rms_target_dbfs: -29
   5:
-    style: "sad"
-    rate_multiplier: 1.15
-    pitch_delta_st: -1
-    volume_delta_db: +5
+    style: "General"
+    rate_multiplier: 1.08           # M15: female Shouting rate; panic
+    pitch_delta_st: +5              # M15: female pitch +4% to +10%
+    volume_delta_db: +7
     rms_target_dbfs: -30
 
 disfluency:

--- a/configs/speakers/speaker_VIC_F_25-40_004.yaml
+++ b/configs/speakers/speaker_VIC_F_25-40_004.yaml
@@ -23,32 +23,32 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.97           # M15: female Calm rate; VIC slightly hesitant
+    rate_multiplier: 0.96           # M15: consensus Calm [-6%,+2%]; variant: hesitant
     pitch_delta_st: -2              # M15: female pitch -3% to +2%
     volume_delta_db: 0
     rms_target_dbfs: -26
   2:
     style: "General"
-    rate_multiplier: 0.97           # M15: female Neutral rate
+    rate_multiplier: 0.97           # M15: consensus Neutral [0%,+4%]; variant: guarded
     pitch_delta_st: -1              # M15: female pitch -2% to +3%
     volume_delta_db: 0
     rms_target_dbfs: -27
   3:
     style: "General"
-    rate_multiplier: 0.95           # M15: female Irritation rate; VIC slows
-    pitch_delta_st: +1              # M15: female pitch 0% to +5%
+    rate_multiplier: 0.93           # M15: consensus Irritation; variant: slow
+    pitch_delta_st: +2              # M15: female pitch 0% to +5%
     volume_delta_db: +3
     rms_target_dbfs: -28
   4:
     style: "General"
-    rate_multiplier: 0.95           # M15: female Anger rate; VIC pleading
-    pitch_delta_st: +3              # M15: female pitch +2% to +7%
+    rate_multiplier: 0.94           # M15: consensus Anger; variant: slow pleading
+    pitch_delta_st: +4              # M15: female pitch +2% to +7%
     volume_delta_db: +5
     rms_target_dbfs: -29
   5:
     style: "General"
-    rate_multiplier: 1.05           # M15: female Shouting rate; panic speeds up
-    pitch_delta_st: +5              # M15: female pitch +4% to +10%
+    rate_multiplier: 1.06           # M15: consensus Shouting; variant: panic
+    pitch_delta_st: +6              # M15: female pitch +4% to +10%
     volume_delta_db: +7
     rms_target_dbfs: -30
 

--- a/configs/speakers/speaker_VIC_F_25-40_004.yaml
+++ b/configs/speakers/speaker_VIC_F_25-40_004.yaml
@@ -23,33 +23,33 @@ prosody_baseline:
 style_map:
   1:
     style: "General"
-    rate_multiplier: 0.95
-    pitch_delta_st: -4
+    rate_multiplier: 0.97           # M15: female Calm rate; VIC slightly hesitant
+    pitch_delta_st: -2              # M15: female pitch -3% to +2%
     volume_delta_db: 0
     rms_target_dbfs: -26
   2:
     style: "General"
-    rate_multiplier: 0.98
-    pitch_delta_st: -3
-    volume_delta_db: -1
+    rate_multiplier: 0.97           # M15: female Neutral rate
+    pitch_delta_st: -1              # M15: female pitch -2% to +3%
+    volume_delta_db: 0
     rms_target_dbfs: -27
   3:
-    style: "sad"
-    rate_multiplier: 1.0
-    pitch_delta_st: -2
-    volume_delta_db: -2
+    style: "General"
+    rate_multiplier: 0.95           # M15: female Irritation rate; VIC slows
+    pitch_delta_st: +1              # M15: female pitch 0% to +5%
+    volume_delta_db: +3
     rms_target_dbfs: -28
   4:
-    style: "sad"
-    rate_multiplier: 1.05
-    pitch_delta_st: -1
-    volume_delta_db: -3
+    style: "General"
+    rate_multiplier: 0.95           # M15: female Anger rate; VIC pleading
+    pitch_delta_st: +3              # M15: female pitch +2% to +7%
+    volume_delta_db: +5
     rms_target_dbfs: -29
   5:
-    style: "sad"
-    rate_multiplier: 1.10
-    pitch_delta_st: -1
-    volume_delta_db: -4
+    style: "General"
+    rate_multiplier: 1.05           # M15: female Shouting rate; panic speeds up
+    pitch_delta_st: +5              # M15: female pitch +4% to +10%
+    volume_delta_db: +7
     rms_target_dbfs: -30
 
 disfluency:

--- a/synthbanshee/script/types.py
+++ b/synthbanshee/script/types.py
@@ -51,6 +51,9 @@ class DialogueTurn:
     # M7: snapshot of SpeakerState.to_metadata_dict() at render time (pre-update).
     # Populated by TTSRenderer.render_scene(); empty when rendered without state.
     speaker_state_snapshot: dict[str, float] = field(default_factory=dict)
+    # M15: quality gate failures recorded during render_scene().
+    # Each entry is "{gate_name}: {detail}".  Empty list means all gates passed.
+    quality_gate_failures: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         # Default text_spoken to the original LLM text when not explicitly set.

--- a/synthbanshee/tts/quality_gates.py
+++ b/synthbanshee/tts/quality_gates.py
@@ -33,11 +33,17 @@ FEMALE_F0_MIN_HZ: float = 150.0
 FEMALE_F0_MAX_HZ: float = 290.0
 
 # Click detection: minimum absolute sample-to-sample jump (normalized to [-1,1])
-# that qualifies as a DC-offset click.  Empirically: 0.05 of full-scale.
-CLICK_THRESHOLD: float = 0.05
+# that qualifies as a DC-offset click.  Set at 0.15 to avoid false positives on
+# legitimate plosive transients (/p/, /t/, /k/) which typically peak around 0.1.
+# True DC-offset jumps from SSML block boundaries are typically 0.2+.
+CLICK_THRESHOLD: float = 0.15
 
-# Minimum number of click events to flag a turn.
+# Minimum number of *isolated* click events to flag a turn.
 CLICK_COUNT_THRESHOLD: int = 3
+
+# Number of neighboring samples that must be below threshold for a spike to
+# qualify as an isolated click (vs. a plosive burst which spans many samples).
+CLICK_ISOLATION_RADIUS: int = 3
 
 
 # ---------------------------------------------------------------------------
@@ -200,7 +206,10 @@ def check_clicks(samples: np.ndarray, sr: int) -> GateResult:
     """Detect DC-offset jump clicks in the audio.
 
     Clicks manifest as sudden large sample-to-sample amplitude changes,
-    typically at SSML block boundaries.
+    typically at SSML block boundaries.  To distinguish from legitimate
+    plosive transients (which span many consecutive high-diff samples),
+    only *isolated* spikes are counted — a diff event is a click only if
+    the surrounding ±CLICK_ISOLATION_RADIUS samples are all below threshold.
 
     Args:
         samples: Float32 audio samples, mono, normalized to [-1, 1].
@@ -214,13 +223,30 @@ def check_clicks(samples: np.ndarray, sr: int) -> GateResult:
 
     # Compute absolute sample-to-sample differences
     diffs = np.abs(np.diff(samples))
-    click_count = int(np.sum(diffs > CLICK_THRESHOLD))
+    candidates = np.where(diffs > CLICK_THRESHOLD)[0]
+
+    if len(candidates) < CLICK_COUNT_THRESHOLD:
+        return GateResult(passed=True)
+
+    # Filter to isolated spikes: surrounding samples must be below threshold
+    radius = CLICK_ISOLATION_RADIUS
+    click_count = 0
+    for idx in candidates:
+        lo = max(0, idx - radius)
+        hi = min(len(diffs), idx + radius + 1)
+        # Count how many neighbors (excluding self) are above threshold
+        neighborhood = diffs[lo:hi]
+        n_above = int(np.sum(neighborhood > CLICK_THRESHOLD))
+        # An isolated click has only 1-2 samples above threshold (the jump itself
+        # and possibly the immediate return)
+        if n_above <= 2:
+            click_count += 1
 
     if click_count >= CLICK_COUNT_THRESHOLD:
         return GateResult(
             passed=False,
             gate_name="click_detection",
-            detail=f"Detected {click_count} click events (threshold: {CLICK_COUNT_THRESHOLD})",
+            detail=f"Detected {click_count} isolated click events (threshold: {CLICK_COUNT_THRESHOLD})",
         )
     return GateResult(passed=True)
 

--- a/synthbanshee/tts/quality_gates.py
+++ b/synthbanshee/tts/quality_gates.py
@@ -1,0 +1,266 @@
+"""M15 — Turn-level quality gates for post-TTS render validation.
+
+Quality gates reject or flag individual turn renders that exhibit unrealistic
+acoustic properties.  Gates run after TTS synthesis but before mixing, so
+bad turns can be re-rendered or excluded early.
+
+Research reference: wiki/topics/research-synthesis.md §Quality Gates (lines 159-171).
+
+Three gates implemented:
+1. Sustained-vowel detection — reject turns with >2.8 s single sustained voiced segment.
+2. F0 guardrails — reject if median F0 outside gender-specific range.
+3. Click detection — flag DC-offset jumps between SSML blocks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Thresholds (from research-synthesis.md §Quality Gates)
+# ---------------------------------------------------------------------------
+
+# Maximum sustained voiced segment duration (seconds).
+MAX_SUSTAINED_VOICED_S: float = 2.8
+
+# F0 guardrail ranges (Hz) — reject if median F0 outside.
+MALE_F0_MIN_HZ: float = 80.0
+MALE_F0_MAX_HZ: float = 180.0
+FEMALE_F0_MIN_HZ: float = 150.0
+FEMALE_F0_MAX_HZ: float = 290.0
+
+# Click detection: minimum absolute sample-to-sample jump (normalized to [-1,1])
+# that qualifies as a DC-offset click.  Empirically: 0.05 of full-scale.
+CLICK_THRESHOLD: float = 0.05
+
+# Minimum number of click events to flag a turn.
+CLICK_COUNT_THRESHOLD: int = 3
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GateResult:
+    """Result of a quality gate check on a single turn render.
+
+    Attributes:
+        passed: True if the turn passes all gates.
+        gate_name: Name of the first gate that failed (None if passed).
+        detail: Human-readable detail about the failure.
+    """
+
+    passed: bool
+    gate_name: str | None = None
+    detail: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Gate implementations
+# ---------------------------------------------------------------------------
+
+
+def _wav_bytes_to_samples(wav_bytes: bytes) -> tuple[np.ndarray, int]:
+    """Parse raw WAV bytes into float32 samples and sample rate.
+
+    Handles 16-bit PCM WAV (the only format in this pipeline).
+    Returns samples normalized to [-1.0, 1.0].
+    """
+    import io
+
+    import soundfile as sf
+
+    with io.BytesIO(wav_bytes) as buf:
+        samples, sr = sf.read(buf, dtype="float32")
+    # Ensure mono
+    if samples.ndim > 1:
+        samples = samples[:, 0]
+    return samples, int(sr)
+
+
+def check_sustained_vowel(samples: np.ndarray, sr: int) -> GateResult:
+    """Detect sustained voiced segments longer than MAX_SUSTAINED_VOICED_S.
+
+    Uses energy-based voice activity detection: a frame is "voiced" if its
+    RMS exceeds -40 dBFS.  Consecutive voiced frames form a segment.
+
+    Args:
+        samples: Float32 audio samples, mono, normalized to [-1, 1].
+        sr: Sample rate (Hz).
+
+    Returns:
+        GateResult indicating pass/fail.
+    """
+    frame_len = int(0.020 * sr)  # 20ms frames
+    hop = int(0.010 * sr)  # 10ms hop
+    threshold_linear = 10 ** (-40 / 20)  # -40 dBFS
+
+    n_frames = max(0, (len(samples) - frame_len) // hop + 1)
+    if n_frames == 0:
+        return GateResult(passed=True)
+
+    max_voiced_frames = 0
+    current_run = 0
+
+    for i in range(n_frames):
+        start = i * hop
+        frame = samples[start : start + frame_len]
+        rms = np.sqrt(np.mean(frame**2))
+        if rms > threshold_linear:
+            current_run += 1
+        else:
+            max_voiced_frames = max(max_voiced_frames, current_run)
+            current_run = 0
+    max_voiced_frames = max(max_voiced_frames, current_run)
+
+    max_duration_s = max_voiced_frames * (hop / sr)
+    if max_duration_s > MAX_SUSTAINED_VOICED_S:
+        return GateResult(
+            passed=False,
+            gate_name="sustained_vowel",
+            detail=f"Sustained voiced segment {max_duration_s:.2f}s > {MAX_SUSTAINED_VOICED_S}s",
+        )
+    return GateResult(passed=True)
+
+
+def check_f0_guardrails(
+    samples: np.ndarray,
+    sr: int,
+    gender: Literal["male", "female"],
+) -> GateResult:
+    """Check that median F0 falls within gender-appropriate range.
+
+    Uses autocorrelation-based pitch estimation on voiced frames.
+
+    Args:
+        samples: Float32 audio samples, mono.
+        sr: Sample rate (Hz).
+        gender: Speaker gender for range selection.
+
+    Returns:
+        GateResult indicating pass/fail.
+    """
+    f0_min = MALE_F0_MIN_HZ if gender == "male" else FEMALE_F0_MIN_HZ
+    f0_max = MALE_F0_MAX_HZ if gender == "male" else FEMALE_F0_MAX_HZ
+
+    # Estimate F0 using autocorrelation on 30ms frames
+    frame_len = int(0.030 * sr)
+    hop = int(0.010 * sr)
+    n_frames = max(0, (len(samples) - frame_len) // hop + 1)
+
+    if n_frames == 0:
+        return GateResult(passed=True)
+
+    f0_estimates: list[float] = []
+    # Search range in lag samples
+    min_lag = int(sr / 500)  # 500 Hz max
+    max_lag = int(sr / 50)  # 50 Hz min
+
+    for i in range(n_frames):
+        start = i * hop
+        frame = samples[start : start + frame_len]
+        # Skip silent frames
+        if np.sqrt(np.mean(frame**2)) < 10 ** (-40 / 20):
+            continue
+        # Autocorrelation
+        corr = np.correlate(frame, frame, mode="full")
+        corr = corr[len(corr) // 2 :]  # positive lags only
+        if max_lag >= len(corr):
+            continue
+        # Find peak in valid range
+        search = corr[min_lag : max_lag + 1]
+        if len(search) == 0:
+            continue
+        peak_idx = int(np.argmax(search)) + min_lag
+        # Voicing confidence: ratio of peak to zero-lag
+        if corr[0] > 0 and corr[peak_idx] / corr[0] > 0.3:
+            f0_estimates.append(sr / peak_idx)
+
+    if len(f0_estimates) < 5:
+        # Too few voiced frames to make a judgment — pass by default
+        return GateResult(passed=True)
+
+    median_f0 = float(np.median(f0_estimates))
+
+    if median_f0 < f0_min or median_f0 > f0_max:
+        return GateResult(
+            passed=False,
+            gate_name="f0_guardrails",
+            detail=(f"Median F0 {median_f0:.1f} Hz outside {gender} range [{f0_min}, {f0_max}] Hz"),
+        )
+    return GateResult(passed=True)
+
+
+def check_clicks(samples: np.ndarray, sr: int) -> GateResult:
+    """Detect DC-offset jump clicks in the audio.
+
+    Clicks manifest as sudden large sample-to-sample amplitude changes,
+    typically at SSML block boundaries.
+
+    Args:
+        samples: Float32 audio samples, mono, normalized to [-1, 1].
+        sr: Sample rate (Hz).
+
+    Returns:
+        GateResult indicating pass/fail.
+    """
+    if len(samples) < 2:
+        return GateResult(passed=True)
+
+    # Compute absolute sample-to-sample differences
+    diffs = np.abs(np.diff(samples))
+    click_count = int(np.sum(diffs > CLICK_THRESHOLD))
+
+    if click_count >= CLICK_COUNT_THRESHOLD:
+        return GateResult(
+            passed=False,
+            gate_name="click_detection",
+            detail=f"Detected {click_count} click events (threshold: {CLICK_COUNT_THRESHOLD})",
+        )
+    return GateResult(passed=True)
+
+
+# ---------------------------------------------------------------------------
+# Composite gate runner
+# ---------------------------------------------------------------------------
+
+
+def run_quality_gates(
+    wav_bytes: bytes,
+    gender: Literal["male", "female"],
+) -> GateResult:
+    """Run all turn-level quality gates on rendered WAV bytes.
+
+    Gates are evaluated in order; first failure is returned.
+    If all pass, returns a passing GateResult.
+
+    Args:
+        wav_bytes: Raw WAV file bytes (16 kHz, mono, PCM16 or float32).
+        gender: Speaker gender for F0 range selection.
+
+    Returns:
+        GateResult from the first failing gate, or a pass result.
+    """
+    samples, sr = _wav_bytes_to_samples(wav_bytes)
+
+    # Gate 1: sustained vowel
+    result = check_sustained_vowel(samples, sr)
+    if not result.passed:
+        return result
+
+    # Gate 2: F0 guardrails
+    result = check_f0_guardrails(samples, sr, gender)
+    if not result.passed:
+        return result
+
+    # Gate 3: click detection
+    result = check_clicks(samples, sr)
+    if not result.passed:
+        return result
+
+    return GateResult(passed=True)

--- a/synthbanshee/tts/quality_gates.py
+++ b/synthbanshee/tts/quality_gates.py
@@ -72,10 +72,10 @@ class GateResult:
 
 
 def _wav_bytes_to_samples(wav_bytes: bytes) -> tuple[np.ndarray, int]:
-    """Parse raw WAV bytes into float32 samples and sample rate.
+    """Parse pipeline WAV bytes into mono float32 samples and sample rate.
 
-    Handles 16-bit PCM WAV (the only format in this pipeline).
-    Returns samples normalized to [-1.0, 1.0].
+    Accepts any WAV subtype readable by soundfile (PCM16, float32, etc.)
+    and returns samples normalized to [-1.0, 1.0].
     """
     import io
 

--- a/synthbanshee/tts/quality_gates.py
+++ b/synthbanshee/tts/quality_gates.py
@@ -124,7 +124,10 @@ def check_sustained_vowel(samples: np.ndarray, sr: int) -> GateResult:
             current_run = 0
     max_voiced_frames = max(max_voiced_frames, current_run)
 
-    max_duration_s = max_voiced_frames * (hop / sr)
+    # Duration = first frame length + (N-1) hops (frames overlap by frame_len - hop).
+    max_duration_s = (
+        (frame_len + (max_voiced_frames - 1) * hop) / sr if max_voiced_frames > 0 else 0.0
+    )
     if max_duration_s > MAX_SUSTAINED_VOICED_S:
         return GateResult(
             passed=False,

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 from synthbanshee.script.types import DialogueTurn, MixedScene
 from synthbanshee.tts.mix_mode import MixMode
 from synthbanshee.tts.provider import TTSProvider
+from synthbanshee.tts.quality_gates import run_quality_gates
 from synthbanshee.tts.speaker_state import SpeakerState
 from synthbanshee.tts.ssml_builder import SSMLBuilder
 from synthbanshee.tts.ssml_types import PhraseProsody, collect_phrase_prosody, rebase_phrase_prosody
@@ -303,9 +304,24 @@ class TTSRenderer:
                 speaker_state=state,
                 phrase_prosody=phrases if phrases else None,
             )
+            # M15: run turn-level quality gates on the rendered audio.
+            gate_result = run_quality_gates(wav_bytes, speaker.gender)
+            if not gate_result.passed and verbose_log is not None:
+                verbose_log(
+                    f"  [yellow]turn {i + 1:02d}/{len(turns):02d}"
+                    f" [{turn.speaker_id}] quality gate FAILED:"
+                    f" {gate_result.gate_name}: {gate_result.detail}[/yellow]"
+                )
             # Update state after rendering so the first turn always uses neutral
             # state and drift accumulates from the second turn onward.
             state.update(turn.intensity, speaker.role)
+            # M15: warn if accumulated F0 drift exceeds the 2.0 st bound.
+            if state.f0_drift_exceeded and verbose_log is not None:
+                verbose_log(
+                    f"  [yellow]turn {i + 1:02d}/{len(turns):02d}"
+                    f" [{turn.speaker_id}] F0 drift {state.pitch_offset_st:.2f} st"
+                    f" exceeds ±{state.__class__.__name__} bound[/yellow]"
+                )
             if verbose_log is not None:
                 status = "cache hit" if hit else "rendered"
                 verbose_log(

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -316,9 +316,10 @@ class TTSRenderer:
                 from synthbanshee.tts.speaker_state import MAX_F0_DRIFT_ST
 
                 gate_result = run_quality_gates(wav_bytes, speaker.gender)
-                retries_left = quality_gate_retries if randomize else 0
-                while not gate_result.passed and retries_left > 0:
-                    retries_left -= 1
+                max_retries = quality_gate_retries if randomize else 0
+                retries_attempted = 0
+                while not gate_result.passed and retries_attempted < max_retries:
+                    retries_attempted += 1
                     render_seed = rng.randint(0, 2**31)
                     wav_bytes, _, hit = self.render_utterance(
                         text,
@@ -337,7 +338,7 @@ class TTSRenderer:
                         verbose_log(
                             f"  [yellow]turn {i + 1:02d}/{len(turns):02d}"
                             f" [{turn.speaker_id}] quality gate FAILED"
-                            f" (after {quality_gate_retries} retries):"
+                            f" (after {retries_attempted} retries):"
                             f" {failure_str}[/yellow]"
                         )
             # Update state after rendering so the first turn always uses neutral

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -223,6 +223,8 @@ class TTSRenderer:
         verbose_log: _VerboseLog | None = None,
         project: str = "she_proves",
         project_profile: ProjectProfile | None = None,
+        quality_gates: bool = True,
+        quality_gate_retries: int = 2,
     ) -> MixedScene:
         """Render a multi-speaker dialogue script to a MixedScene.
 
@@ -243,6 +245,10 @@ class TTSRenderer:
             project_profile: Optional ``ProjectProfile`` instance (M13).
                      When provided, gap timing and overlap probabilities are
                      loaded from the profile instead of the hardcoded tables.
+            quality_gates: If True (default), run M15 turn-level quality gates
+                     after each render.  Set False to skip for faster batch runs.
+            quality_gate_retries: Number of re-render attempts on gate failure
+                     (default 2).  Each retry uses a different random seed.
 
         Returns:
             MixedScene with concatenated audio and per-turn timing metadata.
@@ -295,32 +301,54 @@ class TTSRenderer:
                 text = new_text
             # Snapshot pre-render state for reproducibility metadata (prep for M11).
             turn.speaker_state_snapshot = state.to_metadata_dict()
+            render_seed = rng.randint(0, 2**31) if randomize else None
             wav_bytes, _, hit = self.render_utterance(
                 text,
                 speaker,
                 turn.intensity,
                 randomize=randomize,
-                rng_seed=rng.randint(0, 2**31) if randomize else None,
+                rng_seed=render_seed,
                 speaker_state=state,
                 phrase_prosody=phrases if phrases else None,
             )
-            # M15: run turn-level quality gates on the rendered audio.
-            gate_result = run_quality_gates(wav_bytes, speaker.gender)
-            if not gate_result.passed and verbose_log is not None:
-                verbose_log(
-                    f"  [yellow]turn {i + 1:02d}/{len(turns):02d}"
-                    f" [{turn.speaker_id}] quality gate FAILED:"
-                    f" {gate_result.gate_name}: {gate_result.detail}[/yellow]"
-                )
+            # M15: run turn-level quality gates with retry on failure.
+            if quality_gates:
+                from synthbanshee.tts.speaker_state import MAX_F0_DRIFT_ST
+
+                gate_result = run_quality_gates(wav_bytes, speaker.gender)
+                retries_left = quality_gate_retries if randomize else 0
+                while not gate_result.passed and retries_left > 0:
+                    retries_left -= 1
+                    render_seed = rng.randint(0, 2**31)
+                    wav_bytes, _, hit = self.render_utterance(
+                        text,
+                        speaker,
+                        turn.intensity,
+                        randomize=True,
+                        rng_seed=render_seed,
+                        speaker_state=state,
+                        phrase_prosody=phrases if phrases else None,
+                    )
+                    gate_result = run_quality_gates(wav_bytes, speaker.gender)
+                if not gate_result.passed:
+                    failure_str = f"{gate_result.gate_name}: {gate_result.detail}"
+                    turn.quality_gate_failures.append(failure_str)
+                    if verbose_log is not None:
+                        verbose_log(
+                            f"  [yellow]turn {i + 1:02d}/{len(turns):02d}"
+                            f" [{turn.speaker_id}] quality gate FAILED"
+                            f" (after {quality_gate_retries} retries):"
+                            f" {failure_str}[/yellow]"
+                        )
             # Update state after rendering so the first turn always uses neutral
             # state and drift accumulates from the second turn onward.
             state.update(turn.intensity, speaker.role)
             # M15: warn if accumulated F0 drift exceeds the 2.0 st bound.
-            if state.f0_drift_exceeded and verbose_log is not None:
+            if quality_gates and state.f0_drift_exceeded and verbose_log is not None:
                 verbose_log(
                     f"  [yellow]turn {i + 1:02d}/{len(turns):02d}"
                     f" [{turn.speaker_id}] F0 drift {state.pitch_offset_st:.2f} st"
-                    f" exceeds ±{state.__class__.__name__} bound[/yellow]"
+                    f" exceeds ±{MAX_F0_DRIFT_ST} st bound[/yellow]"
                 )
             if verbose_log is not None:
                 status = "cache hit" if hit else "rendered"

--- a/synthbanshee/tts/speaker_state.py
+++ b/synthbanshee/tts/speaker_state.py
@@ -52,6 +52,11 @@ _DRIFT_RATE_ESCALATE: float = 0.60
 # Fraction closed per turn when intensity drops (decay).
 _DRIFT_RATE_DECAY: float = 0.30
 
+# M15: Maximum unexplained F0 drift (semitones) across a clip.
+# Research consensus (wiki/topics/research-synthesis.md line 76):
+# reject if accumulated pitch drift exceeds this bound.
+MAX_F0_DRIFT_ST: float = 2.0
+
 
 def _target_for(role: str, intensity: int) -> tuple[float, float, float]:
     """Return the target offsets for *role* at *intensity* (clamped to 1–5)."""
@@ -115,6 +120,16 @@ class SpeakerState:
         self.rate_offset += drift * (t_rate - self.rate_offset)
         self.pitch_offset_st += drift * (t_pitch - self.pitch_offset_st)
         self.volume_offset_db += drift * (t_vol - self.volume_offset_db)
+
+    @property
+    def f0_drift_exceeded(self) -> bool:
+        """Return True if accumulated pitch drift exceeds the M15 bound.
+
+        The bound (``MAX_F0_DRIFT_ST``) limits unexplained F0 drift to 2.0
+        semitones across a clip, as recommended by the research synthesis
+        (wiki/topics/research-synthesis.md line 76).
+        """
+        return abs(self.pitch_offset_st) > MAX_F0_DRIFT_ST
 
     def to_metadata_dict(self) -> dict[str, float]:
         """Serialize current state for per-turn generation metadata (prep for M11).

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -162,12 +162,12 @@ class TestSpeakerConfig:
         cfg = SpeakerConfig.from_yaml(EXAMPLES_DIR / "speaker_AGG_M_30-45_001.yaml")
         assert 1 in cfg.style_map
         assert 5 in cfg.style_map
-        assert cfg.style_map[5].style == "angry"
+        assert cfg.style_map[5].style == "General"
 
     def test_style_for_intensity_exact(self):
         cfg = SpeakerConfig.from_yaml(EXAMPLES_DIR / "speaker_AGG_M_30-45_001.yaml")
         entry = cfg.style_for_intensity(3)
-        assert entry.style == "angry"
+        assert entry.style == "General"
 
     def test_style_for_intensity_fallback(self):
         cfg = SpeakerConfig.from_yaml(EXAMPLES_DIR / "speaker_AGG_M_30-45_001.yaml")

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -128,23 +128,29 @@ class TestClickDetectionGate:
         result = check_clicks(samples, SR)
         assert result.passed
 
-    def test_multiple_clicks_fails(self) -> None:
-        # Insert artificial DC jumps
-        samples = _sine(200.0, 1.0, amplitude=0.3)
-        # Insert clicks at several points
+    def test_isolated_dc_jumps_fail(self) -> None:
+        # Low-amplitude signal with isolated DC jumps (simulating SSML boundary clicks)
+        samples = np.zeros(16000, dtype=np.float32)
+        # Insert isolated spikes well-separated (>CLICK_ISOLATION_RADIUS apart)
         for pos in [1000, 3000, 5000, 7000]:
-            samples[pos] = 0.8  # Large jump from ~0.3 amplitude signal
+            samples[pos] = 0.8  # Isolated single-sample spike
         result = check_clicks(samples, SR)
         assert not result.passed
         assert result.gate_name == "click_detection"
 
+    def test_plosive_burst_passes(self) -> None:
+        # A plosive burst spans many consecutive high-diff samples — not isolated
+        samples = np.zeros(16000, dtype=np.float32)
+        # Simulate a plosive: multiple consecutive high-amplitude samples
+        samples[5000:5020] = 0.5  # 20-sample burst — NOT an isolated click
+        result = check_clicks(samples, SR)
+        assert result.passed
+
     def test_few_clicks_passes(self) -> None:
-        # Only 1 click — below threshold
-        samples = _sine(200.0, 1.0, amplitude=0.01)
+        # Only 1-2 isolated clicks — below count threshold of 3
+        samples = np.zeros(16000, dtype=np.float32)
         samples[5000] = 0.8
         result = check_clicks(samples, SR)
-        # One click gives exactly 2 diff events (jump up, jump back down)
-        # which is below the threshold of 3
         assert result.passed
 
     def test_empty_passes(self) -> None:

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -1,0 +1,208 @@
+"""Unit tests for M15 turn-level quality gates."""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import soundfile as sf
+
+from synthbanshee.tts.quality_gates import (
+    GateResult,
+    check_clicks,
+    check_f0_guardrails,
+    check_sustained_vowel,
+    run_quality_gates,
+)
+
+SR = 16_000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sine(freq_hz: float, duration_s: float, amplitude: float = 0.5) -> np.ndarray:
+    """Generate a mono float32 sine wave."""
+    t = np.linspace(0, duration_s, int(SR * duration_s), endpoint=False)
+    return (np.sin(2 * np.pi * freq_hz * t) * amplitude).astype(np.float32)
+
+
+def _silence(duration_s: float) -> np.ndarray:
+    return np.zeros(int(SR * duration_s), dtype=np.float32)
+
+
+def _to_wav_bytes(samples: np.ndarray, sr: int = SR) -> bytes:
+    """Encode float32 samples as WAV bytes."""
+    buf = io.BytesIO()
+    sf.write(buf, samples, sr, format="WAV", subtype="PCM_16")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Sustained vowel gate
+# ---------------------------------------------------------------------------
+
+
+class TestSustainedVowelGate:
+    def test_short_voiced_passes(self) -> None:
+        # 1.0s sine — well under 2.8s threshold
+        samples = _sine(200.0, 1.0)
+        result = check_sustained_vowel(samples, SR)
+        assert result.passed
+
+    def test_long_sustained_fails(self) -> None:
+        # 3.5s continuous sine — exceeds 2.8s threshold
+        samples = _sine(200.0, 3.5)
+        result = check_sustained_vowel(samples, SR)
+        assert not result.passed
+        assert result.gate_name == "sustained_vowel"
+
+    def test_interrupted_voiced_passes(self) -> None:
+        # Two 1.5s voiced segments separated by silence — each under threshold
+        seg1 = _sine(200.0, 1.5)
+        gap = _silence(0.5)
+        seg2 = _sine(200.0, 1.5)
+        samples = np.concatenate([seg1, gap, seg2])
+        result = check_sustained_vowel(samples, SR)
+        assert result.passed
+
+    def test_empty_audio_passes(self) -> None:
+        result = check_sustained_vowel(np.array([], dtype=np.float32), SR)
+        assert result.passed
+
+    def test_silence_passes(self) -> None:
+        samples = _silence(5.0)
+        result = check_sustained_vowel(samples, SR)
+        assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# F0 guardrails gate
+# ---------------------------------------------------------------------------
+
+
+class TestF0GuardrailsGate:
+    def test_male_in_range_passes(self) -> None:
+        # 120 Hz sine — within male [80, 180] Hz
+        samples = _sine(120.0, 1.0)
+        result = check_f0_guardrails(samples, SR, "male")
+        assert result.passed
+
+    def test_female_in_range_passes(self) -> None:
+        # 200 Hz sine — within female [150, 290] Hz
+        samples = _sine(200.0, 1.0)
+        result = check_f0_guardrails(samples, SR, "female")
+        assert result.passed
+
+    def test_male_too_high_fails(self) -> None:
+        # 250 Hz — above male max (180 Hz)
+        samples = _sine(250.0, 1.0)
+        result = check_f0_guardrails(samples, SR, "male")
+        assert not result.passed
+        assert result.gate_name == "f0_guardrails"
+
+    def test_female_too_low_fails(self) -> None:
+        # 100 Hz — below female min (150 Hz)
+        samples = _sine(100.0, 1.0)
+        result = check_f0_guardrails(samples, SR, "female")
+        assert not result.passed
+        assert result.gate_name == "f0_guardrails"
+
+    def test_silence_passes(self) -> None:
+        # No voiced frames → pass by default
+        samples = _silence(2.0)
+        result = check_f0_guardrails(samples, SR, "male")
+        assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# Click detection gate
+# ---------------------------------------------------------------------------
+
+
+class TestClickDetectionGate:
+    def test_clean_sine_passes(self) -> None:
+        samples = _sine(200.0, 1.0)
+        result = check_clicks(samples, SR)
+        assert result.passed
+
+    def test_multiple_clicks_fails(self) -> None:
+        # Insert artificial DC jumps
+        samples = _sine(200.0, 1.0, amplitude=0.3)
+        # Insert clicks at several points
+        for pos in [1000, 3000, 5000, 7000]:
+            samples[pos] = 0.8  # Large jump from ~0.3 amplitude signal
+        result = check_clicks(samples, SR)
+        assert not result.passed
+        assert result.gate_name == "click_detection"
+
+    def test_few_clicks_passes(self) -> None:
+        # Only 1 click — below threshold
+        samples = _sine(200.0, 1.0, amplitude=0.01)
+        samples[5000] = 0.8
+        result = check_clicks(samples, SR)
+        # One click gives exactly 2 diff events (jump up, jump back down)
+        # which is below the threshold of 3
+        assert result.passed
+
+    def test_empty_passes(self) -> None:
+        result = check_clicks(np.array([], dtype=np.float32), SR)
+        assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# Composite gate runner
+# ---------------------------------------------------------------------------
+
+
+class TestRunQualityGates:
+    def test_good_male_audio_passes(self) -> None:
+        # 1s at 120 Hz — passes all gates
+        samples = _sine(120.0, 1.0)
+        wav_bytes = _to_wav_bytes(samples)
+        result = run_quality_gates(wav_bytes, "male")
+        assert result.passed
+
+    def test_good_female_audio_passes(self) -> None:
+        # 1s at 200 Hz — passes all gates
+        samples = _sine(200.0, 1.0)
+        wav_bytes = _to_wav_bytes(samples)
+        result = run_quality_gates(wav_bytes, "female")
+        assert result.passed
+
+    def test_sustained_vowel_fails_first(self) -> None:
+        # 4s sustained sine at valid frequency — sustained vowel gate fires
+        samples = _sine(120.0, 4.0)
+        wav_bytes = _to_wav_bytes(samples)
+        result = run_quality_gates(wav_bytes, "male")
+        assert not result.passed
+        assert result.gate_name == "sustained_vowel"
+
+    def test_f0_out_of_range_fails(self) -> None:
+        # Short audio at invalid frequency for male
+        # Use 2.5s so it stays under sustained threshold, but fails F0
+        samples = _sine(250.0, 2.5)
+        wav_bytes = _to_wav_bytes(samples)
+        result = run_quality_gates(wav_bytes, "male")
+        assert not result.passed
+        assert result.gate_name == "f0_guardrails"
+
+
+# ---------------------------------------------------------------------------
+# GateResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestGateResult:
+    def test_default_is_passing(self) -> None:
+        r = GateResult(passed=True)
+        assert r.passed
+        assert r.gate_name is None
+        assert r.detail is None
+
+    def test_failure_has_info(self) -> None:
+        r = GateResult(passed=False, gate_name="test_gate", detail="something bad")
+        assert not r.passed
+        assert r.gate_name == "test_gate"

--- a/tests/unit/test_speaker_state.py
+++ b/tests/unit/test_speaker_state.py
@@ -7,6 +7,7 @@ import pytest
 from synthbanshee.tts.speaker_state import (
     _DRIFT_RATE_DECAY,
     _DRIFT_RATE_ESCALATE,
+    MAX_F0_DRIFT_ST,
     SpeakerState,
     _target_for,
 )
@@ -264,3 +265,46 @@ class TestNeutralRole:
         assert s.rate_offset == pytest.approx(1.0)
         assert s.pitch_offset_st == pytest.approx(0.0)
         assert s.volume_offset_db == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# M15: F0 drift bound
+# ---------------------------------------------------------------------------
+
+
+class TestF0DriftBound:
+    def test_max_f0_drift_is_two_semitones(self) -> None:
+        assert MAX_F0_DRIFT_ST == 2.0
+
+    def test_neutral_state_not_exceeded(self) -> None:
+        assert not SpeakerState().f0_drift_exceeded
+
+    def test_small_drift_not_exceeded(self) -> None:
+        s = SpeakerState()
+        s.pitch_offset_st = 1.5
+        assert not s.f0_drift_exceeded
+
+    def test_exactly_at_bound_not_exceeded(self) -> None:
+        s = SpeakerState()
+        s.pitch_offset_st = 2.0
+        assert not s.f0_drift_exceeded
+
+    def test_above_bound_exceeded(self) -> None:
+        s = SpeakerState()
+        s.pitch_offset_st = 2.1
+        assert s.f0_drift_exceeded
+
+    def test_negative_drift_exceeded(self) -> None:
+        s = SpeakerState()
+        s.pitch_offset_st = -2.5
+        assert s.f0_drift_exceeded
+
+    def test_agg_sustained_i5_may_exceed(self) -> None:
+        """AGG at I5 for many turns can exceed the 2.0 st bound."""
+        s = SpeakerState()
+        for _ in range(20):
+            s.update(5, "AGG")
+        # AGG I5 target is 2.0 st; asymptotically approaches it
+        # After many turns it should be very close to 2.0 but not necessarily over
+        # (depends on drift rate math)
+        assert s.pitch_offset_st <= MAX_F0_DRIFT_ST + 0.01

--- a/tests/unit/test_speaker_state.py
+++ b/tests/unit/test_speaker_state.py
@@ -299,12 +299,11 @@ class TestF0DriftBound:
         s.pitch_offset_st = -2.5
         assert s.f0_drift_exceeded
 
-    def test_agg_sustained_i5_may_exceed(self) -> None:
-        """AGG at I5 for many turns can exceed the 2.0 st bound."""
+    def test_agg_sustained_i5_stays_within_bound(self) -> None:
+        """AGG at I5 asymptotically approaches but never exceeds 2.0 st target."""
         s = SpeakerState()
         for _ in range(20):
             s.update(5, "AGG")
-        # AGG I5 target is 2.0 st; asymptotically approaches it
-        # After many turns it should be very close to 2.0 but not necessarily over
-        # (depends on drift rate math)
+        # AGG I5 target is exactly 2.0 st; drift converges toward it but
+        # never overshoots (exponential decay toward target).
         assert s.pitch_offset_st <= MAX_F0_DRIFT_ST + 0.01


### PR DESCRIPTION
## Summary

- **Update speaker YAML style_maps** to research-consensus prosody values (rate, pitch, volume per intensity level) derived from Amir et al. (2003), T-RES Hebrew emotional prosody, and Gelfer (2005) F0 ranges
- **Add 2.0 semitone F0 drift bound** to `SpeakerState` with `f0_drift_exceeded` property for cross-clip monitoring
- **Implement turn-level quality gates** (`synthbanshee/tts/quality_gates.py`) — sustained-vowel detection (>2.8s reject), F0 guardrails (male [80,180] Hz, female [150,290] Hz), click detection (DC-offset jumps)
- **Wire quality gates** into `TTSRenderer.render_scene()` with verbose logging on failure

## Changes by file

| File | Change |
|------|--------|
| `configs/speakers/*.yaml` (6 files) | Updated style_map rate/pitch/volume to research consensus; replaced `angry`/`sad` styles with `General` |
| `configs/examples/*.yaml` (6 files) | Same updates for example speaker configs |
| `synthbanshee/tts/quality_gates.py` | **New** — three quality gate implementations + composite runner |
| `synthbanshee/tts/speaker_state.py` | Added `MAX_F0_DRIFT_ST` constant and `f0_drift_exceeded` property |
| `synthbanshee/tts/renderer.py` | Wire quality gates post-render; warn on F0 drift exceeded |
| `tests/unit/test_quality_gates.py` | **New** — 19 tests for all quality gates |
| `tests/unit/test_speaker_state.py` | 7 new tests for F0 drift bound |
| `tests/unit/test_config.py` | Updated assertions to match new `General` style |

## Test plan

- [x] `pytest tests/unit/` — 1322 passed
- [x] `ruff check` — all checks passed
- [x] `mypy synthbanshee/tts/quality_gates.py synthbanshee/tts/renderer.py synthbanshee/tts/speaker_state.py` — success, no issues
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, yaml check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)