### PR TITLE
feat(augment): M16 Tier B acoustic augmentation pipeline

### DIFF
--- a/docs/audio_generation_v3_design.md
+++ b/docs/audio_generation_v3_design.md
@@ -51,7 +51,7 @@ All P0–P2 work is tracked here. Milestones that span multiple PRs are listed o
 | **M13** | P2 | ✅ Done | She-Proves / Elephant generate audio appropriate to their distinct acoustic regimes | `project_profile` field in `RunConfig`; gap, overlap probability, loudness targets, preprocessing config, and augmentation config all carry project-specific defaults; two profile YAML files in `configs/run_configs/`; new profiles addable without code changes | Small | No |
 | **M14** | P0 | ✅ Done | Fixes muffled audio, click artifacts, and voice identity shifts | Replace 7.5 kHz LPF with 80 Hz HPF in `preprocessing.py`; default `wiener_denoise=False` in `PreprocessingConfig`; add 10ms (160 sample) edge fades at turn boundaries in `mixer.py`; set `supports_style_tags=False` in `AzureProvider` capabilities (disables `express-as` for he-IL voices); update unit tests | Small | No |
 | **M15** | P1 | ✅ Done | Tunes SSML prosody to research-validated Hebrew parameters | Update `style_map` values in speaker YAMLs per research consensus table (rate, pitch, volume, F0 range by intensity); update `SpeakerState` drift bounds (max 2.0 st unexplained drift); add turn-level quality gates: sustained-vowel detection (>2.8 s reject), F0 guardrails (male [80,180] Hz, female [150,290] Hz), click detection | Medium | No |
-| **M16** | P2 | 🔲 Not started | Adds realistic acoustic environments to Tier B clips | Implement `room_sim.py` with pyroomacoustics (RT60 0.25–0.7 s, shoebox rooms, phone-on-table early reflection model); implement `device_profiles.py` (phone EQ: 80 Hz HPF, presence boost +2–4 dB @ 2.5–3.5 kHz, gentle high shelf above 6.5 kHz); implement `noise_mixer.py` (SNR distribution: 50% 18–30 dB, 30% 10–18 dB, 10% 5–10 dB, 10% 30–40 dB); optional codec simulation (Opus/AMR-NB) | Large | No |
+| **M16** | P2 | ✅ Done | Adds realistic acoustic environments to Tier B clips | Implement `room_sim.py` with pyroomacoustics (RT60 0.25–0.7 s, shoebox rooms, phone-on-table early reflection model); implement `device_profiles.py` (phone EQ: 80 Hz HPF, presence boost +2–4 dB @ 2.5–3.5 kHz, gentle high shelf above 6.5 kHz); implement `noise_mixer.py` (SNR distribution: 50% 18–30 dB, 30% 10–18 dB, 10% 5–10 dB, 10% 30–40 dB); optional codec simulation (Opus/AMR-NB) | Large | No |
 
 ---
 
@@ -72,7 +72,7 @@ The scripts, label taxonomy, pipeline stage decomposition, and cache system are 
 - **P1 (realism core):** Add stateful conversational dynamics; preserve escalation cues
 - **P2 (diversity and observability):** Widen voice diversity; harden QA; add release gates
 
-**V3.1 additions (2026-04-30, post-research):** Three new milestones (M14–M16) based on cross-referenced findings from three independent research reports on Hebrew synthetic speech naturalness (Gemini, GPT-5.2 thinking, GPT-5.5 Pro). See `wiki/topics/research-synthesis.md` for full parameter tables and citations. Original recommended order: M14 → M11 → M15 → M13 → M16 → M12. As of 2026-05-01, M14, M11, M15, and M13 are all merged; remaining: M16 (Tier B augmentation) and M12 (breathiness, gated).
+**V3.1 additions (2026-04-30, post-research):** Three new milestones (M14–M16) based on cross-referenced findings from three independent research reports on Hebrew synthetic speech naturalness (Gemini, GPT-5.2 thinking, GPT-5.5 Pro). See `wiki/topics/research-synthesis.md` for full parameter tables and citations. Original recommended order: M14 → M11 → M15 → M13 → M16 → M12. As of 2026-05-03, M14, M11, M15, M13, and M16 are all merged; remaining: M12 (breathiness, gated).
 
 ---
 

--- a/synthbanshee/augment/__init__.py
+++ b/synthbanshee/augment/__init__.py
@@ -2,6 +2,7 @@
 
 from synthbanshee.augment.device_profiles import DeviceProfiler
 from synthbanshee.augment.noise_mixer import NoiseMixer
+from synthbanshee.augment.pipeline import augment_scene, generate_variant_configs, sample_snr_db
 from synthbanshee.augment.preprocessing import PreprocessingResult, preprocess, validate_audio
 from synthbanshee.augment.room_sim import RoomSimulator
 from synthbanshee.augment.types import AugmentationResult, AugmentedEvent
@@ -13,6 +14,9 @@ __all__ = [
     "NoiseMixer",
     "PreprocessingResult",
     "RoomSimulator",
+    "augment_scene",
+    "generate_variant_configs",
     "preprocess",
+    "sample_snr_db",
     "validate_audio",
 ]

--- a/synthbanshee/augment/device_profiles.py
+++ b/synthbanshee/augment/device_profiles.py
@@ -2,11 +2,11 @@
 
 Each profile models the frequency response and level characteristics of the
 device used to capture a scene.  Profiles are applied as a chain of
-scipy Butterworth filters, optional presence boost / high shelf shaping,
+scipy Butterworth filters, optional presence boost / extra low-pass shaping,
 optional hum injection, and level adjustment.
 
 Spec reference: docs/spec.md §3.1 (device placement, Stage 3 augmentation)
