### PR TITLE
fix(package): exclude QA-failed clips from dataset archive

### DIFF
--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -1957,11 +1957,14 @@ def package_dataset(
     exclude_ids: set[str] = set()
     if not include_failed and qa_report.failed_clip_ids:
         exclude_ids = set(qa_report.failed_clip_ids)
-        console.print(f"[yellow]Excluding {len(exclude_ids)} failed clip(s) from archive.[/yellow]")
+        console.print(
+            f"[yellow]Excluding {len(exclude_ids)} failed clip(s) from archive:"
+            f" {', '.join(sorted(exclude_ids))}[/yellow]"
+        )
 
     console.print(f"[cyan]Creating archive {archive_path} …[/cyan]")
     result = create_archive(
-        data_dir, archive_path, dataset_card_text=card_text, exclude_clip_ids=exclude_ids or None
+        data_dir, archive_path, dataset_card_text=card_text, exclude_clip_ids=exclude_ids
     )
 
     card_out = output_dir / "DATASET_CARD.md"

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -1902,7 +1902,15 @@ def dataset_card(data_dir: Path, version: str, output: Path | None) -> None:
     default=False,
     help="Create the archive even if the QA suite reports failures.",
 )
-def package_dataset(data_dir: Path, output_dir: Path, version: str, *, force: bool) -> None:
+@click.option(
+    "--include-failed",
+    is_flag=True,
+    default=False,
+    help="Include QA-failed clips in the archive (for debugging).",
+)
+def package_dataset(
+    data_dir: Path, output_dir: Path, version: str, *, force: bool, include_failed: bool
+) -> None:
     """Package DATA_DIR into a versioned archive in OUTPUT_DIR.
 
     Steps:
@@ -1946,8 +1954,15 @@ def package_dataset(data_dir: Path, output_dir: Path, version: str, *, force: bo
     archive_name = f"avdp_synth_{version}.tar.gz"
     archive_path = output_dir / archive_name
 
+    exclude_ids: set[str] = set()
+    if not include_failed and qa_report.failed_clip_ids:
+        exclude_ids = set(qa_report.failed_clip_ids)
+        console.print(f"[yellow]Excluding {len(exclude_ids)} failed clip(s) from archive.[/yellow]")
+
     console.print(f"[cyan]Creating archive {archive_path} …[/cyan]")
-    result = create_archive(data_dir, archive_path, dataset_card_text=card_text)
+    result = create_archive(
+        data_dir, archive_path, dataset_card_text=card_text, exclude_clip_ids=exclude_ids or None
+    )
 
     card_out = output_dir / "DATASET_CARD.md"
     card_out.write_text(card_text, encoding="utf-8")

--- a/synthbanshee/package/archiver.py
+++ b/synthbanshee/package/archiver.py
@@ -30,6 +30,9 @@ class ArchiveResult:
     file_count: int
     """Number of data files included (dirty originals excluded)."""
 
+    excluded_clip_count: int
+    """Number of clip IDs excluded via *exclude_clip_ids*."""
+
     total_bytes: int
     """Sum of uncompressed file sizes for all included files."""
 
@@ -51,6 +54,7 @@ def create_archive(
     output_path: Path,
     *,
     dataset_card_text: str | None = None,
+    exclude_clip_ids: set[str] | None = None,
 ) -> ArchiveResult:
     """Create a ``.tar.gz`` archive of *data_dir*.
 