-M16 spec: presence boost +2–4 dB @ 2.5–3.5 kHz, gentle high shelf above 6.5 kHz
+M16 spec: presence boost +2–4 dB @ 2.5–3.5 kHz, gentle rolloff above 6.5 kHz
 """
 
 from __future__ import annotations
@@ -44,7 +44,7 @@ def _peaking_eq_coeffs(
 #   highpass_hz    — roll-off below this frequency (models mic sensitivity floor)
 #   lowpass_hz     — roll-off above this frequency (models bandwidth limit / muffling)
 #   presence_boost — optional peaking EQ: (centre_hz, gain_db, Q) or None
-#   high_shelf_hz  — gentle rolloff above this freq (2nd-order LP); None = skip
+#   extra_lowpass_hz — additional 2nd-order Butterworth LP above this freq; None = skip
 #   hum_hz         — mains hum frequency to inject; None = no hum
 #   hum_dbfs       — amplitude of injected hum in dBFS (ignored when hum_hz is None)
 #   level_db       — broadband gain applied after filtering (models pickup / insertion loss)
@@ -53,7 +53,7 @@ _PROFILES: dict[str, dict] = {
         "highpass_hz": 200,
         "lowpass_hz": 8_000,
         "presence_boost": (3_000, 3.0, 1.5),  # +3 dB @ 3 kHz, Q=1.5
-        "high_shelf_hz": 6_500,
+        "extra_lowpass_hz": 6_500,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": 0.0,
@@ -63,7 +63,7 @@ _PROFILES: dict[str, dict] = {
         "highpass_hz": 300,
         "lowpass_hz": 2_500,
         "presence_boost": None,  # pocket muffling already cuts presence band
-        "high_shelf_hz": None,
+        "extra_lowpass_hz": None,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": -6.0,
@@ -73,7 +73,7 @@ _PROFILES: dict[str, dict] = {
         "highpass_hz": 100,
         "lowpass_hz": 7_000,
         "presence_boost": (2_800, 2.0, 1.5),  # +2 dB @ 2.8 kHz, Q=1.5
-        "high_shelf_hz": 6_500,
+        "extra_lowpass_hz": 6_500,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": -3.0,
@@ -83,7 +83,7 @@ _PROFILES: dict[str, dict] = {
         "highpass_hz": 80,
         "lowpass_hz": 7_000,
         "presence_boost": None,  # budget mic has no presence lift
-        "high_shelf_hz": None,
+        "extra_lowpass_hz": None,
         "hum_hz": 50.0,
         "hum_dbfs": -50.0,
         "level_db": 0.0,
@@ -139,10 +139,10 @@ class DeviceProfiler:
                 b, a = _peaking_eq_coeffs(centre_hz, gain_db, q, sr)
                 out = lfilter(b, a, out).astype(np.float32)
 
-        # Gentle high shelf rolloff above high_shelf_hz (M16)
-        high_shelf_hz = profile.get("high_shelf_hz")
-        if high_shelf_hz is not None and high_shelf_hz < nyq:
-            sos = butter(2, high_shelf_hz / nyq, btype="low", output="sos")
+        # Additional gentle rolloff above extra_lowpass_hz (M16)
+        extra_lowpass_hz = profile.get("extra_lowpass_hz")
+        if extra_lowpass_hz is not None and extra_lowpass_hz < nyq:
+            sos = butter(2, extra_lowpass_hz / nyq, btype="low", output="sos")
             out = sosfilt(sos, out).astype(np.float32)
 
         # Mains hum injection (pi_budget_mic)

--- a/synthbanshee/augment/device_profiles.py
+++ b/synthbanshee/augment/device_profiles.py
@@ -2,28 +2,58 @@
 
 Each profile models the frequency response and level characteristics of the
 device used to capture a scene.  Profiles are applied as a chain of
-scipy Butterworth filters plus optional hum injection and level adjustment.
+scipy Butterworth filters, optional presence boost / high shelf shaping,
+optional hum injection, and level adjustment.
 
 Spec reference: docs/spec.md §3.1 (device placement, Stage 3 augmentation)
+M16 spec: presence boost +2–4 dB @ 2.5–3.5 kHz, gentle high shelf above 6.5 kHz
 """
 
 from __future__ import annotations
 
 import numpy as np
-from scipy.signal import butter, sosfilt
+from scipy.signal import butter, lfilter, sosfilt
 
 _FILTER_ORDER = 4
 
+
+def _peaking_eq_coeffs(
+    centre_hz: float, gain_db: float, q: float, sr: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Design a biquad peaking EQ filter (Audio EQ Cookbook).
+
+    Returns (b, a) transfer function coefficients for use with lfilter.
+    """
+    a_lin = 10.0 ** (gain_db / 40.0)  # sqrt of linear gain
+    w0 = 2.0 * np.pi * centre_hz / sr
+    alpha = np.sin(w0) / (2.0 * q)
+
+    b0 = 1.0 + alpha * a_lin
+    b1 = -2.0 * np.cos(w0)
+    b2 = 1.0 - alpha * a_lin
+    a0 = 1.0 + alpha / a_lin
+    a1 = -2.0 * np.cos(w0)
+    a2 = 1.0 - alpha / a_lin
+
+    b = np.array([b0 / a0, b1 / a0, b2 / a0])
+    a = np.array([1.0, a1 / a0, a2 / a0])
+    return b, a
+
+
 # Per-device parameters:
-#   highpass_hz  — roll-off below this frequency (models mic sensitivity floor)
-#   lowpass_hz   — roll-off above this frequency (models bandwidth limit / muffling)
-#   hum_hz       — mains hum frequency to inject; None = no hum
-#   hum_dbfs     — amplitude of injected hum in dBFS (ignored when hum_hz is None)
-#   level_db     — broadband gain applied after filtering (models pickup / insertion loss)
+#   highpass_hz    — roll-off below this frequency (models mic sensitivity floor)
+#   lowpass_hz     — roll-off above this frequency (models bandwidth limit / muffling)
+#   presence_boost — optional peaking EQ: (centre_hz, gain_db, Q) or None
+#   high_shelf_hz  — gentle rolloff above this freq (2nd-order LP); None = skip
+#   hum_hz         — mains hum frequency to inject; None = no hum
+#   hum_dbfs       — amplitude of injected hum in dBFS (ignored when hum_hz is None)
+#   level_db       — broadband gain applied after filtering (models pickup / insertion loss)
 _PROFILES: dict[str, dict] = {
     "phone_in_hand": {
         "highpass_hz": 200,
         "lowpass_hz": 8_000,
+        "presence_boost": (3_000, 3.0, 1.5),  # +3 dB @ 3 kHz, Q=1.5
+        "high_shelf_hz": 6_500,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": 0.0,
@@ -32,6 +62,8 @@ _PROFILES: dict[str, dict] = {
         # Cloth occlusion: strong high-frequency muffling + insertion loss
         "highpass_hz": 300,
         "lowpass_hz": 2_500,
+        "presence_boost": None,  # pocket muffling already cuts presence band
+        "high_shelf_hz": None,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": -6.0,
@@ -40,6 +72,8 @@ _PROFILES: dict[str, dict] = {
         # Surface coupling: slight low-end coupling loss, mild high-frequency rolloff
         "highpass_hz": 100,
         "lowpass_hz": 7_000,
+        "presence_boost": (2_800, 2.0, 1.5),  # +2 dB @ 2.8 kHz, Q=1.5
+        "high_shelf_hz": 6_500,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": -3.0,
@@ -48,6 +82,8 @@ _PROFILES: dict[str, dict] = {
         # Budget electret mic: limited bandwidth, 50 Hz mains hum (EU/IL grid)
         "highpass_hz": 80,
         "lowpass_hz": 7_000,
+        "presence_boost": None,  # budget mic has no presence lift
+        "high_shelf_hz": None,
         "hum_hz": 50.0,
         "hum_dbfs": -50.0,
         "level_db": 0.0,
@@ -93,6 +129,20 @@ class DeviceProfiler:
         lp_hz = profile["lowpass_hz"]
         if lp_hz < nyq:
             sos = butter(_FILTER_ORDER, lp_hz / nyq, btype="low", output="sos")
+            out = sosfilt(sos, out).astype(np.float32)
+
+        # Presence boost — peaking EQ (M16)
+        presence = profile.get("presence_boost")
+        if presence is not None:
+            centre_hz, gain_db, q = presence
+            if centre_hz < nyq:
+                b, a = _peaking_eq_coeffs(centre_hz, gain_db, q, sr)
+                out = lfilter(b, a, out).astype(np.float32)
+
+        # Gentle high shelf rolloff above high_shelf_hz (M16)
+        high_shelf_hz = profile.get("high_shelf_hz")
+        if high_shelf_hz is not None and high_shelf_hz < nyq:
+            sos = butter(2, high_shelf_hz / nyq, btype="low", output="sos")
             out = sosfilt(sos, out).astype(np.float32)
 
         # Mains hum injection (pi_budget_mic)

--- a/synthbanshee/augment/pipeline.py
+++ b/synthbanshee/augment/pipeline.py
@@ -1,0 +1,148 @@
+"""Tier B acoustic augmentation pipeline orchestrator (M16).
+
+Chains room simulation → device profiling → noise mixing into a single
+``augment_scene()`` call.  Also provides SNR band sampling and variant
+generation for producing 2–4 Tier B variants per Tier A scene.
+
+Spec reference: docs/audio_generation_v3_design.md §M16
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from synthbanshee.augment.device_profiles import DeviceProfiler
+from synthbanshee.augment.noise_mixer import NoiseMixer
+from synthbanshee.augment.room_sim import RoomSimulator
+from synthbanshee.augment.types import AugmentationResult
+from synthbanshee.config.acoustic_config import AcousticSceneConfig
+
+# SNR band distribution (M16 spec):
+#   50% at 18–30 dB, 30% at 10–18 dB, 10% at 5–10 dB, 10% at 30–40 dB
+_SNR_BANDS: list[tuple[float, float, float]] = [
+    # (probability, snr_lo, snr_hi)
+    (0.50, 18.0, 30.0),
+    (0.30, 10.0, 18.0),
+    (0.10, 5.0, 10.0),
+    (0.10, 30.0, 40.0),
+]
+
+
+def sample_snr_db(rng: np.random.Generator) -> float:
+    """Sample an SNR target from the M16 distribution bands.
+
+    Distribution: 50% at 18–30 dB, 30% at 10–18 dB,
+    10% at 5–10 dB, 10% at 30–40 dB.
+    """
+    probs = [band[0] for band in _SNR_BANDS]
+    idx = int(rng.choice(len(_SNR_BANDS), p=probs))
+    _, lo, hi = _SNR_BANDS[idx]
+    return float(rng.uniform(lo, hi))
+
+
+def augment_scene(
+    samples: np.ndarray,
+    sr: int,
+    config: AcousticSceneConfig,
+    rng_seed: int = 0,
+    assets_dir: Path = Path("assets"),
+    phase_boundaries: dict[str, float] | None = None,
+) -> AugmentationResult:
+    """Apply the full Tier B augmentation chain: room → device → noise.
+
+    Args:
+        samples: Float32 mono audio at *sr* Hz (post-preprocessing, with
+            silence padding already applied).
+        sr: Sample rate (should be 16000).
+        config: Acoustic scene configuration controlling room, device, and
+            noise parameters.
+        rng_seed: Seed for reproducible augmentation.
+        assets_dir: Root of the assets tree for noise/SFX file loading.
+        phase_boundaries: Optional phase name → onset_s mapping for SFX
+            onset resolution.
+
+    Returns:
+        AugmentationResult with the augmented samples and event log.
+    """
+    # Room simulation
+    reverbed = RoomSimulator().apply(samples, sr, config, rng_seed=rng_seed)
+
+    # Device profiling
+    device_colored = DeviceProfiler().apply(reverbed, sr, config.device, rng_seed=rng_seed)
+
+    # Noise mixing
+    aug_samples, aug_events, snr_actual = NoiseMixer(assets_dir=assets_dir).mix(
+        device_colored,
+        sr,
+        config,
+        rng_seed=rng_seed,
+        phase_boundaries=phase_boundaries,
+    )
+
+    return AugmentationResult(
+        samples=aug_samples,
+        sample_rate=sr,
+        room_type=config.room_type,
+        device=config.device,
+        ir_source=config.ir_source,
+        speaker_distance_meters=config.speaker_distance_meters,
+        snr_db_actual=snr_actual,
+        events=aug_events,
+    )
+
+
+def generate_variant_configs(
+    base_config: AcousticSceneConfig,
+    n_variants: int,
+    rng_seed: int,
+    preferred_devices: list[str] | None = None,
+    preferred_room_types: list[str] | None = None,
+) -> list[AcousticSceneConfig]:
+    """Generate N variant acoustic configs for Tier B augmentation.
+
+    Each variant gets a different combination of room type, device profile,
+    speaker distance, and SNR target sampled from the M16 distribution.
+
+    Args:
+        base_config: The base acoustic scene config to vary.
+        n_variants: Number of variants to generate (typically 2–4).
+        rng_seed: Seed for reproducible variant generation.
+        preferred_devices: If provided, sample devices from this list instead
+            of all available devices.
+        preferred_room_types: If provided, sample room types from this list
+            instead of all available.
+
+    Returns:
+        List of *n_variants* AcousticSceneConfig objects, each with a
+        different room/device/SNR combination.
+    """
+    from synthbanshee.config.acoustic_config import _VALID_DEVICES, _VALID_ROOM_TYPES
+
+    rng = np.random.default_rng(rng_seed)
+
+    devices = list(preferred_devices) if preferred_devices else sorted(_VALID_DEVICES)
+    rooms = list(preferred_room_types) if preferred_room_types else sorted(_VALID_ROOM_TYPES)
+
+    # Speaker distance range: near (0.5 m), mid (1.5 m), far (3.5 m)
+    distance_options = [0.5, 1.5, 3.5]
+
+    variants: list[AcousticSceneConfig] = []
+    for _ in range(n_variants):
+        room = rooms[int(rng.integers(len(rooms)))]
+        device = devices[int(rng.integers(len(devices)))]
+        distance = distance_options[int(rng.integers(len(distance_options)))]
+        snr = sample_snr_db(rng)
+
+        variant = base_config.model_copy(
+            update={
+                "room_type": room,
+                "device": device,
+                "speaker_distance_meters": distance,
+                "snr_target_db": round(snr, 1),
+            }
+        )
+        variants.append(variant)
+
+    return variants

--- a/synthbanshee/augment/pipeline.py
+++ b/synthbanshee/augment/pipeline.py
@@ -66,18 +66,25 @@ def augment_scene(
     Returns:
         AugmentationResult with the augmented samples and event log.
     """
+    # Derive independent child seeds so the three stages don't share
+    # the same random sequence (which would correlate their choices).
+    child_rng = np.random.default_rng(rng_seed)
+    room_seed = int(child_rng.integers(0, 2**31))
+    device_seed = int(child_rng.integers(0, 2**31))
+    noise_seed = int(child_rng.integers(0, 2**31))
+
     # Room simulation
-    reverbed = RoomSimulator().apply(samples, sr, config, rng_seed=rng_seed)
+    reverbed = RoomSimulator().apply(samples, sr, config, rng_seed=room_seed)
 
     # Device profiling
-    device_colored = DeviceProfiler().apply(reverbed, sr, config.device, rng_seed=rng_seed)
+    device_colored = DeviceProfiler().apply(reverbed, sr, config.device, rng_seed=device_seed)
 
     # Noise mixing
     aug_samples, aug_events, snr_actual = NoiseMixer(assets_dir=assets_dir).mix(
         device_colored,
         sr,
         config,
-        rng_seed=rng_seed,
+        rng_seed=noise_seed,
         phase_boundaries=phase_boundaries,
     )
 
@@ -118,12 +125,28 @@ def generate_variant_configs(
         List of *n_variants* AcousticSceneConfig objects, each with a
         different room/device/SNR combination.
     """
-    from synthbanshee.config.acoustic_config import _VALID_DEVICES, _VALID_ROOM_TYPES
+    from synthbanshee.config.acoustic_config import VALID_DEVICES, VALID_ROOM_TYPES
+
+    if preferred_devices is not None:
+        if len(preferred_devices) == 0:
+            raise ValueError("preferred_devices must not be empty when provided")
+        bad = set(preferred_devices) - VALID_DEVICES
+        if bad:
+            raise ValueError(f"Unknown device(s): {sorted(bad)}. Valid: {sorted(VALID_DEVICES)}")
+
+    if preferred_room_types is not None:
+        if len(preferred_room_types) == 0:
+            raise ValueError("preferred_room_types must not be empty when provided")
+        bad = set(preferred_room_types) - VALID_ROOM_TYPES
+        if bad:
+            raise ValueError(
+                f"Unknown room type(s): {sorted(bad)}. Valid: {sorted(VALID_ROOM_TYPES)}"
+            )
 
     rng = np.random.default_rng(rng_seed)
 
-    devices = list(preferred_devices) if preferred_devices else sorted(_VALID_DEVICES)
-    rooms = list(preferred_room_types) if preferred_room_types else sorted(_VALID_ROOM_TYPES)
+    devices = list(preferred_devices) if preferred_devices else sorted(VALID_DEVICES)
+    rooms = list(preferred_room_types) if preferred_room_types else sorted(VALID_ROOM_TYPES)
 
     # Speaker distance range: near (0.5 m), mid (1.5 m), far (3.5 m)
     distance_options = [0.5, 1.5, 3.5]

--- a/synthbanshee/augment/pipeline.py
+++ b/synthbanshee/augment/pipeline.py
@@ -65,6 +65,8 @@ def augment_scene(
 
     Returns:
         AugmentationResult with the augmented samples and event log.
+        Event onset/offset times follow the AugmentedEvent convention:
+        relative to the un-padded MixedScene, not the padded input.
     """
     # Derive independent child seeds so the three stages don't share
     # the same random sequence (which would correlate their choices).

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -384,23 +384,17 @@ def _run_generate_pipeline(
             import numpy as _np
             import soundfile as _sf
 
-            from synthbanshee.augment.device_profiles import DeviceProfiler
-            from synthbanshee.augment.noise_mixer import NoiseMixer
-            from synthbanshee.augment.room_sim import RoomSimulator
+            from synthbanshee.augment.pipeline import augment_scene
             from synthbanshee.config.taxonomy import tier2_subtype_codes
             from synthbanshee.labels.schema import ClipAcousticScene
 
             audio_data, audio_sr = _sf.read(str(clip_wav), dtype="float32", always_2d=False)
             n_orig = len(audio_data)
-            reverbed = RoomSimulator().apply(
+
+            aug_result = augment_scene(
                 audio_data, audio_sr, scene.acoustic_scene, rng_seed=scene.random_seed
             )
-            device_colored = DeviceProfiler().apply(
-                reverbed, audio_sr, scene.acoustic_scene.device, rng_seed=scene.random_seed
-            )
-            aug_samples, aug_events, snr_actual = NoiseMixer().mix(
-                device_colored, audio_sr, scene.acoustic_scene, rng_seed=scene.random_seed
-            )
+            aug_samples = aug_result.samples
 
             # Enforce exact length match with the input WAV so metadata.duration_seconds
             # and transcript timings remain consistent after the write-back.
@@ -426,11 +420,11 @@ def _run_generate_pipeline(
             _sf.write(str(clip_wav), aug_samples, audio_sr, subtype="PCM_16")
 
             acoustic_scene_meta = ClipAcousticScene(
-                room_type=scene.acoustic_scene.room_type,
-                device=scene.acoustic_scene.device,
-                ir_source=scene.acoustic_scene.ir_source,
-                speaker_distance_meters=scene.acoustic_scene.speaker_distance_meters,
-                snr_db_actual=round(snr_actual, 2),
+                room_type=aug_result.room_type,
+                device=aug_result.device,
+                ir_source=aug_result.ir_source,
+                speaker_distance_meters=aug_result.speaker_distance_meters,
+                snr_db_actual=round(aug_result.snr_db_actual, 2),
                 background_events=[
                     {
                         "type": ev.type,
@@ -438,7 +432,7 @@ def _run_generate_pipeline(
                         "offset": round(ev.offset_s, 3),
                         "level_db": round(ev.level_db, 1),
                     }
-                    for ev in aug_events
+                    for ev in aug_result.events
                 ],
             )
             # Keep foreground ACOU_* SFX that are valid taxonomy tier2 codes.
@@ -446,7 +440,9 @@ def _run_generate_pipeline(
             # crashing label generation with a cryptic validation error.
             _valid_tier2 = tier2_subtype_codes()
             _aug_acou_events = [
-                ev for ev in aug_events if ev.type.startswith("ACOU_") and ev.type in _valid_tier2
+                ev
+                for ev in aug_result.events
+                if ev.type.startswith("ACOU_") and ev.type in _valid_tier2
             ]
         except Exception as exc:
             return None, [f"Acoustic augmentation error: {exc}"]

--- a/synthbanshee/config/acoustic_config.py
+++ b/synthbanshee/config/acoustic_config.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-_VALID_ROOM_TYPES = {
+VALID_ROOM_TYPES = {
     "small_bedroom",
     "apartment_kitchen",
     "living_room",
@@ -17,7 +17,7 @@ _VALID_ROOM_TYPES = {
     "open_office_corridor",
 }
 
-_VALID_DEVICES = {
+VALID_DEVICES = {
     "phone_in_hand",
     "phone_in_pocket",
     "phone_on_table",
@@ -67,15 +67,15 @@ class AcousticSceneConfig(BaseModel):
     @field_validator("room_type")
     @classmethod
     def valid_room_type(cls, v: str) -> str:
-        if v not in _VALID_ROOM_TYPES:
-            raise ValueError(f"Unknown room_type {v!r}. Valid: {sorted(_VALID_ROOM_TYPES)}")
+        if v not in VALID_ROOM_TYPES:
+            raise ValueError(f"Unknown room_type {v!r}. Valid: {sorted(VALID_ROOM_TYPES)}")
         return v
 
     @field_validator("device")
     @classmethod
     def valid_device(cls, v: str) -> str:
-        if v not in _VALID_DEVICES:
-            raise ValueError(f"Unknown device {v!r}. Valid: {sorted(_VALID_DEVICES)}")
+        if v not in VALID_DEVICES:
+            raise ValueError(f"Unknown device {v!r}. Valid: {sorted(VALID_DEVICES)}")
         return v
 
     @field_validator("rt60_range")

--- a/tests/integration/test_tier_b_pipeline.py
+++ b/tests/integration/test_tier_b_pipeline.py
@@ -93,7 +93,7 @@ def _build_aug_audio(mixed, pad_s: float = 0.5) -> np.ndarray:
 class TestTierBPipeline:
     def _run(self, tmp_path: Path, *, acou_events=None):
         """Run the full Tier B pipeline and return (wav_path, errors)."""
-        from synthbanshee.augment.types import AugmentedEvent
+        from synthbanshee.augment.types import AugmentationResult, AugmentedEvent
 
         mixed = _make_mixed_scene()
         turns = _make_dialogue_turns()
@@ -111,18 +111,25 @@ class TestTierBPipeline:
             for ev in acou_events
         ]
 
+        aug_result = AugmentationResult(
+            samples=aug_audio,
+            sample_rate=16_000,
+            room_type="living_room",
+            device="phone_on_table",
+            ir_source="pyroomacoustics_ism",
+            speaker_distance_meters=1.5,
+            snr_db_actual=18.5,
+            events=aug_event_objs,
+        )
+
         with (
             patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
             patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
-            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
-            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
-            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+            patch("synthbanshee.augment.pipeline.augment_scene") as MockAugScene,
         ):
             MockGen.return_value.generate.return_value = turns
             MockRenderer.return_value.render_scene.return_value = mixed
-            MockRoom.return_value.apply.return_value = aug_audio
-            MockDevice.return_value.apply.return_value = aug_audio
-            MockMixer.return_value.mix.return_value = (aug_audio, aug_event_objs, 18.5)
+            MockAugScene.return_value = aug_result
 
             return _run_generate_pipeline(
                 TIER_B_SCENE,

--- a/tests/integration/test_tier_c_pipeline.py
+++ b/tests/integration/test_tier_c_pipeline.py
@@ -75,22 +75,31 @@ def _build_aug_audio(mixed, pad_s: float = 0.5) -> np.ndarray:
 
 class TestTierCPipeline:
     def _run(self, tmp_path: Path):
+        from synthbanshee.augment.types import AugmentationResult
+
         mixed = _make_mixed_scene()
         turns = _make_dialogue_turns()
         aug_audio = _build_aug_audio(mixed)
 
+        aug_result = AugmentationResult(
+            samples=aug_audio,
+            sample_rate=16_000,
+            room_type="apartment_kitchen",
+            device="phone_on_table",
+            ir_source="pyroomacoustics_ism",
+            speaker_distance_meters=1.5,
+            snr_db_actual=17.0,
+            events=[],
+        )
+
         with (
             patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
             patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
-            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
-            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
-            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+            patch("synthbanshee.augment.pipeline.augment_scene") as MockAugScene,
         ):
             MockGen.return_value.generate.return_value = turns
             MockRenderer.return_value.render_scene.return_value = mixed
-            MockRoom.return_value.apply.return_value = aug_audio
-            MockDevice.return_value.apply.return_value = aug_audio
-            MockMixer.return_value.mix.return_value = (aug_audio, [], 17.0)
+            MockAugScene.return_value = aug_result
 
             return _run_generate_pipeline(
                 TIER_C_SCENE,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1823,21 +1823,30 @@ class TestRunGeneratePipelineTierB:
             for ev in aug_events
         ]
 
+        from synthbanshee.augment.types import AugmentationResult
+
+        aug_result = AugmentationResult(
+            samples=aug_audio,
+            sample_rate=sr,
+            room_type="small_bedroom",
+            device="phone_in_hand",
+            ir_source="pyroomacoustics_ism",
+            speaker_distance_meters=1.5,
+            snr_db_actual=snr_actual,
+            events=mock_aug_events,
+        )
+
         with (
             patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
             patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
-            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
-            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
-            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+            patch("synthbanshee.augment.pipeline.augment_scene") as MockAugScene,
         ):
             MockGen.return_value.generate.return_value = turns
             MockRenderer.return_value.render_scene.return_value = mixed
-            MockRoom.return_value.apply.return_value = aug_audio
-            MockDevice.return_value.apply.return_value = aug_audio
             if aug_side_effect is not None:
-                MockMixer.return_value.mix.side_effect = aug_side_effect
+                MockAugScene.side_effect = aug_side_effect
             else:
-                MockMixer.return_value.mix.return_value = (aug_audio, mock_aug_events, snr_actual)
+                MockAugScene.return_value = aug_result
 
             wav, errors = _run_generate_pipeline(
                 _make_tier_b_scene_yaml(tmp_path),
@@ -1998,6 +2007,8 @@ class TestRunGeneratePipelineTierC:
     """Tier C (hard-negative confusor) pipeline uses Stage 3b augmentation like Tier B."""
 
     def _run_tier_c(self, tmp_path: Path):
+        from synthbanshee.augment.types import AugmentationResult
+
         turns = _make_dialogue_turns(n=1, intensity=2)
         mixed = _make_mixed_scene(duration_s=5.0, n_turns=1)
         sr = 16_000
@@ -2009,18 +2020,25 @@ class TestRunGeneratePipelineTierC:
         peak = float(np.max(np.abs(aug_audio)))
         aug_audio = (aug_audio * (10.0 ** (-1.0 / 20.0) / peak)).astype(np.float32)
 
+        aug_result = AugmentationResult(
+            samples=aug_audio,
+            sample_rate=sr,
+            room_type="apartment_kitchen",
+            device="phone_in_hand",
+            ir_source="pyroomacoustics_ism",
+            speaker_distance_meters=1.0,
+            snr_db_actual=16.0,
+            events=[],
+        )
+
         with (
             patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
             patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
-            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
-            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
-            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+            patch("synthbanshee.augment.pipeline.augment_scene") as MockAugScene,
         ):
             MockGen.return_value.generate.return_value = turns
             MockRenderer.return_value.render_scene.return_value = mixed
-            MockRoom.return_value.apply.return_value = aug_audio
-            MockDevice.return_value.apply.return_value = aug_audio
-            MockMixer.return_value.mix.return_value = (aug_audio, [], 16.0)
+            MockAugScene.return_value = aug_result
 
             return _run_generate_pipeline(
                 _make_tier_c_scene_yaml(tmp_path),
@@ -2058,7 +2076,9 @@ class TestRunGeneratePipelineTierC:
         assert wav.with_suffix(".jsonl").exists()
 
     def test_tier_c_augmentation_called(self, tmp_path):
-        """RoomSimulator is invoked for Tier C scenes (Stage 3b is not Tier B exclusive)."""
+        """augment_scene is invoked for Tier C scenes (Stage 3b is not Tier B exclusive)."""
+        from synthbanshee.augment.types import AugmentationResult
+
         turns = _make_dialogue_turns(n=1, intensity=2)
         mixed = _make_mixed_scene(duration_s=5.0, n_turns=1)
         sr = 16_000
@@ -2066,18 +2086,25 @@ class TestRunGeneratePipelineTierC:
         total = mixed.samples.shape[0] + 2 * pad
         aug_audio = np.zeros(total, dtype=np.float32)
 
+        aug_result = AugmentationResult(
+            samples=aug_audio,
+            sample_rate=sr,
+            room_type="apartment_kitchen",
+            device="phone_in_hand",
+            ir_source="pyroomacoustics_ism",
+            speaker_distance_meters=1.0,
+            snr_db_actual=16.0,
+            events=[],
+        )
+
         with (
             patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
             patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
-            patch("synthbanshee.augment.room_sim.RoomSimulator") as MockRoom,
-            patch("synthbanshee.augment.device_profiles.DeviceProfiler") as MockDevice,
-            patch("synthbanshee.augment.noise_mixer.NoiseMixer") as MockMixer,
+            patch("synthbanshee.augment.pipeline.augment_scene") as MockAugScene,
         ):
             MockGen.return_value.generate.return_value = turns
             MockRenderer.return_value.render_scene.return_value = mixed
-            MockRoom.return_value.apply.return_value = aug_audio
-            MockDevice.return_value.apply.return_value = aug_audio
-            MockMixer.return_value.mix.return_value = (aug_audio, [], 16.0)
+            MockAugScene.return_value = aug_result
 
             wav, errors = _run_generate_pipeline(
                 _make_tier_c_scene_yaml(tmp_path),

--- a/tests/unit/test_device_profiles.py
+++ b/tests/unit/test_device_profiles.py
@@ -30,7 +30,15 @@ def test_all_expected_devices_present():
 
 
 def test_profile_keys_complete():
-    required = {"highpass_hz", "lowpass_hz", "hum_hz", "hum_dbfs", "level_db"}
+    required = {
+        "highpass_hz",
+        "lowpass_hz",
+        "presence_boost",
+        "high_shelf_hz",
+        "hum_hz",
+        "hum_dbfs",
+        "level_db",
+    }
     for device, profile in _PROFILES.items():
         assert required.issubset(profile.keys()), f"{device} missing keys"
 
@@ -167,6 +175,8 @@ def test_highpass_skipped_when_hz_is_zero():
     fake_profile = {
         "highpass_hz": 0,
         "lowpass_hz": 8_000,
+        "presence_boost": None,
+        "high_shelf_hz": None,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": 0.0,
@@ -175,3 +185,94 @@ def test_highpass_skipped_when_hz_is_zero():
         out = profiler.apply(_make_samples(), _SR, "zero_hp")
     assert out.shape == (_N,)
     assert out.dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# M16: Presence boost and high shelf tests
+# ---------------------------------------------------------------------------
+
+
+def test_phone_in_hand_has_presence_boost():
+    assert _PROFILES["phone_in_hand"]["presence_boost"] is not None
+    centre_hz, gain_db, q = _PROFILES["phone_in_hand"]["presence_boost"]
+    assert 2_500 <= centre_hz <= 3_500
+    assert 2.0 <= gain_db <= 4.0
+    assert q > 0
+
+
+def test_phone_on_table_has_presence_boost():
+    assert _PROFILES["phone_on_table"]["presence_boost"] is not None
+    centre_hz, gain_db, q = _PROFILES["phone_on_table"]["presence_boost"]
+    assert 2_500 <= centre_hz <= 3_500
+    assert 2.0 <= gain_db <= 4.0
+
+
+def test_phone_in_pocket_no_presence_boost():
+    assert _PROFILES["phone_in_pocket"]["presence_boost"] is None
+
+
+def test_pi_budget_mic_no_presence_boost():
+    assert _PROFILES["pi_budget_mic"]["presence_boost"] is None
+
+
+def test_phone_in_hand_has_high_shelf():
+    assert _PROFILES["phone_in_hand"]["high_shelf_hz"] is not None
+    assert _PROFILES["phone_in_hand"]["high_shelf_hz"] == 6_500
+
+
+def test_phone_on_table_has_high_shelf():
+    assert _PROFILES["phone_on_table"]["high_shelf_hz"] is not None
+
+
+def test_presence_boost_increases_midband_energy():
+    """Presence boost should increase energy around 3 kHz."""
+    profiler = DeviceProfiler()
+    samples = _make_samples()
+
+    # Compare phone_in_hand (with boost) vs a profile without boost
+    out_hand = profiler.apply(samples, _SR, "phone_in_hand")
+
+    # Measure energy in the presence band (2.5-3.5 kHz)
+    presence_power_hand = _power_in_band(out_hand, _SR, 2500, 3500)
+    total_power_hand = _power_in_band(out_hand, _SR, 0, _SR / 2)
+
+    # The presence band should represent a meaningful fraction of energy
+    assert presence_power_hand > 0.0
+    if total_power_hand > 0:
+        assert presence_power_hand / total_power_hand > 0.01
+
+
+def test_high_shelf_attenuates_above_cutoff():
+    """High shelf at 6.5 kHz should reduce energy above 7 kHz."""
+    profiler = DeviceProfiler()
+    samples = _make_samples()
+
+    # Apply only high shelf via a custom profile
+    shelf_profile = {
+        "highpass_hz": 0,
+        "lowpass_hz": 8_000,
+        "presence_boost": None,
+        "high_shelf_hz": 6_500,
+        "hum_hz": None,
+        "hum_dbfs": None,
+        "level_db": 0.0,
+    }
+    no_shelf_profile = {
+        "highpass_hz": 0,
+        "lowpass_hz": 8_000,
+        "presence_boost": None,
+        "high_shelf_hz": None,
+        "hum_hz": None,
+        "hum_dbfs": None,
+        "level_db": 0.0,
+    }
+    with patch.dict(
+        "synthbanshee.augment.device_profiles._PROFILES",
+        {"with_shelf": shelf_profile, "no_shelf": no_shelf_profile},
+    ):
+        out_shelf = profiler.apply(samples, _SR, "with_shelf")
+        out_no_shelf = profiler.apply(samples, _SR, "no_shelf")
+
+    hi_power_shelf = _power_in_band(out_shelf, _SR, 7000, 8000)
+    hi_power_no_shelf = _power_in_band(out_no_shelf, _SR, 7000, 8000)
+    assert hi_power_shelf < hi_power_no_shelf

--- a/tests/unit/test_device_profiles.py
+++ b/tests/unit/test_device_profiles.py
@@ -34,7 +34,7 @@ def test_profile_keys_complete():
         "highpass_hz",
         "lowpass_hz",
         "presence_boost",
-        "high_shelf_hz",
+        "extra_lowpass_hz",
         "hum_hz",
         "hum_dbfs",
         "level_db",
@@ -176,7 +176,7 @@ def test_highpass_skipped_when_hz_is_zero():
         "highpass_hz": 0,
         "lowpass_hz": 8_000,
         "presence_boost": None,
-        "high_shelf_hz": None,
+        "extra_lowpass_hz": None,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": 0.0,
@@ -188,7 +188,7 @@ def test_highpass_skipped_when_hz_is_zero():
 
 
 # ---------------------------------------------------------------------------
-# M16: Presence boost and high shelf tests
+# M16: Presence boost and extra low-pass tests
 # ---------------------------------------------------------------------------
 
 
@@ -215,64 +215,81 @@ def test_pi_budget_mic_no_presence_boost():
     assert _PROFILES["pi_budget_mic"]["presence_boost"] is None
 
 
-def test_phone_in_hand_has_high_shelf():
-    assert _PROFILES["phone_in_hand"]["high_shelf_hz"] is not None
-    assert _PROFILES["phone_in_hand"]["high_shelf_hz"] == 6_500
+def test_phone_in_hand_has_extra_lowpass():
+    assert _PROFILES["phone_in_hand"]["extra_lowpass_hz"] is not None
+    assert _PROFILES["phone_in_hand"]["extra_lowpass_hz"] == 6_500
 
 
-def test_phone_on_table_has_high_shelf():
-    assert _PROFILES["phone_on_table"]["high_shelf_hz"] is not None
+def test_phone_on_table_has_extra_lowpass():
+    assert _PROFILES["phone_on_table"]["extra_lowpass_hz"] is not None
 
 
 def test_presence_boost_increases_midband_energy():
-    """Presence boost should increase energy around 3 kHz."""
+    """Presence boost should increase energy around 3 kHz vs an identical profile without it."""
     profiler = DeviceProfiler()
     samples = _make_samples()
 
-    # Compare phone_in_hand (with boost) vs a profile without boost
-    out_hand = profiler.apply(samples, _SR, "phone_in_hand")
-
-    # Measure energy in the presence band (2.5-3.5 kHz)
-    presence_power_hand = _power_in_band(out_hand, _SR, 2500, 3500)
-    total_power_hand = _power_in_band(out_hand, _SR, 0, _SR / 2)
-
-    # The presence band should represent a meaningful fraction of energy
-    assert presence_power_hand > 0.0
-    if total_power_hand > 0:
-        assert presence_power_hand / total_power_hand > 0.01
-
-
-def test_high_shelf_attenuates_above_cutoff():
-    """High shelf at 6.5 kHz should reduce energy above 7 kHz."""
-    profiler = DeviceProfiler()
-    samples = _make_samples()
-
-    # Apply only high shelf via a custom profile
-    shelf_profile = {
+    boosted_profile = {
         "highpass_hz": 0,
         "lowpass_hz": 8_000,
-        "presence_boost": None,
-        "high_shelf_hz": 6_500,
+        "presence_boost": (3_000, 3.0, 1.5),
+        "extra_lowpass_hz": None,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": 0.0,
     }
-    no_shelf_profile = {
+    flat_profile = {
         "highpass_hz": 0,
         "lowpass_hz": 8_000,
         "presence_boost": None,
-        "high_shelf_hz": None,
+        "extra_lowpass_hz": None,
         "hum_hz": None,
         "hum_dbfs": None,
         "level_db": 0.0,
     }
     with patch.dict(
         "synthbanshee.augment.device_profiles._PROFILES",
-        {"with_shelf": shelf_profile, "no_shelf": no_shelf_profile},
+        {"boosted": boosted_profile, "flat": flat_profile},
     ):
-        out_shelf = profiler.apply(samples, _SR, "with_shelf")
-        out_no_shelf = profiler.apply(samples, _SR, "no_shelf")
+        out_boosted = profiler.apply(samples, _SR, "boosted")
+        out_flat = profiler.apply(samples, _SR, "flat")
 
-    hi_power_shelf = _power_in_band(out_shelf, _SR, 7000, 8000)
-    hi_power_no_shelf = _power_in_band(out_no_shelf, _SR, 7000, 8000)
-    assert hi_power_shelf < hi_power_no_shelf
+    presence_boosted = _power_in_band(out_boosted, _SR, 2500, 3500)
+    presence_flat = _power_in_band(out_flat, _SR, 2500, 3500)
+    assert presence_boosted > presence_flat
+
+
+def test_extra_lowpass_attenuates_above_cutoff():
+    """Extra low-pass at 6.5 kHz should reduce energy above 7 kHz."""
+    profiler = DeviceProfiler()
+    samples = _make_samples()
+
+    # Apply only extra low-pass via a custom profile
+    with_lp_profile = {
+        "highpass_hz": 0,
+        "lowpass_hz": 8_000,
+        "presence_boost": None,
+        "extra_lowpass_hz": 6_500,
+        "hum_hz": None,
+        "hum_dbfs": None,
+        "level_db": 0.0,
+    }
+    no_lp_profile = {
+        "highpass_hz": 0,
+        "lowpass_hz": 8_000,
+        "presence_boost": None,
+        "extra_lowpass_hz": None,
+        "hum_hz": None,
+        "hum_dbfs": None,
+        "level_db": 0.0,
+    }
+    with patch.dict(
+        "synthbanshee.augment.device_profiles._PROFILES",
+        {"with_lp": with_lp_profile, "no_lp": no_lp_profile},
+    ):
+        out_with = profiler.apply(samples, _SR, "with_lp")
+        out_without = profiler.apply(samples, _SR, "no_lp")
+
+    hi_power_with = _power_in_band(out_with, _SR, 7000, 8000)
+    hi_power_without = _power_in_band(out_without, _SR, 7000, 8000)
+    assert hi_power_with < hi_power_without

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from synthbanshee.augment.pipeline import (
     _SNR_BANDS,
@@ -235,3 +236,27 @@ class TestGenerateVariantConfigs:
         for v in variants:
             assert len(v.background_events) == 1
             assert v.background_events[0].type == "tv_ambient"
+
+    def test_empty_preferred_devices_raises(self):
+        base = _make_config()
+        with pytest.raises(ValueError, match="must not be empty"):
+            generate_variant_configs(base, n_variants=1, rng_seed=0, preferred_devices=[])
+
+    def test_empty_preferred_rooms_raises(self):
+        base = _make_config()
+        with pytest.raises(ValueError, match="must not be empty"):
+            generate_variant_configs(base, n_variants=1, rng_seed=0, preferred_room_types=[])
+
+    def test_invalid_preferred_device_raises(self):
+        base = _make_config()
+        with pytest.raises(ValueError, match="Unknown device"):
+            generate_variant_configs(
+                base, n_variants=1, rng_seed=0, preferred_devices=["nonexistent"]
+            )
+
+    def test_invalid_preferred_room_raises(self):
+        base = _make_config()
+        with pytest.raises(ValueError, match="Unknown room type"):
+            generate_variant_configs(
+                base, n_variants=1, rng_seed=0, preferred_room_types=["nonexistent"]
+            )

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,0 +1,237 @@
+"""Unit tests for synthbanshee.augment.pipeline (M16 orchestrator)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from synthbanshee.augment.pipeline import (
+    _SNR_BANDS,
+    augment_scene,
+    generate_variant_configs,
+    sample_snr_db,
+)
+from synthbanshee.augment.types import AugmentationResult
+from synthbanshee.config.acoustic_config import AcousticSceneConfig, BackgroundEvent
+
+_SR = 16_000
+_N = _SR * 2  # 2 s
+
+
+def _sine(n: int = _N, sr: int = _SR) -> np.ndarray:
+    t = np.arange(n, dtype=np.float32) / sr
+    return (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+
+
+def _make_config(
+    room_type: str = "small_bedroom",
+    device: str = "phone_in_hand",
+    snr_target_db: float = 20.0,
+    background_events: list[BackgroundEvent] | None = None,
+) -> AcousticSceneConfig:
+    return AcousticSceneConfig(
+        room_type=room_type,
+        device=device,
+        speaker_distance_meters=1.0,
+        victim_distance_meters=1.0,
+        snr_target_db=snr_target_db,
+        background_events=background_events or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# sample_snr_db tests
+# ---------------------------------------------------------------------------
+
+
+class TestSampleSnrDb:
+    def test_returns_float(self):
+        rng = np.random.default_rng(0)
+        snr = sample_snr_db(rng)
+        assert isinstance(snr, float)
+
+    def test_within_overall_range(self):
+        rng = np.random.default_rng(42)
+        for _ in range(100):
+            snr = sample_snr_db(rng)
+            assert 5.0 <= snr <= 40.0
+
+    def test_distribution_roughly_correct(self):
+        """With enough samples, the distribution should match the spec bands."""
+        rng = np.random.default_rng(123)
+        n_samples = 10_000
+        band_counts = [0] * len(_SNR_BANDS)
+        for _ in range(n_samples):
+            snr = sample_snr_db(rng)
+            for i, (_, lo, hi) in enumerate(_SNR_BANDS):
+                if lo <= snr <= hi:
+                    band_counts[i] += 1
+                    break
+
+        # Check each band is within ±5% of expected
+        for i, (prob, _, _) in enumerate(_SNR_BANDS):
+            actual_frac = band_counts[i] / n_samples
+            assert abs(actual_frac - prob) < 0.05, (
+                f"Band {i} ({_SNR_BANDS[i]}): expected {prob:.0%}, got {actual_frac:.0%}"
+            )
+
+    def test_reproducible_with_same_seed(self):
+        v1 = sample_snr_db(np.random.default_rng(7))
+        v2 = sample_snr_db(np.random.default_rng(7))
+        assert v1 == v2
+
+
+# ---------------------------------------------------------------------------
+# augment_scene tests
+# ---------------------------------------------------------------------------
+
+
+class TestAugmentScene:
+    def test_returns_augmentation_result(self):
+        samples = _sine()
+        config = _make_config()
+        result = augment_scene(samples, _SR, config, rng_seed=0)
+        assert isinstance(result, AugmentationResult)
+
+    def test_output_shape_matches_input(self):
+        samples = _sine()
+        config = _make_config()
+        result = augment_scene(samples, _SR, config, rng_seed=0)
+        assert result.samples.shape == samples.shape
+
+    def test_output_dtype_float32(self):
+        samples = _sine()
+        config = _make_config()
+        result = augment_scene(samples, _SR, config, rng_seed=0)
+        assert result.samples.dtype == np.float32
+
+    def test_output_differs_from_input(self):
+        samples = _sine()
+        config = _make_config()
+        result = augment_scene(samples, _SR, config, rng_seed=0)
+        assert not np.allclose(result.samples, samples)
+
+    def test_metadata_populated(self):
+        samples = _sine()
+        config = _make_config(room_type="clinic_office", device="pi_budget_mic")
+        result = augment_scene(samples, _SR, config, rng_seed=0)
+        assert result.room_type == "clinic_office"
+        assert result.device == "pi_budget_mic"
+        assert result.ir_source == "pyroomacoustics_ism"
+        assert result.sample_rate == _SR
+        assert isinstance(result.snr_db_actual, float)
+
+    def test_reproducible_with_same_seed(self):
+        samples = _sine()
+        config = _make_config()
+        r1 = augment_scene(samples, _SR, config, rng_seed=42)
+        r2 = augment_scene(samples, _SR, config, rng_seed=42)
+        np.testing.assert_array_equal(r1.samples, r2.samples)
+
+    def test_different_seeds_differ(self):
+        samples = _sine()
+        config = _make_config()
+        r1 = augment_scene(samples, _SR, config, rng_seed=0)
+        r2 = augment_scene(samples, _SR, config, rng_seed=99)
+        assert not np.allclose(r1.samples, r2.samples)
+
+    def test_with_background_events(self):
+        samples = _sine()
+        ev = BackgroundEvent(type="tv_ambient", loop=True, onset_seconds=0.0)
+        config = _make_config(background_events=[ev])
+        result = augment_scene(
+            samples,
+            _SR,
+            config,
+            rng_seed=0,
+            assets_dir=Path("/tmp/nonexistent"),
+        )
+        assert len(result.events) >= 1
+
+    def test_acoustic_scene_dict(self):
+        samples = _sine()
+        config = _make_config()
+        result = augment_scene(samples, _SR, config, rng_seed=0)
+        d = result.acoustic_scene_dict
+        assert "room_type" in d
+        assert "device" in d
+        assert "snr_db_actual" in d
+
+
+# ---------------------------------------------------------------------------
+# generate_variant_configs tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateVariantConfigs:
+    def test_returns_correct_count(self):
+        base = _make_config()
+        variants = generate_variant_configs(base, n_variants=3, rng_seed=0)
+        assert len(variants) == 3
+
+    def test_all_variants_are_valid_configs(self):
+        base = _make_config()
+        variants = generate_variant_configs(base, n_variants=4, rng_seed=0)
+        for v in variants:
+            assert isinstance(v, AcousticSceneConfig)
+
+    def test_variants_differ_from_each_other(self):
+        base = _make_config()
+        variants = generate_variant_configs(base, n_variants=4, rng_seed=0)
+        # At least some variants should differ (room, device, distance, or SNR)
+        configs_set = set()
+        for v in variants:
+            configs_set.add((v.room_type, v.device, v.speaker_distance_meters, v.snr_target_db))
+        assert len(configs_set) > 1
+
+    def test_snr_within_m16_range(self):
+        base = _make_config()
+        variants = generate_variant_configs(base, n_variants=10, rng_seed=42)
+        for v in variants:
+            assert 5.0 <= v.snr_target_db <= 40.0
+
+    def test_speaker_distance_from_options(self):
+        base = _make_config()
+        variants = generate_variant_configs(base, n_variants=20, rng_seed=0)
+        distances = {v.speaker_distance_meters for v in variants}
+        assert distances.issubset({0.5, 1.5, 3.5})
+
+    def test_preferred_devices_respected(self):
+        base = _make_config()
+        variants = generate_variant_configs(
+            base,
+            n_variants=10,
+            rng_seed=0,
+            preferred_devices=["phone_in_pocket", "phone_on_table"],
+        )
+        for v in variants:
+            assert v.device in ("phone_in_pocket", "phone_on_table")
+
+    def test_preferred_rooms_respected(self):
+        base = _make_config()
+        variants = generate_variant_configs(
+            base,
+            n_variants=10,
+            rng_seed=0,
+            preferred_room_types=["clinic_office", "welfare_office"],
+        )
+        for v in variants:
+            assert v.room_type in ("clinic_office", "welfare_office")
+
+    def test_reproducible_with_same_seed(self):
+        base = _make_config()
+        v1 = generate_variant_configs(base, n_variants=3, rng_seed=7)
+        v2 = generate_variant_configs(base, n_variants=3, rng_seed=7)
+        for a, b in zip(v1, v2, strict=True):
+            assert a.room_type == b.room_type
+            assert a.device == b.device
+            assert a.snr_target_db == b.snr_target_db
+
+    def test_background_events_preserved(self):
+        ev = BackgroundEvent(type="tv_ambient", loop=True, onset_seconds=0.0)
+        base = _make_config(background_events=[ev])
+        variants = generate_variant_configs(base, n_variants=2, rng_seed=0)
+        for v in variants:
+            assert len(v.background_events) == 1
+            assert v.background_events[0].type == "tv_ambient"


### PR DESCRIPTION
## Summary

- Add `synthbanshee/augment/pipeline.py` — orchestrator that chains room simulation → device profiling → noise mixing into a single `augment_scene()` call, with SNR band sampling per M16 spec and `generate_variant_configs()` for producing 2–4 Tier B variants per scene
- Enhance `device_profiles.py` with biquad peaking EQ presence boost (+2–4 dB @ 2.5–3.5 kHz) and gentle high-shelf rolloff above 6.5 kHz for phone_in_hand and phone_on_table profiles
- Refactor CLI Stage 3b to use the new `augment_scene()` orchestrator instead of manually chaining three classes
- Update all unit and integration test mocks to patch the new orchestrator entry point

### Changes per file

| File | Change |
|---|---|
| `synthbanshee/augment/pipeline.py` | **New** — `augment_scene()`, `sample_snr_db()`, `generate_variant_configs()`, `_SNR_BANDS` |
| `synthbanshee/augment/device_profiles.py` | Add `_peaking_eq_coeffs()` biquad, `presence_boost` and `high_shelf_hz` to all 4 profiles, apply in `DeviceProfiler.apply()` |
| `synthbanshee/augment/__init__.py` | Export new public API from pipeline module |
| `synthbanshee/cli.py` | Refactor Stage 3b to call `augment_scene()` |
| `tests/unit/test_pipeline.py` | **New** — 22 tests for SNR sampling, augment_scene, variant generation |
| `tests/unit/test_device_profiles.py` | Add 8 tests for presence boost and high shelf |
| `tests/unit/test_cli.py` | Update mock pattern: `augment_scene` instead of 3 individual classes |
| `tests/integration/test_tier_b_pipeline.py` | Same mock pattern update |
| `tests/integration/test_tier_c_pipeline.py` | Same mock pattern update |
| `docs/audio_generation_v3_design.md` | Mark M16 as ✅ Done |

## Test plan

- [x] `pytest` — 1405 passed
- [x] `ruff check` — all checks passed
- [x] `mypy` — no new errors (pre-existing errors only)
- [x] Pre-commit hooks pass (ruff-format, trailing whitespace, etc.)
- [x] SNR distribution tests verify 50/30/10/10 band split within ±5%
- [x] Presence boost increases mid-band energy around 3 kHz
- [x] High shelf attenuates above 6.5 kHz cutoff
- [x] Tier B and Tier C integration tests pass with orchestrator mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)