@@ -62,17 +66,21 @@ def create_archive(
             created if it does not exist.
         dataset_card_text: Optional text to include as ``DATASET_CARD.md`` at
             the archive root.
+        exclude_clip_ids: Optional set of clip IDs (filename stems) whose
+            sibling files (``.wav``, ``.txt``, ``.json``, ``.jsonl``) should
+            be excluded from the archive.
 
     Returns:
         :class:`ArchiveResult` with the archive path, SHA-256 checksum, file
         count, total uncompressed bytes, and path to ``SHA256SUMS.txt``.
     """
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    _excluded = exclude_clip_ids or set()
 
     files = sorted(
         p
         for p in data_dir.rglob("*")
-        if p.is_file() and not p.is_symlink() and "_dirty" not in p.stem
+        if p.is_file() and not p.is_symlink() and "_dirty" not in p.stem and p.stem not in _excluded
     )
 
     file_checksums: list[tuple[str, str]] = []
@@ -113,6 +121,7 @@ def create_archive(
         archive_path=output_path,
         checksum=archive_checksum,
         file_count=len(files),
+        excluded_clip_count=len(_excluded),
         total_bytes=total_bytes,
         manifest_path=manifest_path,
     )

--- a/synthbanshee/package/archiver.py
+++ b/synthbanshee/package/archiver.py
@@ -30,14 +30,14 @@ class ArchiveResult:
     file_count: int
     """Number of data files included (dirty originals excluded)."""
 
-    excluded_clip_count: int
-    """Number of clip IDs excluded via *exclude_clip_ids*."""
-
     total_bytes: int
     """Sum of uncompressed file sizes for all included files."""
 
     manifest_path: Path
     """Path to ``SHA256SUMS.txt`` written alongside the archive."""
+
+    excluded_clip_count: int = 0
+    """Number of clip IDs that were actually present in *data_dir* and excluded."""
 
 
 def _file_sha256(path: Path) -> str:
@@ -77,11 +77,24 @@ def create_archive(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     _excluded = exclude_clip_ids or set()
 
-    files = sorted(
+    all_candidates = sorted(
         p
         for p in data_dir.rglob("*")
-        if p.is_file() and not p.is_symlink() and "_dirty" not in p.stem and p.stem not in _excluded
+        if p.is_file() and not p.is_symlink() and "_dirty" not in p.stem
     )
+
+    if _excluded:
+        actually_excluded: set[str] = set()
+        files: list[Path] = []
+        for p in all_candidates:
+            if p.stem in _excluded:
+                actually_excluded.add(p.stem)
+            else:
+                files.append(p)
+        _actual_excluded_count = len(actually_excluded)
+    else:
+        files = all_candidates
+        _actual_excluded_count = 0
 
     file_checksums: list[tuple[str, str]] = []
     total_bytes = 0
@@ -121,7 +134,7 @@ def create_archive(
         archive_path=output_path,
         checksum=archive_checksum,
         file_count=len(files),
-        excluded_clip_count=len(_excluded),
+        excluded_clip_count=_actual_excluded_count,
         total_bytes=total_bytes,
         manifest_path=manifest_path,
     )

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -149,3 +149,32 @@ class TestCreateArchive:
         with tarfile.open(out, "r:gz") as tar:
             names = tar.getnames()
         assert not any("link" in n for n in names)
+
+    def test_exclude_clip_ids_removes_siblings(self, tmp_path):
+        """All sibling files for an excluded clip ID are omitted."""
+        data_dir = _make_data_dir(tmp_path)
+        out = tmp_path / "dataset.tar.gz"
+        # clip_001 has .wav, .txt, .json → all 3 should be excluded
+        result = create_archive(data_dir, out, exclude_clip_ids={"clip_001"})
+        with tarfile.open(out, "r:gz") as tar:
+            names = tar.getnames()
+        assert not any("clip_001" in n for n in names)
+        # Only sub/clip_002.wav should remain
+        assert result.file_count == 1
+        assert result.excluded_clip_count == 1
+
+    def test_exclude_clip_ids_empty_set_changes_nothing(self, tmp_path):
+        """An empty exclusion set behaves the same as no exclusion."""
+        data_dir = _make_data_dir(tmp_path)
+        out = tmp_path / "dataset.tar.gz"
+        result = create_archive(data_dir, out, exclude_clip_ids=set())
+        assert result.file_count == 4  # same as default
+        assert result.excluded_clip_count == 0
+
+    def test_exclude_nonexistent_clip_id(self, tmp_path):
+        """Excluding a clip ID not present in data_dir is a no-op."""
+        data_dir = _make_data_dir(tmp_path)
+        out = tmp_path / "dataset.tar.gz"
+        result = create_archive(data_dir, out, exclude_clip_ids={"no_such_clip"})
+        assert result.file_count == 4
+        assert result.excluded_clip_count == 1

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -177,4 +177,4 @@ class TestCreateArchive:
         out = tmp_path / "dataset.tar.gz"
         result = create_archive(data_dir, out, exclude_clip_ids={"no_such_clip"})
         assert result.file_count == 4
-        assert result.excluded_clip_count == 1
+        assert result.excluded_clip_count == 0  # nothing was actually in data_dir

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2409,6 +2409,89 @@ class TestPackageDatasetCommand:
             assert result.exit_code != 0, f"Expected failure for version {bad_version!r}"
             assert not (out_dir / f"avdp_synth_{bad_version}.tar.gz").exists()
 
+    def test_failed_clips_excluded_by_default(self, tmp_path):
+        """Failed clip IDs from QA are excluded from the archive by default."""
+        data_dir = _make_empty_data_dir(tmp_path)
+        # Create a file that would be excluded
+        (data_dir / "bad_clip.wav").write_bytes(b"bad")
+        (data_dir / "good_clip.wav").write_bytes(b"good")
+        out_dir = tmp_path / "releases"
+        from unittest.mock import patch
+
+        from synthbanshee.package.qa import DatasetStats, QAReport
+
+        report = QAReport(
+            data_dir=str(data_dir),
+            stats=DatasetStats(total_clips=1, failed_clips=1),
+            failed_clip_ids=["bad_clip"],
+            passed=True,
+            failure_rate=0.01,
+        )
+        with patch("synthbanshee.package.qa.run_qa", return_value=report):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["package-dataset", str(data_dir), str(out_dir), "--version", "v1.0"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Excluding 1 failed clip(s)" in result.output
+        assert "bad_clip" in result.output
+        import tarfile
+
+        with tarfile.open(out_dir / "avdp_synth_v1.0.tar.gz", "r:gz") as tar:
+            names = tar.getnames()
+        assert not any("bad_clip" in n for n in names)
+        assert any("good_clip" in n for n in names)
+
+    def test_include_failed_flag_keeps_failed_clips(self, tmp_path):
+        """--include-failed overrides exclusion and keeps failed clips in archive."""
+        data_dir = _make_empty_data_dir(tmp_path)
+        (data_dir / "bad_clip.wav").write_bytes(b"bad")
+        out_dir = tmp_path / "releases"
+        from unittest.mock import patch
+
+        from synthbanshee.package.qa import DatasetStats, QAReport
+
+        report = QAReport(
+            data_dir=str(data_dir),
+            stats=DatasetStats(total_clips=0, failed_clips=1),
+            failed_clip_ids=["bad_clip"],
+            passed=True,
+            failure_rate=0.01,
+        )
+        with patch("synthbanshee.package.qa.run_qa", return_value=report):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "package-dataset",
+                    str(data_dir),
+                    str(out_dir),
+                    "--version",
+                    "v1.0",
+                    "--include-failed",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Excluding" not in result.output
+        import tarfile
+
+        with tarfile.open(out_dir / "avdp_synth_v1.0.tar.gz", "r:gz") as tar:
+            names = tar.getnames()
+        assert any("bad_clip" in n for n in names)
+
+    def test_no_failures_no_exclusion_message(self, tmp_path):
+        """When QA has no failures, no exclusion message is printed."""
+        data_dir = _make_empty_data_dir(tmp_path)
+        out_dir = tmp_path / "releases"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["package-dataset", str(data_dir), str(out_dir), "--version", "v1.0"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Excluding" not in result.output
+
 
 # ---------------------------------------------------------------------------
 # _distribute_speakers tests (M9b)


### PR DESCRIPTION
Closes #18

## Summary

- `create_archive()` now accepts an optional `exclude_clip_ids` set; files whose stem matches an excluded ID are omitted from the archive
- `package-dataset` CLI wires `QAReport.failed_clip_ids` into the exclusion set by default, so packaged contents match dataset card stats
- New `--include-failed` flag overrides exclusion for debugging

## Changes

| File | Change |
|---|---|
| `synthbanshee/package/archiver.py` | Add `exclude_clip_ids` parameter and `excluded_clip_count` result field |
| `synthbanshee/cli.py` | Wire exclusion from QA report; add `--include-failed` flag |
| `tests/unit/test_archiver.py` | 3 new tests: exclusion works, empty set is no-op, nonexistent ID is no-op |

## Test plan

- [x] `test_exclude_clip_ids_removes_siblings` — all sibling files for excluded clip are omitted
- [x] `test_exclude_clip_ids_empty_set_changes_nothing` — empty set behaves like no exclusion
- [x] `test_exclude_nonexistent_clip_id` — nonexistent clip ID is a no-op
- [x] All 1331 existing unit tests pass
- [x] ruff check + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)