### PR TITLE
fix(script): gender-aware bidirectional Hebrew disambiguation

### DIFF
--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -289,7 +289,8 @@ def _run_generate_pipeline(
     from synthbanshee.script.hebrew_disambiguator import disambiguate_turns
 
     speaker_roles_map = {spk_ref.speaker_id: spk_ref.role for spk_ref in scene.speakers}
-    turns = disambiguate_turns(turns, speaker_roles_map)
+    speaker_genders_map = {sid: spk.gender for sid, spk in speakers.items()}
+    turns = disambiguate_turns(turns, speaker_roles_map, speaker_genders_map)
     n_modified = sum(1 for t in turns if t.normalization_rules_triggered)
     vlog(f"  [dim]disambiguation: {n_modified}/{len(turns)} turns modified[/dim]")
 

--- a/synthbanshee/script/hebrew_disambiguator.py
+++ b/synthbanshee/script/hebrew_disambiguator.py
@@ -1,14 +1,15 @@
 """Hebrew gender disambiguation for TTS text normalization (pipeline M1).
 
-Azure TTS defaults to masculine inflection for morphologically ambiguous
-unvocalized Hebrew second-person forms.  When the aggressor (AGG) addresses
-the victim (VIC) — the dominant address direction in the current scenes —
-this produces systematic gender errors that are audible to native speakers
-and confirmed by direct listening (Shay, debug_run_1).
+Azure TTS produces inconsistent gender readings for morphologically ambiguous
+unvocalized Hebrew second-person forms.  When the addressee gender is known
+from the scene config, we insert niqqud (Hebrew vowel diacritics) that force
+the TTS engine to produce the correct gendered pronunciation.
 
-Strategy: rule-based lexicon substitution that inserts niqqud (Hebrew vowel
-diacritics) for the highest-risk tokens so that Azure TTS receives an
-unambiguous phonetic target and reads the correct feminine form.
+Strategy: rule-based lexicon substitution keyed on **addressee gender** (for
+2nd-person forms) and **speaker gender** (for 1st-person forms).  Each lexicon
+entry targets a surface form where the unvocalized consonant string is
+identical for masculine and feminine, and replaces it with a fully vocalized
+form that is phonetically unambiguous.
 
 Only ``DialogueTurn.text_spoken`` is modified; the original LLM output
 (``DialogueTurn.text``) is preserved unchanged for auditing and caching.
@@ -20,6 +21,7 @@ from __future__ import annotations
 
 import dataclasses
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -28,148 +30,511 @@ if TYPE_CHECKING:
 
 
 class LexiconEntry(NamedTuple):
-    """One disambiguation rule mapping an ambiguous surface form to its vocalized feminine replacement."""
+    """One disambiguation rule mapping an ambiguous surface form to a vocalized replacement."""
 
     rule_id: str
     surface: str  # unvocalized form to match in source text
-    feminine_spoken: str  # niqqud-vocalized form for TTS; forces feminine reading
-    description: str  # human-readable note (masc default → correct fem reading)
+    spoken_form: str  # niqqud-vocalized form for TTS; forces gendered reading
+    target_gender: str  # "female" or "male" — the gender this form is correct for
+    person: str  # "2" = addressee-keyed, "1" = speaker-keyed
+    description: str  # human-readable note
 
 
 # ---------------------------------------------------------------------------
-# Lexicon — high-risk second-person forms
+# Lexicon — second-person forms keyed on ADDRESSEE gender
 # ---------------------------------------------------------------------------
 #
-# Sources: Shay's direct listening feedback on debug_run_1 ("שלך always
-# pronounced 'shelkha' instead of 'shelakh', הלכת pronounced 'halakhta'
-# instead of 'halakht'"), Gemini review, Hebrew morphological reference.
+# Sources: Shay's direct listening feedback on debug_run_1, listening test
+# 2026-05-03 (issue #63), Hebrew morphological reference.
 #
 # Each entry targets a form where:
 #   (a) the written unvocalized text is identical for masc and fem, and
-#   (b) Azure TTS (he-IL-AvriNeural) defaults to the masculine reading.
-#
-# The niqqud replacement is the *only* change — the surrounding text is
-# untouched.  IPA equivalents are in the description for verification.
+#   (b) Azure TTS may read the wrong gendered form without niqqud.
 
-_LEXICON: tuple[LexiconEntry, ...] = (
-    # --- Possessive / object pronouns ---
+_LEXICON_2P_FEMININE: tuple[LexiconEntry, ...] = (
+    # --- Possessive / object pronouns (addressee is female) ---
     LexiconEntry(
-        "POSS_SHEL",
-        "שלך",
-        "שֶׁלָּךְ",
-        "shelakh (f) ← shelkha (m default); 'yours'",
+        "F2_POSS_SHEL",
+        "\u05e9\u05dc\u05da",
+        "\u05e9\u05b6\u05c1\u05dc\u05b8\u05bc\u05da\u05b0",
+        "female",
+        "2",
+        "shelakh (f) \u2190 shelkha (m default); 'yours'",
     ),
     LexiconEntry(
-        "PRON_OTKH",
-        "אותך",
-        "אוֹתָךְ",
-        "otakh (f) ← otkha (m default); 'you' (direct object)",
+        "F2_PRON_OTKH",
+        "\u05d0\u05d5\u05ea\u05da",
+        "\u05d0\u05d5\u05b9\u05ea\u05b8\u05da\u05b0",
+        "female",
+        "2",
+        "otakh (f) \u2190 otkha (m default); 'you' (direct object)",
     ),
     LexiconEntry(
-        "PRON_ITZAKH",
-        "אתך",
-        "אִתָּךְ",
-        "itakh (f) ← itkha (m default); 'with you'",
+        "F2_PRON_ITKH",
+        "\u05d0\u05ea\u05da",
+        "\u05d0\u05b4\u05ea\u05b8\u05bc\u05da\u05b0",
+        "female",
+        "2",
+        "itakh (f) \u2190 itkha (m default); 'with you'",
     ),
-    # --- Prepositional clitics ---
+    # --- Prepositional clitics (addressee is female) ---
     LexiconEntry(
-        "PREP_LAKH",
-        "לך",
-        "לָךְ",
-        "lakh (f) ← lekha (m default); 'to/for you'",
-    ),
-    LexiconEntry(
-        "PREP_BAKH",
-        "בך",
-        "בָּךְ",
-        "bakh (f) ← bekha (m default); 'in/at you'",
+        "F2_PREP_LAKH",
+        "\u05dc\u05da",
+        "\u05dc\u05b8\u05da\u05b0",
+        "female",
+        "2",
+        "lakh (f) \u2190 lekha (m default); 'to/for you'",
     ),
     LexiconEntry(
-        "PREP_MIMEKH",
-        "ממך",
-        "מִמֵּךְ",
-        "mimekh (f) ← mimkha (m default); 'from you'",
+        "F2_PREP_BAKH",
+        "\u05d1\u05da",
+        "\u05d1\u05b8\u05bc\u05da\u05b0",
+        "female",
+        "2",
+        "bakh (f) \u2190 bekha (m default); 'in/at you'",
     ),
     LexiconEntry(
-        "PREP_ALAIKH",
-        "עליך",
-        "עָלַיִךְ",
-        "alaikh (f) ← alekha (m default); 'on/about you'",
+        "F2_PREP_MIMEKH",
+        "\u05de\u05de\u05da",
+        "\u05de\u05b4\u05de\u05b5\u05bc\u05da\u05b0",
+        "female",
+        "2",
+        "mimekh (f) \u2190 mimkha (m default); 'from you'",
     ),
     LexiconEntry(
-        "PREP_ELAIKH",
-        "אליך",
-        "אֵלַיִךְ",
-        "elaikh (f) ← elekha (m default); 'toward you'",
-    ),
-    # --- Past-tense 2sg verbs — fem ends /-t/ (תְּ), masc /-ta/ (תָּ) ---
-    LexiconEntry(
-        "VERB_PAST_HALAKHT",
-        "הלכת",
-        "הָלַכְתְּ",
-        "halakht (f) ← halakhta (m default); 'you went'",
+        "F2_PREP_ALAIKH",
+        "\u05e2\u05dc\u05d9\u05da",
+        "\u05e2\u05b8\u05dc\u05b7\u05d9\u05b4\u05da\u05b0",
+        "female",
+        "2",
+        "alaikh (f) \u2190 alekha (m default); 'on/about you'",
     ),
     LexiconEntry(
-        "VERB_PAST_ASIT",
-        "עשית",
-        "עָשִׂיתְ",
-        "asit (f) ← asita (m default); 'you did/made'",
+        "F2_PREP_ELAIKH",
+        "\u05d0\u05dc\u05d9\u05da",
+        "\u05d0\u05b5\u05dc\u05b7\u05d9\u05b4\u05da\u05b0",
+        "female",
+        "2",
+        "elaikh (f) \u2190 elekha (m default); 'toward you'",
+    ),
+    # --- Past-tense 2sg verbs (addressee is female) ---
+    # Fem ends /-t/ (shva on tav), masc /-ta/ (kamatz on tav)
+    LexiconEntry(
+        "F2_VERB_HALAKHT",
+        "\u05d4\u05dc\u05db\u05ea",
+        "\u05d4\u05b8\u05dc\u05b7\u05db\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "halakht (f) \u2190 halakhta (m default); 'you went'",
     ),
     LexiconEntry(
-        "VERB_PAST_KHASHAVT",
-        "חשבת",
-        "חָשַׁבְתְּ",
-        "khashavt (f) ← khashavta (m default); 'you thought'",
+        "F2_VERB_ASIT",
+        "\u05e2\u05e9\u05d9\u05ea",
+        "\u05e2\u05b8\u05e9\u05c2\u05b4\u05d9\u05ea\u05b0",
+        "female",
+        "2",
+        "asit (f) \u2190 asita (m default); 'you did/made'",
     ),
     LexiconEntry(
-        "VERB_PAST_DIBBART",
-        "דיברת",
-        "דִּיבַּרְתְּ",
-        "dibart (f) ← dibarta (m default); 'you spoke'",
+        "F2_VERB_KHASHAVT",
+        "\u05d7\u05e9\u05d1\u05ea",
+        "\u05d7\u05b8\u05e9\u05c1\u05b7\u05d1\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "khashavt (f) \u2190 khashavta (m default); 'you thought'",
     ),
     LexiconEntry(
-        "VERB_PAST_YADAT",
-        "ידעת",
-        "יָדַעְתְּ",
-        "yadat (f) ← yadata (m default); 'you knew'",
+        "F2_VERB_DIBART",
+        "\u05d3\u05d9\u05d1\u05e8\u05ea",
+        "\u05d3\u05b4\u05bc\u05d9\u05d1\u05b7\u05bc\u05e8\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "dibart (f) \u2190 dibarta (m default); 'you spoke'",
     ),
     LexiconEntry(
-        "VERB_PAST_HAYIT",
-        "היית",
-        "הָיִיתְ",
-        "hayit (f) ← hayita (m default); 'you were'",
+        "F2_VERB_YADAT",
+        "\u05d9\u05d3\u05e2\u05ea",
+        "\u05d9\u05b8\u05d3\u05b7\u05e2\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "yadat (f) \u2190 yadata (m default); 'you knew'",
     ),
     LexiconEntry(
-        "VERB_PAST_RATSIT",
-        "רצית",
-        "רָצִיתְ",
-        "ratsit (f) ← ratsita (m default); 'you wanted'",
+        "F2_VERB_HAYIT",
+        "\u05d4\u05d9\u05d9\u05ea",
+        "\u05d4\u05b8\u05d9\u05b4\u05d9\u05ea\u05b0",
+        "female",
+        "2",
+        "hayit (f) \u2190 hayita (m default); 'you were'",
+    ),
+    LexiconEntry(
+        "F2_VERB_RATSIT",
+        "\u05e8\u05e6\u05d9\u05ea",
+        "\u05e8\u05b8\u05e6\u05b4\u05d9\u05ea\u05b0",
+        "female",
+        "2",
+        "ratsit (f) \u2190 ratsita (m default); 'you wanted'",
+    ),
+    # --- Additional past-tense 2sg verbs (addressee is female) ---
+    LexiconEntry(
+        "F2_VERB_ANIT",
+        "\u05e2\u05e0\u05d9\u05ea",
+        "\u05e2\u05b8\u05e0\u05b4\u05d9\u05ea\u05b0",
+        "female",
+        "2",
+        "anit (f) \u2190 anita (m default); 'you answered'",
+    ),
+    LexiconEntry(
+        "F2_VERB_AMART",
+        "\u05d0\u05de\u05e8\u05ea",
+        "\u05d0\u05b8\u05de\u05b7\u05e8\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "amart (f) \u2190 amarta (m default); 'you said'",
+    ),
+    LexiconEntry(
+        "F2_VERB_SHAMAT",
+        "\u05e9\u05de\u05e2\u05ea",
+        "\u05e9\u05c1\u05b8\u05de\u05b7\u05e2\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "shamat (f) \u2190 shamata (m default); 'you heard'",
+    ),
+    LexiconEntry(
+        "F2_VERB_RAIT",
+        "\u05e8\u05d0\u05d9\u05ea",
+        "\u05e8\u05b8\u05d0\u05b4\u05d9\u05ea\u05b0",
+        "female",
+        "2",
+        "ra'it (f) \u2190 ra'ita (m default); 'you saw'",
+    ),
+    LexiconEntry(
+        "F2_VERB_LAKAKHT",
+        "\u05dc\u05e7\u05d7\u05ea",
+        "\u05dc\u05b8\u05e7\u05b7\u05d7\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "lakakht (f) \u2190 lakakhta (m default); 'you took'",
+    ),
+    LexiconEntry(
+        "F2_VERB_NATATT",
+        "\u05e0\u05ea\u05ea",
+        "\u05e0\u05b8\u05ea\u05b7\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "natatt (f) \u2190 natata (m default); 'you gave'",
+    ),
+    LexiconEntry(
+        "F2_VERB_BAT",
+        "\u05d1\u05d0\u05ea",
+        "\u05d1\u05b8\u05d0\u05ea\u05b0",
+        "female",
+        "2",
+        "bat (f) \u2190 bata (m default); 'you came'",
+    ),
+    LexiconEntry(
+        "F2_VERB_YATSAT",
+        "\u05d9\u05e6\u05d0\u05ea",
+        "\u05d9\u05b8\u05e6\u05b8\u05d0\u05ea\u05b0",
+        "female",
+        "2",
+        "yatsat (f) \u2190 yatsata (m default); 'you went out'",
+    ),
+    LexiconEntry(
+        "F2_VERB_SHAKHAKHT",
+        "\u05e9\u05db\u05d7\u05ea",
+        "\u05e9\u05c1\u05b8\u05db\u05b7\u05d7\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "shakhakht (f) \u2190 shakhakhta (m default); 'you forgot'",
+    ),
+    LexiconEntry(
+        "F2_VERB_HITKHALAT",
+        "\u05d4\u05ea\u05d7\u05dc\u05ea",
+        "\u05d4\u05b4\u05ea\u05b0\u05d7\u05b7\u05dc\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "hitkhalat (f) \u2190 hitkhalta (m default); 'you started'",
+    ),
+    LexiconEntry(
+        "F2_VERB_HIFSAKT",
+        "\u05d4\u05e4\u05e1\u05e7\u05ea",
+        "\u05d4\u05b4\u05e4\u05b0\u05e1\u05b7\u05e7\u05b0\u05ea\u05b0\u05bc",
+        "female",
+        "2",
+        "hifsakt (f) \u2190 hifsakta (m default); 'you stopped'",
     ),
 )
 
-# Pre-compile one regex per lexicon entry.
-# Lookahead/lookbehind on Hebrew token characters ensure we match whole
-# tokens, not substrings embedded inside longer words.  The guard covers
-# both Hebrew base letters (U+05D0–U+05EA) and Hebrew combining marks /
-# related marks (U+0591–U+05C7), so a partially-vocalized letter immediately
-# adjacent to the surface form does not create a false word boundary that
-# would allow an in-word match.
+_LEXICON_2P_MASCULINE: tuple[LexiconEntry, ...] = (
+    # --- Possessive / object pronouns (addressee is male) ---
+    LexiconEntry(
+        "M2_POSS_SHEL",
+        "\u05e9\u05dc\u05da",
+        "\u05e9\u05b6\u05c1\u05dc\u05b0\u05bc\u05da\u05b8",
+        "male",
+        "2",
+        "shelkha (m) \u2190 shelakh (f); 'yours'",
+    ),
+    LexiconEntry(
+        "M2_PRON_OTKH",
+        "\u05d0\u05d5\u05ea\u05da",
+        "\u05d0\u05d5\u05b9\u05ea\u05b0\u05da\u05b8",
+        "male",
+        "2",
+        "otkha (m) \u2190 otakh (f); 'you' (direct object)",
+    ),
+    LexiconEntry(
+        "M2_PRON_ITKH",
+        "\u05d0\u05ea\u05da",
+        "\u05d0\u05b4\u05ea\u05b0\u05bc\u05da\u05b8",
+        "male",
+        "2",
+        "itkha (m) \u2190 itakh (f); 'with you'",
+    ),
+    # --- Prepositional clitics (addressee is male) ---
+    LexiconEntry(
+        "M2_PREP_LEKHA",
+        "\u05dc\u05da",
+        "\u05dc\u05b0\u05da\u05b8",
+        "male",
+        "2",
+        "lekha (m) \u2190 lakh (f); 'to/for you'",
+    ),
+    LexiconEntry(
+        "M2_PREP_BEKHA",
+        "\u05d1\u05da",
+        "\u05d1\u05b0\u05bc\u05da\u05b8",
+        "male",
+        "2",
+        "bekha (m) \u2190 bakh (f); 'in/at you'",
+    ),
+    LexiconEntry(
+        "M2_PREP_MIMKHA",
+        "\u05de\u05de\u05da",
+        "\u05de\u05b4\u05de\u05b0\u05bc\u05da\u05b8",
+        "male",
+        "2",
+        "mimkha (m) \u2190 mimekh (f); 'from you'",
+    ),
+    LexiconEntry(
+        "M2_PREP_ALEKHA",
+        "\u05e2\u05dc\u05d9\u05da",
+        "\u05e2\u05b8\u05dc\u05b6\u05d9\u05da\u05b8",
+        "male",
+        "2",
+        "alekha (m) \u2190 alaikh (f); 'on/about you'",
+    ),
+    LexiconEntry(
+        "M2_PREP_ELEKHA",
+        "\u05d0\u05dc\u05d9\u05da",
+        "\u05d0\u05b5\u05dc\u05b6\u05d9\u05da\u05b8",
+        "male",
+        "2",
+        "elekha (m) \u2190 elaikh (f); 'toward you'",
+    ),
+    # --- Past-tense 2sg verbs (addressee is male) ---
+    # Masc ends /-ta/ (kamatz+dagesh on tav), fem /-t/ (shva on tav)
+    LexiconEntry(
+        "M2_VERB_HALAKHTA",
+        "\u05d4\u05dc\u05db\u05ea",
+        "\u05d4\u05b8\u05dc\u05b7\u05db\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "halakhta (m) \u2190 halakht (f); 'you went'",
+    ),
+    LexiconEntry(
+        "M2_VERB_ASITA",
+        "\u05e2\u05e9\u05d9\u05ea",
+        "\u05e2\u05b8\u05e9\u05c2\u05b4\u05d9\u05ea\u05b8",
+        "male",
+        "2",
+        "asita (m) \u2190 asit (f); 'you did/made'",
+    ),
+    LexiconEntry(
+        "M2_VERB_KHASHAVTA",
+        "\u05d7\u05e9\u05d1\u05ea",
+        "\u05d7\u05b8\u05e9\u05c1\u05b7\u05d1\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "khashavta (m) \u2190 khashavt (f); 'you thought'",
+    ),
+    LexiconEntry(
+        "M2_VERB_DIBARTA",
+        "\u05d3\u05d9\u05d1\u05e8\u05ea",
+        "\u05d3\u05b4\u05bc\u05d9\u05d1\u05b7\u05bc\u05e8\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "dibarta (m) \u2190 dibart (f); 'you spoke'",
+    ),
+    LexiconEntry(
+        "M2_VERB_YADATA",
+        "\u05d9\u05d3\u05e2\u05ea",
+        "\u05d9\u05b8\u05d3\u05b7\u05e2\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "yadata (m) \u2190 yadat (f); 'you knew'",
+    ),
+    LexiconEntry(
+        "M2_VERB_HAYITA",
+        "\u05d4\u05d9\u05d9\u05ea",
+        "\u05d4\u05b8\u05d9\u05b4\u05d9\u05ea\u05b8",
+        "male",
+        "2",
+        "hayita (m) \u2190 hayit (f); 'you were'",
+    ),
+    LexiconEntry(
+        "M2_VERB_RATSITA",
+        "\u05e8\u05e6\u05d9\u05ea",
+        "\u05e8\u05b8\u05e6\u05b4\u05d9\u05ea\u05b8",
+        "male",
+        "2",
+        "ratsita (m) \u2190 ratsit (f); 'you wanted'",
+    ),
+    # --- Additional past-tense 2sg verbs (addressee is male) ---
+    LexiconEntry(
+        "M2_VERB_ANITA",
+        "\u05e2\u05e0\u05d9\u05ea",
+        "\u05e2\u05b8\u05e0\u05b4\u05d9\u05ea\u05b8",
+        "male",
+        "2",
+        "anita (m) \u2190 anit (f); 'you answered'",
+    ),
+    LexiconEntry(
+        "M2_VERB_AMARTA",
+        "\u05d0\u05de\u05e8\u05ea",
+        "\u05d0\u05b8\u05de\u05b7\u05e8\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "amarta (m) \u2190 amart (f); 'you said'",
+    ),
+    LexiconEntry(
+        "M2_VERB_SHAMATA",
+        "\u05e9\u05de\u05e2\u05ea",
+        "\u05e9\u05c1\u05b8\u05de\u05b7\u05e2\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "shamata (m) \u2190 shamat (f); 'you heard'",
+    ),
+    LexiconEntry(
+        "M2_VERB_RAITA",
+        "\u05e8\u05d0\u05d9\u05ea",
+        "\u05e8\u05b8\u05d0\u05b4\u05d9\u05ea\u05b8",
+        "male",
+        "2",
+        "ra'ita (m) \u2190 ra'it (f); 'you saw'",
+    ),
+    LexiconEntry(
+        "M2_VERB_LAKAKHTA",
+        "\u05dc\u05e7\u05d7\u05ea",
+        "\u05dc\u05b8\u05e7\u05b7\u05d7\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "lakakhta (m) \u2190 lakakht (f); 'you took'",
+    ),
+    LexiconEntry(
+        "M2_VERB_NATATA",
+        "\u05e0\u05ea\u05ea",
+        "\u05e0\u05b8\u05ea\u05b7\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "natata (m) \u2190 natatt (f); 'you gave'",
+    ),
+    LexiconEntry(
+        "M2_VERB_BATA",
+        "\u05d1\u05d0\u05ea",
+        "\u05d1\u05b8\u05d0\u05ea\u05b8",
+        "male",
+        "2",
+        "bata (m) \u2190 bat (f); 'you came'",
+    ),
+    LexiconEntry(
+        "M2_VERB_YATSATA",
+        "\u05d9\u05e6\u05d0\u05ea",
+        "\u05d9\u05b8\u05e6\u05b8\u05d0\u05ea\u05b8",
+        "male",
+        "2",
+        "yatsata (m) \u2190 yatsat (f); 'you went out'",
+    ),
+    LexiconEntry(
+        "M2_VERB_SHAKHAKHTA",
+        "\u05e9\u05db\u05d7\u05ea",
+        "\u05e9\u05c1\u05b8\u05db\u05b7\u05d7\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "shakhakhta (m) \u2190 shakhakht (f); 'you forgot'",
+    ),
+    LexiconEntry(
+        "M2_VERB_HITKHALTA",
+        "\u05d4\u05ea\u05d7\u05dc\u05ea",
+        "\u05d4\u05b4\u05ea\u05b0\u05d7\u05b7\u05dc\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "hitkhalta (m) \u2190 hitkhalat (f); 'you started'",
+    ),
+    LexiconEntry(
+        "M2_VERB_HIFSAKTA",
+        "\u05d4\u05e4\u05e1\u05e7\u05ea",
+        "\u05d4\u05b4\u05e4\u05b0\u05e1\u05b7\u05e7\u05b0\u05ea\u05b8\u05bc",
+        "male",
+        "2",
+        "hifsakta (m) \u2190 hifsakt (f); 'you stopped'",
+    ),
+)
+
+# Combined lexicon for backward-compatible parametrized tests.
+_LEXICON: tuple[LexiconEntry, ...] = _LEXICON_2P_FEMININE + _LEXICON_2P_MASCULINE
+
+# ---------------------------------------------------------------------------
+# Surface forms that remain gender-ambiguous after disambiguation
+# ---------------------------------------------------------------------------
+# Used by the QA gate to flag turns that may still contain wrong-gender forms.
+# These are common 2nd-person surface forms whose unvocalized spelling is
+# shared between masculine and feminine.  If any of these survive in
+# text_spoken without niqqud, they are suspicious.
+_AMBIGUOUS_SURFACES: frozenset[str] = frozenset(entry.surface for entry in _LEXICON)
+
+# ---------------------------------------------------------------------------
+# Regex compilation
+# ---------------------------------------------------------------------------
+
 _HEB_TOKEN_CHAR = r"[\u0591-\u05C7\u05D0-\u05EA]"
 
-_COMPILED: tuple[tuple[LexiconEntry, re.Pattern[str]], ...] = tuple(
-    (
-        entry,
-        re.compile(
-            r"(?<!"
-            + _HEB_TOKEN_CHAR
-            + r")"
-            + re.escape(entry.surface)
-            + r"(?!"
-            + _HEB_TOKEN_CHAR
-            + r")"
-        ),
+
+def _compile_entries(
+    entries: tuple[LexiconEntry, ...],
+) -> tuple[tuple[LexiconEntry, re.Pattern[str]], ...]:
+    return tuple(
+        (
+            entry,
+            re.compile(
+                r"(?<!"
+                + _HEB_TOKEN_CHAR
+                + r")"
+                + re.escape(entry.surface)
+                + r"(?!"
+                + _HEB_TOKEN_CHAR
+                + r")"
+            ),
+        )
+        for entry in entries
     )
-    for entry in _LEXICON
+
+
+_COMPILED_2P_FEMININE = _compile_entries(_LEXICON_2P_FEMININE)
+_COMPILED_2P_MASCULINE = _compile_entries(_LEXICON_2P_MASCULINE)
+
+# Pre-compile a single scanner regex for the QA gate: matches any unvocalized
+# ambiguous surface form that was NOT replaced by a niqqud-bearing form.
+_AMBIGUOUS_SCANNER = re.compile(
+    r"(?<!"
+    + _HEB_TOKEN_CHAR
+    + r")(?:"
+    + "|".join(re.escape(s) for s in sorted(_AMBIGUOUS_SURFACES, key=len, reverse=True))
+    + r")(?!"
+    + _HEB_TOKEN_CHAR
+    + r")"
 )
 
 
@@ -201,32 +566,38 @@ class NormalizationResult:
 
 def disambiguate_for_speaker(
     text: str,
-    speaker_role: str,
-    addressee_role: str,
+    speaker_gender: str,
+    addressee_gender: str,
 ) -> NormalizationResult:
-    """Apply feminine gender corrections when AGG addresses VIC.
+    """Apply gender corrections based on speaker and addressee genders.
 
-    Substitutions are only applied when *speaker_role* is ``"AGG"`` and
-    *addressee_role* is ``"VIC"`` — the dominant AGG→VIC direction in all
-    current scene configurations.  All other role pairs are returned
-    unchanged, preserving VIC self-references and VIC→AGG address forms.
+    Second-person forms (pronouns, prepositions, verbs) are selected based
+    on the *addressee* gender.  The rules insert niqqud to force the TTS
+    engine to read the correct gendered form.
 
     Args:
         text: UTF-8 Hebrew source text (``DialogueTurn.text``).
-        speaker_role: Role of the turn's speaker, e.g. ``"AGG"``.
-        addressee_role: Role of the primary addressee, e.g. ``"VIC"``.
+        speaker_gender: Gender of the turn's speaker (``"male"`` or
+            ``"female"``).
+        addressee_gender: Gender of the primary addressee (``"male"`` or
+            ``"female"``).
 
     Returns:
         :class:`NormalizationResult` carrying the (possibly modified)
         ``text_spoken`` and the list of rule IDs that fired.
     """
-    if not (speaker_role == "AGG" and addressee_role == "VIC"):
+    # Select the correct compiled lexicon based on addressee gender.
+    if addressee_gender == "female":
+        compiled = _COMPILED_2P_FEMININE
+    elif addressee_gender == "male":
+        compiled = _COMPILED_2P_MASCULINE
+    else:
         return NormalizationResult(text_spoken=text)
 
     result = text
     triggered: list[str] = []
-    for entry, pattern in _COMPILED:
-        new_text, n = pattern.subn(entry.feminine_spoken, result)
+    for entry, pattern in compiled:
+        new_text, n = pattern.subn(entry.spoken_form, result)
         if n:
             result = new_text
             triggered.append(entry.rule_id)
@@ -237,21 +608,36 @@ def disambiguate_for_speaker(
     )
 
 
+def check_gender_ambiguity(text_spoken: str) -> list[str]:
+    """Flag remaining gender-ambiguous surface forms after disambiguation.
+
+    Scans *text_spoken* for unvocalized tokens that appear in the lexicon
+    but were not replaced (e.g. because the addressee gender was unknown).
+
+    Returns:
+        List of warning strings, one per ambiguous token found.  Empty if
+        no suspicious forms remain.
+    """
+    warnings: list[str] = []
+    for match in _AMBIGUOUS_SCANNER.finditer(text_spoken):
+        token = match.group()
+        warnings.append(f"gender_ambiguity: unresolved '{token}' at position {match.start()}")
+    return warnings
+
+
 def disambiguate_turns(
     turns: list[DialogueTurn],
     speaker_roles: dict[str, str],
+    speaker_genders: Mapping[str, str] | None = None,
 ) -> list[DialogueTurn]:
     """Apply gender disambiguation to every turn in a scene.
 
-    For each turn the addressee role is inferred heuristically from the
-    other speakers in *speaker_roles*.  The function first looks for another
-    speaker whose role matches the priority order ``"VIC"``, ``"AGG"``,
-    ``"BYS"`` (excluding the current speaker's own ``speaker_id``).  If none
-    of those roles is present among the other speakers, it falls back to the
-    first other speaker role encountered.  This matches the standard
-    two-speaker AGG/VIC scene and provides a best-effort heuristic for
-    multi-speaker scenes, where the inferred addressee may still be
-    inaccurate.
+    For each turn the addressee is inferred heuristically from the other
+    speakers in *speaker_roles*.  Gender information is looked up from
+    *speaker_genders* (mapping ``{speaker_id: "male"|"female"}``).
+
+    When *speaker_genders* is ``None``, falls back to legacy behaviour:
+    AGG is assumed male, VIC is assumed female.
 
     The original ``DialogueTurn`` objects are never mutated.  New instances
     are returned with ``text_spoken`` and ``normalization_rules_triggered``
@@ -261,42 +647,65 @@ def disambiguate_turns(
         turns: Ordered list of turns from :class:`ScriptGenerator`.
         speaker_roles: Mapping ``{speaker_id: role}`` for all speakers in
             the scene (built from ``SceneConfig.speakers``).
+        speaker_genders: Mapping ``{speaker_id: gender}`` for all speakers.
+            When ``None``, gender is inferred from role (legacy fallback).
 
     Returns:
         New list of :class:`DialogueTurn` with disambiguation applied.
     """
 
-    # Priority order for addressee selection in multi-speaker scenes.
-    # AGG prefers VIC; VIC prefers AGG; BYS is always last resort.
     _ROLE_PRIORITY = ["VIC", "AGG", "BYS"]
 
-    def _addressee_role(speaker_id: str) -> str:
+    # Legacy gender inference from role.
+    _ROLE_GENDER_FALLBACK: dict[str, str] = {
+        "AGG": "male",
+        "VIC": "female",
+    }
+
+    def _gender(speaker_id: str) -> str:
+        if speaker_genders and speaker_id in speaker_genders:
+            return speaker_genders[speaker_id]
+        role = speaker_roles.get(speaker_id, "UNK")
+        return _ROLE_GENDER_FALLBACK.get(role, "")
+
+    def _addressee_id(speaker_id: str) -> str:
+        """Return the speaker_id of the most likely addressee."""
         my_role = speaker_roles.get(speaker_id, "UNK")
-        other_roles = {
-            role for sid, role in speaker_roles.items() if sid != speaker_id and role != my_role
-        }
-        for candidate in _ROLE_PRIORITY:
-            if candidate in other_roles:
-                return candidate
-        # Fall back to any other role not in the priority list.
-        for sid, role in speaker_roles.items():
-            if sid != speaker_id and role != my_role:
-                return role
-        return "UNK"
+        # Build candidates: other speakers ordered by role priority.
+        others = [(sid, role) for sid, role in speaker_roles.items() if sid != speaker_id]
+        for candidate_role in _ROLE_PRIORITY:
+            if candidate_role == my_role:
+                continue
+            for sid, role in others:
+                if role == candidate_role:
+                    return sid
+        # Fall back to first other speaker.
+        for sid, _role in others:
+            return sid
+        return ""
 
     result: list[DialogueTurn] = []
     for turn in turns:
-        addr_role = _addressee_role(turn.speaker_id)
+        addr_id = _addressee_id(turn.speaker_id)
+        spk_gender = _gender(turn.speaker_id)
+        addr_gender = _gender(addr_id) if addr_id else ""
+
         norm = disambiguate_for_speaker(
             turn.text_spoken or turn.text,
-            speaker_roles.get(turn.speaker_id, "UNK"),
-            addr_role,
+            spk_gender,
+            addr_gender,
         )
+
+        # QA gate: flag remaining ambiguous forms.
+        qa_warnings = check_gender_ambiguity(norm.text_spoken)
+        gate_failures = list(turn.quality_gate_failures) + qa_warnings
+
         result.append(
             dataclasses.replace(
                 turn,
                 text_spoken=norm.text_spoken,
                 normalization_rules_triggered=norm.normalization_rules_triggered,
+                quality_gate_failures=gate_failures,
             )
         )
     return result

--- a/synthbanshee/script/hebrew_disambiguator.py
+++ b/synthbanshee/script/hebrew_disambiguator.py
@@ -5,8 +5,8 @@ unvocalized Hebrew second-person forms.  When the addressee gender is known
 from the scene config, we insert niqqud (Hebrew vowel diacritics) that force
 the TTS engine to produce the correct gendered pronunciation.
 
-Strategy: rule-based lexicon substitution keyed on **addressee gender** (for
-2nd-person forms) and **speaker gender** (for 1st-person forms).  Each lexicon
+Strategy: rule-based lexicon substitution keyed on **addressee gender** for
+2nd-person forms (pronouns, prepositions, past-tense verbs).  Each lexicon
 entry targets a surface form where the unvocalized consonant string is
 identical for masculine and feminine, and replaces it with a fully vocalized
 form that is phonetically unambiguous.
@@ -15,6 +15,12 @@ Only ``DialogueTurn.text_spoken`` is modified; the original LLM output
 (``DialogueTurn.text``) is preserved unchanged for auditing and caching.
 
 Reference: docs/audio_generation_v3_design.md §4.1, M1
+
+.. note:: Rule IDs changed in this version.
+
+   Feminine entries were renamed from ``POSS_SHEL`` to ``F2_POSS_SHEL`` (etc.)
+   to distinguish them from the new masculine ``M2_*`` entries.  Update any
+   log-analysis or dashboard filters that match on the old ID format.
 """
 
 from __future__ import annotations
@@ -36,12 +42,27 @@ class LexiconEntry(NamedTuple):
     surface: str  # unvocalized form to match in source text
     spoken_form: str  # niqqud-vocalized form for TTS; forces gendered reading
     target_gender: str  # "female" or "male" — the gender this form is correct for
-    person: str  # "2" = addressee-keyed, "1" = speaker-keyed
     description: str  # human-readable note
 
 
+class _AmbiguousForm(NamedTuple):
+    """Single source-of-truth entry for a gender-ambiguous Hebrew surface form.
+
+    Both feminine and masculine ``LexiconEntry`` objects are generated from
+    each ``_AmbiguousForm`` — eliminating duplication between the two
+    lexicons and guaranteeing that every surface form has both gendered
+    variants.
+    """
+
+    base_id: str
+    surface: str
+    female_spoken: str
+    male_spoken: str
+    description: str  # short gloss, e.g. "'yours'"
+
+
 # ---------------------------------------------------------------------------
-# Lexicon — second-person forms keyed on ADDRESSEE gender
+# Lexicon data — single source of truth
 # ---------------------------------------------------------------------------
 #
 # Sources: Shay's direct listening feedback on debug_run_1, listening test
@@ -51,439 +72,223 @@ class LexiconEntry(NamedTuple):
 #   (a) the written unvocalized text is identical for masc and fem, and
 #   (b) Azure TTS may read the wrong gendered form without niqqud.
 
-_LEXICON_2P_FEMININE: tuple[LexiconEntry, ...] = (
-    # --- Possessive / object pronouns (addressee is female) ---
-    LexiconEntry(
-        "F2_POSS_SHEL",
+_AMBIGUOUS_FORMS: tuple[_AmbiguousForm, ...] = (
+    # --- Possessive / object pronouns ---
+    #              base_id         surface   female_spoken            male_spoken              description
+    _AmbiguousForm(
+        "POSS_SHEL",
         "\u05e9\u05dc\u05da",
         "\u05e9\u05b6\u05c1\u05dc\u05b8\u05bc\u05da\u05b0",
-        "female",
-        "2",
-        "shelakh (f) \u2190 shelkha (m default); 'yours'",
+        "\u05e9\u05b6\u05c1\u05dc\u05b0\u05bc\u05da\u05b8",
+        "'yours' — shelakh (f) / shelkha (m)",
     ),
-    LexiconEntry(
-        "F2_PRON_OTKH",
+    _AmbiguousForm(
+        "PRON_OTKH",
         "\u05d0\u05d5\u05ea\u05da",
         "\u05d0\u05d5\u05b9\u05ea\u05b8\u05da\u05b0",
-        "female",
-        "2",
-        "otakh (f) \u2190 otkha (m default); 'you' (direct object)",
+        "\u05d0\u05d5\u05b9\u05ea\u05b0\u05da\u05b8",
+        "'you' (obj) — otakh (f) / otkha (m)",
     ),
-    LexiconEntry(
-        "F2_PRON_ITKH",
+    _AmbiguousForm(
+        "PRON_ITKH",
         "\u05d0\u05ea\u05da",
         "\u05d0\u05b4\u05ea\u05b8\u05bc\u05da\u05b0",
-        "female",
-        "2",
-        "itakh (f) \u2190 itkha (m default); 'with you'",
+        "\u05d0\u05b4\u05ea\u05b0\u05bc\u05da\u05b8",
+        "'with you' — itakh (f) / itkha (m)",
     ),
-    # --- Prepositional clitics (addressee is female) ---
-    LexiconEntry(
-        "F2_PREP_LAKH",
+    # --- Prepositional clitics ---
+    _AmbiguousForm(
+        "PREP_LAKH",
         "\u05dc\u05da",
         "\u05dc\u05b8\u05da\u05b0",
-        "female",
-        "2",
-        "lakh (f) \u2190 lekha (m default); 'to/for you'",
+        "\u05dc\u05b0\u05da\u05b8",
+        "'to/for you' — lakh (f) / lekha (m)",
     ),
-    LexiconEntry(
-        "F2_PREP_BAKH",
+    _AmbiguousForm(
+        "PREP_BAKH",
         "\u05d1\u05da",
         "\u05d1\u05b8\u05bc\u05da\u05b0",
-        "female",
-        "2",
-        "bakh (f) \u2190 bekha (m default); 'in/at you'",
+        "\u05d1\u05b0\u05bc\u05da\u05b8",
+        "'in/at you' — bakh (f) / bekha (m)",
     ),
-    LexiconEntry(
-        "F2_PREP_MIMEKH",
+    _AmbiguousForm(
+        "PREP_MIMEKH",
         "\u05de\u05de\u05da",
         "\u05de\u05b4\u05de\u05b5\u05bc\u05da\u05b0",
-        "female",
-        "2",
-        "mimekh (f) \u2190 mimkha (m default); 'from you'",
+        "\u05de\u05b4\u05de\u05b0\u05bc\u05da\u05b8",
+        "'from you' — mimekh (f) / mimkha (m)",
     ),
-    LexiconEntry(
-        "F2_PREP_ALAIKH",
+    _AmbiguousForm(
+        "PREP_ALAIKH",
         "\u05e2\u05dc\u05d9\u05da",
         "\u05e2\u05b8\u05dc\u05b7\u05d9\u05b4\u05da\u05b0",
-        "female",
-        "2",
-        "alaikh (f) \u2190 alekha (m default); 'on/about you'",
+        "\u05e2\u05b8\u05dc\u05b6\u05d9\u05da\u05b8",
+        "'on/about you' — alaikh (f) / alekha (m)",
     ),
-    LexiconEntry(
-        "F2_PREP_ELAIKH",
+    _AmbiguousForm(
+        "PREP_ELAIKH",
         "\u05d0\u05dc\u05d9\u05da",
         "\u05d0\u05b5\u05dc\u05b7\u05d9\u05b4\u05da\u05b0",
-        "female",
-        "2",
-        "elaikh (f) \u2190 elekha (m default); 'toward you'",
+        "\u05d0\u05b5\u05dc\u05b6\u05d9\u05da\u05b8",
+        "'toward you' — elaikh (f) / elekha (m)",
     ),
-    # --- Past-tense 2sg verbs (addressee is female) ---
+    # --- Past-tense 2sg verbs ---
     # Fem ends /-t/ (shva on tav), masc /-ta/ (kamatz on tav)
-    LexiconEntry(
-        "F2_VERB_HALAKHT",
+    _AmbiguousForm(
+        "VERB_HALAKHT",
         "\u05d4\u05dc\u05db\u05ea",
         "\u05d4\u05b8\u05dc\u05b7\u05db\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "halakht (f) \u2190 halakhta (m default); 'you went'",
+        "\u05d4\u05b8\u05dc\u05b7\u05db\u05b0\u05ea\u05b8\u05bc",
+        "'you went' — halakht (f) / halakhta (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_ASIT",
+    _AmbiguousForm(
+        "VERB_ASIT",
         "\u05e2\u05e9\u05d9\u05ea",
         "\u05e2\u05b8\u05e9\u05c2\u05b4\u05d9\u05ea\u05b0",
-        "female",
-        "2",
-        "asit (f) \u2190 asita (m default); 'you did/made'",
+        "\u05e2\u05b8\u05e9\u05c2\u05b4\u05d9\u05ea\u05b8",
+        "'you did/made' — asit (f) / asita (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_KHASHAVT",
+    _AmbiguousForm(
+        "VERB_KHASHAVT",
         "\u05d7\u05e9\u05d1\u05ea",
         "\u05d7\u05b8\u05e9\u05c1\u05b7\u05d1\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "khashavt (f) \u2190 khashavta (m default); 'you thought'",
+        "\u05d7\u05b8\u05e9\u05c1\u05b7\u05d1\u05b0\u05ea\u05b8\u05bc",
+        "'you thought' — khashavt (f) / khashavta (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_DIBART",
+    _AmbiguousForm(
+        "VERB_DIBART",
         "\u05d3\u05d9\u05d1\u05e8\u05ea",
         "\u05d3\u05b4\u05bc\u05d9\u05d1\u05b7\u05bc\u05e8\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "dibart (f) \u2190 dibarta (m default); 'you spoke'",
+        "\u05d3\u05b4\u05bc\u05d9\u05d1\u05b7\u05bc\u05e8\u05b0\u05ea\u05b8\u05bc",
+        "'you spoke' — dibart (f) / dibarta (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_YADAT",
+    _AmbiguousForm(
+        "VERB_YADAT",
         "\u05d9\u05d3\u05e2\u05ea",
         "\u05d9\u05b8\u05d3\u05b7\u05e2\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "yadat (f) \u2190 yadata (m default); 'you knew'",
+        "\u05d9\u05b8\u05d3\u05b7\u05e2\u05b0\u05ea\u05b8\u05bc",
+        "'you knew' — yadat (f) / yadata (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_HAYIT",
+    _AmbiguousForm(
+        "VERB_HAYIT",
         "\u05d4\u05d9\u05d9\u05ea",
         "\u05d4\u05b8\u05d9\u05b4\u05d9\u05ea\u05b0",
-        "female",
-        "2",
-        "hayit (f) \u2190 hayita (m default); 'you were'",
+        "\u05d4\u05b8\u05d9\u05b4\u05d9\u05ea\u05b8",
+        "'you were' — hayit (f) / hayita (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_RATSIT",
+    _AmbiguousForm(
+        "VERB_RATSIT",
         "\u05e8\u05e6\u05d9\u05ea",
         "\u05e8\u05b8\u05e6\u05b4\u05d9\u05ea\u05b0",
-        "female",
-        "2",
-        "ratsit (f) \u2190 ratsita (m default); 'you wanted'",
+        "\u05e8\u05b8\u05e6\u05b4\u05d9\u05ea\u05b8",
+        "'you wanted' — ratsit (f) / ratsita (m)",
     ),
-    # --- Additional past-tense 2sg verbs (addressee is female) ---
-    LexiconEntry(
-        "F2_VERB_ANIT",
+    _AmbiguousForm(
+        "VERB_ANIT",
         "\u05e2\u05e0\u05d9\u05ea",
         "\u05e2\u05b8\u05e0\u05b4\u05d9\u05ea\u05b0",
-        "female",
-        "2",
-        "anit (f) \u2190 anita (m default); 'you answered'",
+        "\u05e2\u05b8\u05e0\u05b4\u05d9\u05ea\u05b8",
+        "'you answered' — anit (f) / anita (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_AMART",
+    _AmbiguousForm(
+        "VERB_AMART",
         "\u05d0\u05de\u05e8\u05ea",
         "\u05d0\u05b8\u05de\u05b7\u05e8\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "amart (f) \u2190 amarta (m default); 'you said'",
+        "\u05d0\u05b8\u05de\u05b7\u05e8\u05b0\u05ea\u05b8\u05bc",
+        "'you said' — amart (f) / amarta (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_SHAMAT",
+    _AmbiguousForm(
+        "VERB_SHAMAT",
         "\u05e9\u05de\u05e2\u05ea",
         "\u05e9\u05c1\u05b8\u05de\u05b7\u05e2\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "shamat (f) \u2190 shamata (m default); 'you heard'",
+        "\u05e9\u05c1\u05b8\u05de\u05b7\u05e2\u05b0\u05ea\u05b8\u05bc",
+        "'you heard' — shamat (f) / shamata (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_RAIT",
+    _AmbiguousForm(
+        "VERB_RAIT",
         "\u05e8\u05d0\u05d9\u05ea",
         "\u05e8\u05b8\u05d0\u05b4\u05d9\u05ea\u05b0",
-        "female",
-        "2",
-        "ra'it (f) \u2190 ra'ita (m default); 'you saw'",
+        "\u05e8\u05b8\u05d0\u05b4\u05d9\u05ea\u05b8",
+        "'you saw' — ra'it (f) / ra'ita (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_LAKAKHT",
+    _AmbiguousForm(
+        "VERB_LAKAKHT",
         "\u05dc\u05e7\u05d7\u05ea",
         "\u05dc\u05b8\u05e7\u05b7\u05d7\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "lakakht (f) \u2190 lakakhta (m default); 'you took'",
+        "\u05dc\u05b8\u05e7\u05b7\u05d7\u05b0\u05ea\u05b8\u05bc",
+        "'you took' — lakakht (f) / lakakhta (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_NATATT",
+    _AmbiguousForm(
+        "VERB_NATATT",
         "\u05e0\u05ea\u05ea",
         "\u05e0\u05b8\u05ea\u05b7\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "natatt (f) \u2190 natata (m default); 'you gave'",
+        "\u05e0\u05b8\u05ea\u05b7\u05ea\u05b8\u05bc",
+        "'you gave' — natatt (f) / natata (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_BAT",
+    _AmbiguousForm(
+        "VERB_BAT",
         "\u05d1\u05d0\u05ea",
         "\u05d1\u05b8\u05d0\u05ea\u05b0",
-        "female",
-        "2",
-        "bat (f) \u2190 bata (m default); 'you came'",
+        "\u05d1\u05b8\u05d0\u05ea\u05b8",
+        "'you came' — bat (f) / bata (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_YATSAT",
+    _AmbiguousForm(
+        "VERB_YATSAT",
         "\u05d9\u05e6\u05d0\u05ea",
         "\u05d9\u05b8\u05e6\u05b8\u05d0\u05ea\u05b0",
-        "female",
-        "2",
-        "yatsat (f) \u2190 yatsata (m default); 'you went out'",
+        "\u05d9\u05b8\u05e6\u05b8\u05d0\u05ea\u05b8",
+        "'you went out' — yatsat (f) / yatsata (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_SHAKHAKHT",
+    _AmbiguousForm(
+        "VERB_SHAKHAKHT",
         "\u05e9\u05db\u05d7\u05ea",
         "\u05e9\u05c1\u05b8\u05db\u05b7\u05d7\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "shakhakht (f) \u2190 shakhakhta (m default); 'you forgot'",
+        "\u05e9\u05c1\u05b8\u05db\u05b7\u05d7\u05b0\u05ea\u05b8\u05bc",
+        "'you forgot' — shakhakht (f) / shakhakhta (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_HITKHALAT",
+    _AmbiguousForm(
+        "VERB_HITKHALAT",
         "\u05d4\u05ea\u05d7\u05dc\u05ea",
         "\u05d4\u05b4\u05ea\u05b0\u05d7\u05b7\u05dc\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "hitkhalat (f) \u2190 hitkhalta (m default); 'you started'",
+        "\u05d4\u05b4\u05ea\u05b0\u05d7\u05b7\u05dc\u05b0\u05ea\u05b8\u05bc",
+        "'you started' — hitkhalat (f) / hitkhalta (m)",
     ),
-    LexiconEntry(
-        "F2_VERB_HIFSAKT",
+    _AmbiguousForm(
+        "VERB_HIFSAKT",
         "\u05d4\u05e4\u05e1\u05e7\u05ea",
         "\u05d4\u05b4\u05e4\u05b0\u05e1\u05b7\u05e7\u05b0\u05ea\u05b0\u05bc",
-        "female",
-        "2",
-        "hifsakt (f) \u2190 hifsakta (m default); 'you stopped'",
-    ),
-)
-
-_LEXICON_2P_MASCULINE: tuple[LexiconEntry, ...] = (
-    # --- Possessive / object pronouns (addressee is male) ---
-    LexiconEntry(
-        "M2_POSS_SHEL",
-        "\u05e9\u05dc\u05da",
-        "\u05e9\u05b6\u05c1\u05dc\u05b0\u05bc\u05da\u05b8",
-        "male",
-        "2",
-        "shelkha (m) \u2190 shelakh (f); 'yours'",
-    ),
-    LexiconEntry(
-        "M2_PRON_OTKH",
-        "\u05d0\u05d5\u05ea\u05da",
-        "\u05d0\u05d5\u05b9\u05ea\u05b0\u05da\u05b8",
-        "male",
-        "2",
-        "otkha (m) \u2190 otakh (f); 'you' (direct object)",
-    ),
-    LexiconEntry(
-        "M2_PRON_ITKH",
-        "\u05d0\u05ea\u05da",
-        "\u05d0\u05b4\u05ea\u05b0\u05bc\u05da\u05b8",
-        "male",
-        "2",
-        "itkha (m) \u2190 itakh (f); 'with you'",
-    ),
-    # --- Prepositional clitics (addressee is male) ---
-    LexiconEntry(
-        "M2_PREP_LEKHA",
-        "\u05dc\u05da",
-        "\u05dc\u05b0\u05da\u05b8",
-        "male",
-        "2",
-        "lekha (m) \u2190 lakh (f); 'to/for you'",
-    ),
-    LexiconEntry(
-        "M2_PREP_BEKHA",
-        "\u05d1\u05da",
-        "\u05d1\u05b0\u05bc\u05da\u05b8",
-        "male",
-        "2",
-        "bekha (m) \u2190 bakh (f); 'in/at you'",
-    ),
-    LexiconEntry(
-        "M2_PREP_MIMKHA",
-        "\u05de\u05de\u05da",
-        "\u05de\u05b4\u05de\u05b0\u05bc\u05da\u05b8",
-        "male",
-        "2",
-        "mimkha (m) \u2190 mimekh (f); 'from you'",
-    ),
-    LexiconEntry(
-        "M2_PREP_ALEKHA",
-        "\u05e2\u05dc\u05d9\u05da",
-        "\u05e2\u05b8\u05dc\u05b6\u05d9\u05da\u05b8",
-        "male",
-        "2",
-        "alekha (m) \u2190 alaikh (f); 'on/about you'",
-    ),
-    LexiconEntry(
-        "M2_PREP_ELEKHA",
-        "\u05d0\u05dc\u05d9\u05da",
-        "\u05d0\u05b5\u05dc\u05b6\u05d9\u05da\u05b8",
-        "male",
-        "2",
-        "elekha (m) \u2190 elaikh (f); 'toward you'",
-    ),
-    # --- Past-tense 2sg verbs (addressee is male) ---
-    # Masc ends /-ta/ (kamatz+dagesh on tav), fem /-t/ (shva on tav)
-    LexiconEntry(
-        "M2_VERB_HALAKHTA",
-        "\u05d4\u05dc\u05db\u05ea",
-        "\u05d4\u05b8\u05dc\u05b7\u05db\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "halakhta (m) \u2190 halakht (f); 'you went'",
-    ),
-    LexiconEntry(
-        "M2_VERB_ASITA",
-        "\u05e2\u05e9\u05d9\u05ea",
-        "\u05e2\u05b8\u05e9\u05c2\u05b4\u05d9\u05ea\u05b8",
-        "male",
-        "2",
-        "asita (m) \u2190 asit (f); 'you did/made'",
-    ),
-    LexiconEntry(
-        "M2_VERB_KHASHAVTA",
-        "\u05d7\u05e9\u05d1\u05ea",
-        "\u05d7\u05b8\u05e9\u05c1\u05b7\u05d1\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "khashavta (m) \u2190 khashavt (f); 'you thought'",
-    ),
-    LexiconEntry(
-        "M2_VERB_DIBARTA",
-        "\u05d3\u05d9\u05d1\u05e8\u05ea",
-        "\u05d3\u05b4\u05bc\u05d9\u05d1\u05b7\u05bc\u05e8\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "dibarta (m) \u2190 dibart (f); 'you spoke'",
-    ),
-    LexiconEntry(
-        "M2_VERB_YADATA",
-        "\u05d9\u05d3\u05e2\u05ea",
-        "\u05d9\u05b8\u05d3\u05b7\u05e2\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "yadata (m) \u2190 yadat (f); 'you knew'",
-    ),
-    LexiconEntry(
-        "M2_VERB_HAYITA",
-        "\u05d4\u05d9\u05d9\u05ea",
-        "\u05d4\u05b8\u05d9\u05b4\u05d9\u05ea\u05b8",
-        "male",
-        "2",
-        "hayita (m) \u2190 hayit (f); 'you were'",
-    ),
-    LexiconEntry(
-        "M2_VERB_RATSITA",
-        "\u05e8\u05e6\u05d9\u05ea",
-        "\u05e8\u05b8\u05e6\u05b4\u05d9\u05ea\u05b8",
-        "male",
-        "2",
-        "ratsita (m) \u2190 ratsit (f); 'you wanted'",
-    ),
-    # --- Additional past-tense 2sg verbs (addressee is male) ---
-    LexiconEntry(
-        "M2_VERB_ANITA",
-        "\u05e2\u05e0\u05d9\u05ea",
-        "\u05e2\u05b8\u05e0\u05b4\u05d9\u05ea\u05b8",
-        "male",
-        "2",
-        "anita (m) \u2190 anit (f); 'you answered'",
-    ),
-    LexiconEntry(
-        "M2_VERB_AMARTA",
-        "\u05d0\u05de\u05e8\u05ea",
-        "\u05d0\u05b8\u05de\u05b7\u05e8\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "amarta (m) \u2190 amart (f); 'you said'",
-    ),
-    LexiconEntry(
-        "M2_VERB_SHAMATA",
-        "\u05e9\u05de\u05e2\u05ea",
-        "\u05e9\u05c1\u05b8\u05de\u05b7\u05e2\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "shamata (m) \u2190 shamat (f); 'you heard'",
-    ),
-    LexiconEntry(
-        "M2_VERB_RAITA",
-        "\u05e8\u05d0\u05d9\u05ea",
-        "\u05e8\u05b8\u05d0\u05b4\u05d9\u05ea\u05b8",
-        "male",
-        "2",
-        "ra'ita (m) \u2190 ra'it (f); 'you saw'",
-    ),
-    LexiconEntry(
-        "M2_VERB_LAKAKHTA",
-        "\u05dc\u05e7\u05d7\u05ea",
-        "\u05dc\u05b8\u05e7\u05b7\u05d7\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "lakakhta (m) \u2190 lakakht (f); 'you took'",
-    ),
-    LexiconEntry(
-        "M2_VERB_NATATA",
-        "\u05e0\u05ea\u05ea",
-        "\u05e0\u05b8\u05ea\u05b7\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "natata (m) \u2190 natatt (f); 'you gave'",
-    ),
-    LexiconEntry(
-        "M2_VERB_BATA",
-        "\u05d1\u05d0\u05ea",
-        "\u05d1\u05b8\u05d0\u05ea\u05b8",
-        "male",
-        "2",
-        "bata (m) \u2190 bat (f); 'you came'",
-    ),
-    LexiconEntry(
-        "M2_VERB_YATSATA",
-        "\u05d9\u05e6\u05d0\u05ea",
-        "\u05d9\u05b8\u05e6\u05b8\u05d0\u05ea\u05b8",
-        "male",
-        "2",
-        "yatsata (m) \u2190 yatsat (f); 'you went out'",
-    ),
-    LexiconEntry(
-        "M2_VERB_SHAKHAKHTA",
-        "\u05e9\u05db\u05d7\u05ea",
-        "\u05e9\u05c1\u05b8\u05db\u05b7\u05d7\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "shakhakhta (m) \u2190 shakhakht (f); 'you forgot'",
-    ),
-    LexiconEntry(
-        "M2_VERB_HITKHALTA",
-        "\u05d4\u05ea\u05d7\u05dc\u05ea",
-        "\u05d4\u05b4\u05ea\u05b0\u05d7\u05b7\u05dc\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "hitkhalta (m) \u2190 hitkhalat (f); 'you started'",
-    ),
-    LexiconEntry(
-        "M2_VERB_HIFSAKTA",
-        "\u05d4\u05e4\u05e1\u05e7\u05ea",
         "\u05d4\u05b4\u05e4\u05b0\u05e1\u05b7\u05e7\u05b0\u05ea\u05b8\u05bc",
-        "male",
-        "2",
-        "hifsakta (m) \u2190 hifsakt (f); 'you stopped'",
+        "'you stopped' — hifsakt (f) / hifsakta (m)",
     ),
 )
 
-# Combined lexicon for backward-compatible parametrized tests.
+# ---------------------------------------------------------------------------
+# Generated per-gender lexicons (from _AMBIGUOUS_FORMS)
+# ---------------------------------------------------------------------------
+
+_LEXICON_2P_FEMININE: tuple[LexiconEntry, ...] = tuple(
+    LexiconEntry(
+        rule_id=f"F2_{f.base_id}",
+        surface=f.surface,
+        spoken_form=f.female_spoken,
+        target_gender="female",
+        description=f.description,
+    )
+    for f in _AMBIGUOUS_FORMS
+)
+
+_LEXICON_2P_MASCULINE: tuple[LexiconEntry, ...] = tuple(
+    LexiconEntry(
+        rule_id=f"M2_{f.base_id}",
+        surface=f.surface,
+        spoken_form=f.male_spoken,
+        target_gender="male",
+        description=f.description,
+    )
+    for f in _AMBIGUOUS_FORMS
+)
+
+# Combined lexicon for parametrized tests.
 _LEXICON: tuple[LexiconEntry, ...] = _LEXICON_2P_FEMININE + _LEXICON_2P_MASCULINE
 
 # ---------------------------------------------------------------------------
@@ -493,7 +298,12 @@ _LEXICON: tuple[LexiconEntry, ...] = _LEXICON_2P_FEMININE + _LEXICON_2P_MASCULIN
 # These are common 2nd-person surface forms whose unvocalized spelling is
 # shared between masculine and feminine.  If any of these survive in
 # text_spoken without niqqud, they are suspicious.
-_AMBIGUOUS_SURFACES: frozenset[str] = frozenset(entry.surface for entry in _LEXICON)
+#
+# KNOWN LIMITATION: some surface forms overlap with unrelated Hebrew words
+# (e.g. "לך" can also be the imperative "go!", "באת" overlaps with a noun
+# form).  The gate is therefore a *heuristic* that flags candidates for
+# review, not a definitive error detector.  False positives are expected.
+_AMBIGUOUS_SURFACES: frozenset[str] = frozenset(f.surface for f in _AMBIGUOUS_FORMS)
 
 # ---------------------------------------------------------------------------
 # Regex compilation
@@ -566,10 +376,9 @@ class NormalizationResult:
 
 def disambiguate_for_speaker(
     text: str,
-    speaker_gender: str,
     addressee_gender: str,
 ) -> NormalizationResult:
-    """Apply gender corrections based on speaker and addressee genders.
+    """Apply gender corrections based on addressee gender.
 
     Second-person forms (pronouns, prepositions, verbs) are selected based
     on the *addressee* gender.  The rules insert niqqud to force the TTS
@@ -577,8 +386,6 @@ def disambiguate_for_speaker(
 
     Args:
         text: UTF-8 Hebrew source text (``DialogueTurn.text``).
-        speaker_gender: Gender of the turn's speaker (``"male"`` or
-            ``"female"``).
         addressee_gender: Gender of the primary addressee (``"male"`` or
             ``"female"``).
 
@@ -613,6 +420,13 @@ def check_gender_ambiguity(text_spoken: str) -> list[str]:
 
     Scans *text_spoken* for unvocalized tokens that appear in the lexicon
     but were not replaced (e.g. because the addressee gender was unknown).
+
+    .. note::
+
+       This is a **heuristic** gate.  Some surface forms overlap with
+       unrelated Hebrew words (e.g. "\u05dc\u05da" = imperative "go!", "\u05d1\u05d0\u05ea" can be a
+       noun).  False positives are expected — treat warnings as candidates
+       for review, not confirmed errors.
 
     Returns:
         List of warning strings, one per ambiguous token found.  Empty if
@@ -687,12 +501,10 @@ def disambiguate_turns(
     result: list[DialogueTurn] = []
     for turn in turns:
         addr_id = _addressee_id(turn.speaker_id)
-        spk_gender = _gender(turn.speaker_id)
         addr_gender = _gender(addr_id) if addr_id else ""
 
         norm = disambiguate_for_speaker(
             turn.text_spoken or turn.text,
-            spk_gender,
             addr_gender,
         )
 

--- a/tests/unit/test_hebrew_disambiguator.py
+++ b/tests/unit/test_hebrew_disambiguator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from synthbanshee.script.hebrew_disambiguator import (
+    _AMBIGUOUS_FORMS,
     _LEXICON,
     _LEXICON_2P_FEMININE,
     _LEXICON_2P_MASCULINE,
@@ -26,13 +27,13 @@ from synthbanshee.script.types import DialogueTurn
 
 
 def _addr_female(text: str) -> NormalizationResult:
-    """Disambiguate with a male speaker addressing a female."""
-    return disambiguate_for_speaker(text, speaker_gender="male", addressee_gender="female")
+    """Disambiguate addressing a female."""
+    return disambiguate_for_speaker(text, addressee_gender="female")
 
 
 def _addr_male(text: str) -> NormalizationResult:
-    """Disambiguate with a female speaker addressing a male."""
-    return disambiguate_for_speaker(text, speaker_gender="female", addressee_gender="male")
+    """Disambiguate addressing a male."""
+    return disambiguate_for_speaker(text, addressee_gender="male")
 
 
 # ---------------------------------------------------------------------------
@@ -41,25 +42,25 @@ def _addr_male(text: str) -> NormalizationResult:
 
 
 class TestGenderGuard:
-    """Substitutions must fire based on addressee gender, not role."""
+    """Substitutions must fire based on addressee gender."""
 
     def test_addressee_female_applies_feminine_rules(self):
-        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "male", "female")
+        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "female")
         assert result.text_spoken == "\u05e9\u05b6\u05c1\u05dc\u05b8\u05bc\u05da\u05b0"
         assert result.normalization_rules_triggered == ["F2_POSS_SHEL"]
 
     def test_addressee_male_applies_masculine_rules(self):
-        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "female", "male")
+        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "male")
         assert result.text_spoken == "\u05e9\u05b6\u05c1\u05dc\u05b0\u05bc\u05da\u05b8"
         assert result.normalization_rules_triggered == ["M2_POSS_SHEL"]
 
     def test_unknown_addressee_gender_no_change(self):
-        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "male", "")
+        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "")
         assert result.text_spoken == "\u05e9\u05dc\u05da"
         assert result.normalization_rules_triggered == []
 
     def test_unknown_addressee_gender_unk_no_change(self):
-        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "male", "unknown")
+        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "unknown")
         assert result.text_spoken == "\u05e9\u05dc\u05da"
         assert result.normalization_rules_triggered == []
 
@@ -209,7 +210,7 @@ class TestMultipleSubstitutions:
     def test_two_tokens_in_one_turn_male(self):
         text = "\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea \u05e2\u05dd \u05e9\u05dc\u05da?"
         result = _addr_male(text)
-        assert "M2_VERB_ASITA" in result.normalization_rules_triggered
+        assert "M2_VERB_ASIT" in result.normalization_rules_triggered
         assert "M2_POSS_SHEL" in result.normalization_rules_triggered
 
     def test_same_token_twice(self):
@@ -233,12 +234,11 @@ class TestBidirectional:
     """The same unvocalized token must produce different niqqud for M vs F addressees."""
 
     def test_lekha_vs_lakh(self):
-        """'\u05dc\u05da' must become '\u05dc\u05b0\u05da\u05b8' (lekha) for male and '\u05dc\u05b8\u05da\u05b0' (lakh) for female."""
         fem = _addr_female("\u05dc\u05da")
         masc = _addr_male("\u05dc\u05da")
         assert fem.text_spoken != masc.text_spoken
         assert "F2_PREP_LAKH" in fem.normalization_rules_triggered
-        assert "M2_PREP_LEKHA" in masc.normalization_rules_triggered
+        assert "M2_PREP_LAKH" in masc.normalization_rules_triggered
 
     def test_shelakh_vs_shelkha(self):
         fem = _addr_female("\u05e9\u05dc\u05da")
@@ -250,7 +250,7 @@ class TestBidirectional:
         masc = _addr_male("\u05e2\u05e9\u05d9\u05ea")
         assert fem.text_spoken != masc.text_spoken
         assert "F2_VERB_ASIT" in fem.normalization_rules_triggered
-        assert "M2_VERB_ASITA" in masc.normalization_rules_triggered
+        assert "M2_VERB_ASIT" in masc.normalization_rules_triggered
 
 
 # ---------------------------------------------------------------------------
@@ -340,7 +340,9 @@ class TestDisambiguateTurns:
     def _make_turns(self) -> list[DialogueTurn]:
         return [
             DialogueTurn(
-                speaker_id="AGG_001", text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?", intensity=2
+                speaker_id="AGG_001",
+                text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?",
+                intensity=2,
             ),
             DialogueTurn(
                 speaker_id="VIC_001",
@@ -365,7 +367,24 @@ class TestDisambiguateTurns:
         turns = disambiguate_turns(self._make_turns(), self._roles(), self._genders())
         vic_turn = next(t for t in turns if t.speaker_id == "VIC_001")
         # VIC (female) addressing AGG (male) — masculine 2P rules fire
-        assert "M2_PREP_LEKHA" in vic_turn.normalization_rules_triggered
+        assert "M2_PREP_LAKH" in vic_turn.normalization_rules_triggered
+
+    def test_female_agg_addressing_male_vic(self):
+        """Gender != role: a female AGG addressing a male VIC must get masculine rules."""
+        turns = [
+            DialogueTurn(
+                speaker_id="AGG_001",
+                text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?",
+                intensity=2,
+            ),
+        ]
+        roles = {"AGG_001": "AGG", "VIC_001": "VIC"}
+        # Inverted genders: female aggressor, male victim
+        genders = {"AGG_001": "female", "VIC_001": "male"}
+        result = disambiguate_turns(turns, roles, genders)
+        # AGG addresses VIC (male) — masculine rules must fire, not feminine
+        assert "M2_VERB_ASIT" in result[0].normalization_rules_triggered
+        assert not any(rid.startswith("F2_") for rid in result[0].normalization_rules_triggered)
 
     def test_original_turns_not_mutated(self):
         original = self._make_turns()
@@ -390,7 +409,9 @@ class TestDisambiguateTurns:
     def test_three_speaker_agg_prefers_vic(self):
         turns = [
             DialogueTurn(
-                speaker_id="AGG_001", text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?", intensity=2
+                speaker_id="AGG_001",
+                text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?",
+                intensity=2,
             )
         ]
         roles = {"AGG_001": "AGG", "BYS_001": "BYS", "VIC_001": "VIC"}
@@ -399,19 +420,20 @@ class TestDisambiguateTurns:
         agg_turn = result[0]
         assert "F2_VERB_ASIT" in agg_turn.normalization_rules_triggered
 
-    def test_three_speaker_bys_gets_no_disambiguation_toward_vic(self):
-        """BYS addressing AGG (male) should get masculine rules, not feminine."""
+    def test_three_speaker_bys_addresses_vic_with_feminine_rules(self):
+        """In a 3-role scene, BYS's addressee is VIC (highest-priority non-self
+        role), so feminine rules fire because VIC is female."""
         turns = [
             DialogueTurn(
-                speaker_id="BYS_001", text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?", intensity=1
+                speaker_id="BYS_001",
+                text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?",
+                intensity=1,
             )
         ]
         roles = {"AGG_001": "AGG", "VIC_001": "VIC", "BYS_001": "BYS"}
         genders = {"AGG_001": "male", "VIC_001": "female", "BYS_001": "male"}
         result = disambiguate_turns(turns, roles, genders)
-        # BYS→VIC (first non-self in priority order is VIC)
         bys_turn = result[0]
-        # BYS addresses VIC (female) per priority — feminine rules fire
         assert "F2_VERB_ASIT" in bys_turn.normalization_rules_triggered
 
     def test_unknown_role_fallback(self):
@@ -434,7 +456,9 @@ class TestLegacyFallback:
     def test_agg_assumed_male_vic_assumed_female(self):
         turns = [
             DialogueTurn(
-                speaker_id="AGG_001", text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?", intensity=2
+                speaker_id="AGG_001",
+                text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?",
+                intensity=2,
             ),
         ]
         roles = {"AGG_001": "AGG", "VIC_001": "VIC"}
@@ -452,7 +476,7 @@ class TestLegacyFallback:
         roles = {"AGG_001": "AGG", "VIC_001": "VIC"}
         result = disambiguate_turns(turns, roles)  # no genders
         # VIC→AGG: AGG is assumed male, so masculine rules should fire
-        assert "M2_PREP_LEKHA" in result[0].normalization_rules_triggered
+        assert "M2_PREP_LAKH" in result[0].normalization_rules_triggered
 
 
 # ---------------------------------------------------------------------------
@@ -530,9 +554,13 @@ class TestLexiconConsistency:
 
     def test_feminine_and_masculine_produce_different_spoken_forms(self):
         """For each surface, the fem and masc spoken forms must differ."""
-        fem_by_surface = {e.surface: e.spoken_form for e in _LEXICON_2P_FEMININE}
-        masc_by_surface = {e.surface: e.spoken_form for e in _LEXICON_2P_MASCULINE}
-        for surface in fem_by_surface:
-            assert fem_by_surface[surface] != masc_by_surface[surface], (
-                f"Surface '{surface}': fem and masc spoken forms are identical"
+        for form in _AMBIGUOUS_FORMS:
+            assert form.female_spoken != form.male_spoken, (
+                f"Surface '{form.surface}' ({form.base_id}): "
+                f"fem and masc spoken forms are identical"
             )
+
+    def test_generated_lexicon_count_matches_source(self):
+        """Both generated lexicons must have exactly as many entries as _AMBIGUOUS_FORMS."""
+        assert len(_LEXICON_2P_FEMININE) == len(_AMBIGUOUS_FORMS)
+        assert len(_LEXICON_2P_MASCULINE) == len(_AMBIGUOUS_FORMS)

--- a/tests/unit/test_hebrew_disambiguator.py
+++ b/tests/unit/test_hebrew_disambiguator.py
@@ -11,7 +11,10 @@ import pytest
 
 from synthbanshee.script.hebrew_disambiguator import (
     _LEXICON,
+    _LEXICON_2P_FEMININE,
+    _LEXICON_2P_MASCULINE,
     NormalizationResult,
+    check_gender_ambiguity,
     disambiguate_for_speaker,
     disambiguate_turns,
 )
@@ -22,42 +25,42 @@ from synthbanshee.script.types import DialogueTurn
 # ---------------------------------------------------------------------------
 
 
-def _agg_vic(text: str) -> NormalizationResult:
-    """Convenience: disambiguate as AGG speaker addressing VIC."""
-    return disambiguate_for_speaker(text, speaker_role="AGG", addressee_role="VIC")
+def _addr_female(text: str) -> NormalizationResult:
+    """Disambiguate with a male speaker addressing a female."""
+    return disambiguate_for_speaker(text, speaker_gender="male", addressee_gender="female")
+
+
+def _addr_male(text: str) -> NormalizationResult:
+    """Disambiguate with a female speaker addressing a male."""
+    return disambiguate_for_speaker(text, speaker_gender="female", addressee_gender="male")
 
 
 # ---------------------------------------------------------------------------
-# disambiguate_for_speaker — direction guard
+# disambiguate_for_speaker — gender guard
 # ---------------------------------------------------------------------------
 
 
-class TestDirectionGuard:
-    """Substitutions must only fire for AGG→VIC; all other pairs are no-ops."""
+class TestGenderGuard:
+    """Substitutions must fire based on addressee gender, not role."""
 
-    def test_agg_vic_may_modify(self):
-        result = disambiguate_for_speaker("שלך", "AGG", "VIC")
-        assert result.text_spoken == "שֶׁלָּךְ"
-        assert result.normalization_rules_triggered == ["POSS_SHEL"]
+    def test_addressee_female_applies_feminine_rules(self):
+        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "male", "female")
+        assert result.text_spoken == "\u05e9\u05b6\u05c1\u05dc\u05b8\u05bc\u05da\u05b0"
+        assert result.normalization_rules_triggered == ["F2_POSS_SHEL"]
 
-    def test_vic_agg_no_change(self):
-        result = disambiguate_for_speaker("שלך", "VIC", "AGG")
-        assert result.text_spoken == "שלך"
+    def test_addressee_male_applies_masculine_rules(self):
+        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "female", "male")
+        assert result.text_spoken == "\u05e9\u05b6\u05c1\u05dc\u05b0\u05bc\u05da\u05b8"
+        assert result.normalization_rules_triggered == ["M2_POSS_SHEL"]
+
+    def test_unknown_addressee_gender_no_change(self):
+        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "male", "")
+        assert result.text_spoken == "\u05e9\u05dc\u05da"
         assert result.normalization_rules_triggered == []
 
-    def test_agg_agg_no_change(self):
-        result = disambiguate_for_speaker("הלכת", "AGG", "AGG")
-        assert result.text_spoken == "הלכת"
-        assert result.normalization_rules_triggered == []
-
-    def test_unk_speaker_no_change(self):
-        result = disambiguate_for_speaker("שלך", "UNK", "VIC")
-        assert result.text_spoken == "שלך"
-        assert result.normalization_rules_triggered == []
-
-    def test_vic_vic_no_change(self):
-        result = disambiguate_for_speaker("עשית", "VIC", "VIC")
-        assert result.text_spoken == "עשית"
+    def test_unknown_addressee_gender_unk_no_change(self):
+        result = disambiguate_for_speaker("\u05e9\u05dc\u05da", "male", "unknown")
+        assert result.text_spoken == "\u05e9\u05dc\u05da"
         assert result.normalization_rules_triggered == []
 
 
@@ -68,88 +71,127 @@ class TestDirectionGuard:
 
 class TestPassThrough:
     def test_unlisted_word_unchanged(self):
-        text = "שלום, מה שלומך?"
-        result = _agg_vic(text)
+        text = "\u05e9\u05dc\u05d5\u05dd, \u05de\u05d4 \u05e9\u05dc\u05d5\u05de\u05da?"
+        result = _addr_female(text)
         assert result.text_spoken == text
         assert result.normalization_rules_triggered == []
 
     def test_empty_string(self):
-        result = _agg_vic("")
+        result = _addr_female("")
         assert result.text_spoken == ""
         assert result.normalization_rules_triggered == []
 
     def test_already_vocalized_text_unchanged(self):
-        # Niqqud already present — surface form (unvocalized) won't match
-        text = "הָלַכְתְּ"
-        result = _agg_vic(text)
+        text = "\u05d4\u05b8\u05dc\u05b7\u05db\u05b0\u05ea\u05b0\u05bc"
+        result = _addr_female(text)
         assert result.text_spoken == text
         assert result.normalization_rules_triggered == []
 
     def test_non_hebrew_text_unchanged(self):
         text = "hello world"
-        result = _agg_vic(text)
+        result = _addr_female(text)
         assert result.text_spoken == text
         assert result.normalization_rules_triggered == []
 
 
 # ---------------------------------------------------------------------------
-# disambiguate_for_speaker — individual lexicon entries
+# disambiguate_for_speaker — individual feminine lexicon entries
 # ---------------------------------------------------------------------------
 
 
-class TestLexiconEntries:
-    """One test per entry in _LEXICON ensuring the surface→feminine mapping is correct."""
+class TestFeminineLexiconEntries:
+    """One test per entry in _LEXICON_2P_FEMININE."""
 
-    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    @pytest.mark.parametrize("entry", _LEXICON_2P_FEMININE, ids=lambda e: e.rule_id)
     def test_surface_replaced_by_feminine(self, entry):
-        """Each surface form surrounded by spaces must be replaced by its feminine variant."""
-        text = f"אמרתי {entry.surface} לאחרונה"
-        result = _agg_vic(text)
-        assert entry.surface not in result.text_spoken, (
-            f"Rule {entry.rule_id}: surface form still present after disambiguation"
+        text = (
+            f"\u05d4\u05d9\u05d5\u05dd {entry.surface} \u05dc\u05d0\u05d7\u05e8\u05d5\u05e0\u05d4"
         )
-        assert entry.feminine_spoken in result.text_spoken, (
-            f"Rule {entry.rule_id}: feminine form not inserted"
+        result = _addr_female(text)
+        assert entry.spoken_form in result.text_spoken, (
+            f"Rule {entry.rule_id}: spoken form not inserted"
         )
         assert entry.rule_id in result.normalization_rules_triggered
 
-    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    @pytest.mark.parametrize("entry", _LEXICON_2P_FEMININE, ids=lambda e: e.rule_id)
     def test_surface_at_start_of_string(self, entry):
-        text = f"{entry.surface} הוא הדבר"
-        result = _agg_vic(text)
-        assert entry.feminine_spoken in result.text_spoken
+        text = f"{entry.surface} \u05d4\u05d5\u05d0 \u05d4\u05d3\u05d1\u05e8"
+        result = _addr_female(text)
+        assert entry.spoken_form in result.text_spoken
 
-    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    @pytest.mark.parametrize("entry", _LEXICON_2P_FEMININE, ids=lambda e: e.rule_id)
     def test_surface_at_end_of_string(self, entry):
-        text = f"רציתי לדבר {entry.surface}"
-        result = _agg_vic(text)
-        assert entry.feminine_spoken in result.text_spoken
+        text = f"\u05e8\u05e6\u05d9\u05ea\u05d9 \u05dc\u05d3\u05d1\u05e8 {entry.surface}"
+        result = _addr_female(text)
+        assert entry.spoken_form in result.text_spoken
 
-    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    @pytest.mark.parametrize("entry", _LEXICON_2P_FEMININE, ids=lambda e: e.rule_id)
     def test_surface_not_matched_as_substring(self, entry):
-        """A longer Hebrew word that CONTAINS the surface form must not be corrupted."""
-        # Prepend and append a Hebrew letter to simulate embedding in a longer word.
-        # The lexicon entry should NOT match inside a longer word.
-        longer_word = "מ" + entry.surface + "ם"
-        result = _agg_vic(longer_word)
-        # The longer word is not a standalone match so text should be unchanged.
+        longer_word = "\u05de" + entry.surface + "\u05dd"
+        result = _addr_female(longer_word)
         assert result.text_spoken == longer_word
 
-    @pytest.mark.parametrize("entry", _LEXICON, ids=lambda e: e.rule_id)
+    @pytest.mark.parametrize("entry", _LEXICON_2P_FEMININE, ids=lambda e: e.rule_id)
     def test_surface_not_matched_after_vocalized_letter(self, entry):
-        """A surface form immediately following a niqqud-bearing letter must not match.
-
-        Regression guard for the U+0591–U+05C7 combining-mark boundary fix: before
-        the fix, a niqqud character after the preceding letter was not treated as a
-        token character, so the lookbehind saw a non-letter at that position and
-        allowed an in-word match.
-        """
-        # בָּ = bet (U+05D1) + dagesh (U+05BC) + patah (U+05B7): a vocalized letter
-        # immediately before the surface form simulates a partially-vocalized longer word.
-        adjacent = "בָּ" + entry.surface
-        result = _agg_vic(adjacent)
-        # Must not match: the surface form is not a standalone token here.
+        adjacent = "\u05d1\u05b8\u05bc" + entry.surface
+        result = _addr_female(adjacent)
         assert result.text_spoken == adjacent
+
+    @pytest.mark.parametrize("entry", _LEXICON_2P_FEMININE, ids=lambda e: e.rule_id)
+    def test_masculine_lexicon_does_not_fire_for_female_addressee(self, entry):
+        """When addressee is female, masculine rules must not fire."""
+        text = (
+            f"\u05d4\u05d9\u05d5\u05dd {entry.surface} \u05dc\u05d0\u05d7\u05e8\u05d5\u05e0\u05d4"
+        )
+        result = _addr_female(text)
+        assert not any(rid.startswith("M2_") for rid in result.normalization_rules_triggered)
+
+
+# ---------------------------------------------------------------------------
+# disambiguate_for_speaker — individual masculine lexicon entries
+# ---------------------------------------------------------------------------
+
+
+class TestMasculineLexiconEntries:
+    """One test per entry in _LEXICON_2P_MASCULINE."""
+
+    @pytest.mark.parametrize("entry", _LEXICON_2P_MASCULINE, ids=lambda e: e.rule_id)
+    def test_surface_replaced_by_masculine(self, entry):
+        text = (
+            f"\u05d4\u05d9\u05d5\u05dd {entry.surface} \u05dc\u05d0\u05d7\u05e8\u05d5\u05e0\u05d4"
+        )
+        result = _addr_male(text)
+        assert entry.spoken_form in result.text_spoken, (
+            f"Rule {entry.rule_id}: spoken form not inserted"
+        )
+        assert entry.rule_id in result.normalization_rules_triggered
+
+    @pytest.mark.parametrize("entry", _LEXICON_2P_MASCULINE, ids=lambda e: e.rule_id)
+    def test_surface_at_start_of_string(self, entry):
+        text = f"{entry.surface} \u05d4\u05d5\u05d0 \u05d4\u05d3\u05d1\u05e8"
+        result = _addr_male(text)
+        assert entry.spoken_form in result.text_spoken
+
+    @pytest.mark.parametrize("entry", _LEXICON_2P_MASCULINE, ids=lambda e: e.rule_id)
+    def test_surface_at_end_of_string(self, entry):
+        text = f"\u05e8\u05e6\u05d9\u05ea\u05d9 \u05dc\u05d3\u05d1\u05e8 {entry.surface}"
+        result = _addr_male(text)
+        assert entry.spoken_form in result.text_spoken
+
+    @pytest.mark.parametrize("entry", _LEXICON_2P_MASCULINE, ids=lambda e: e.rule_id)
+    def test_surface_not_matched_as_substring(self, entry):
+        longer_word = "\u05de" + entry.surface + "\u05dd"
+        result = _addr_male(longer_word)
+        assert result.text_spoken == longer_word
+
+    @pytest.mark.parametrize("entry", _LEXICON_2P_MASCULINE, ids=lambda e: e.rule_id)
+    def test_feminine_lexicon_does_not_fire_for_male_addressee(self, entry):
+        """When addressee is male, feminine rules must not fire."""
+        text = (
+            f"\u05d4\u05d9\u05d5\u05dd {entry.surface} \u05dc\u05d0\u05d7\u05e8\u05d5\u05e0\u05d4"
+        )
+        result = _addr_male(text)
+        assert not any(rid.startswith("F2_") for rid in result.normalization_rules_triggered)
 
 
 # ---------------------------------------------------------------------------
@@ -158,26 +200,57 @@ class TestLexiconEntries:
 
 
 class TestMultipleSubstitutions:
-    def test_two_tokens_in_one_turn(self):
-        text = "מה עשית עם שלך?"
-        result = _agg_vic(text)
-        assert "עָשִׂיתְ" in result.text_spoken
-        assert "שֶׁלָּךְ" in result.text_spoken
-        assert "VERB_PAST_ASIT" in result.normalization_rules_triggered
-        assert "POSS_SHEL" in result.normalization_rules_triggered
+    def test_two_tokens_in_one_turn_female(self):
+        text = "\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea \u05e2\u05dd \u05e9\u05dc\u05da?"
+        result = _addr_female(text)
+        assert "F2_VERB_ASIT" in result.normalization_rules_triggered
+        assert "F2_POSS_SHEL" in result.normalization_rules_triggered
+
+    def test_two_tokens_in_one_turn_male(self):
+        text = "\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea \u05e2\u05dd \u05e9\u05dc\u05da?"
+        result = _addr_male(text)
+        assert "M2_VERB_ASITA" in result.normalization_rules_triggered
+        assert "M2_POSS_SHEL" in result.normalization_rules_triggered
 
     def test_same_token_twice(self):
-        text = "לך ואחרי זה לך שוב"
-        result = _agg_vic(text)
-        # Both occurrences of לך should be replaced
-        assert result.text_spoken.count("לָךְ") == 2
+        text = "\u05dc\u05da \u05d5\u05d0\u05d7\u05e8\u05d9 \u05d6\u05d4 \u05dc\u05da \u05e9\u05d5\u05d1"
+        result = _addr_female(text)
+        assert result.text_spoken.count("\u05dc\u05b8\u05da\u05b0") == 2
 
     def test_rules_triggered_list_contains_each_rule_once(self):
-        text = "הלכת לשם ועשית את זה"
-        result = _agg_vic(text)
-        # Each triggered rule_id should appear at most once in the result list
+        text = "\u05d4\u05dc\u05db\u05ea \u05dc\u05e9\u05dd \u05d5\u05e2\u05e9\u05d9\u05ea \u05d0\u05ea \u05d6\u05d4"
+        result = _addr_female(text)
         seen = result.normalization_rules_triggered
         assert len(seen) == len(set(seen)), "Duplicate rule IDs in triggered list"
+
+
+# ---------------------------------------------------------------------------
+# Bidirectional disambiguation — same surface, different output
+# ---------------------------------------------------------------------------
+
+
+class TestBidirectional:
+    """The same unvocalized token must produce different niqqud for M vs F addressees."""
+
+    def test_lekha_vs_lakh(self):
+        """'\u05dc\u05da' must become '\u05dc\u05b0\u05da\u05b8' (lekha) for male and '\u05dc\u05b8\u05da\u05b0' (lakh) for female."""
+        fem = _addr_female("\u05dc\u05da")
+        masc = _addr_male("\u05dc\u05da")
+        assert fem.text_spoken != masc.text_spoken
+        assert "F2_PREP_LAKH" in fem.normalization_rules_triggered
+        assert "M2_PREP_LEKHA" in masc.normalization_rules_triggered
+
+    def test_shelakh_vs_shelkha(self):
+        fem = _addr_female("\u05e9\u05dc\u05da")
+        masc = _addr_male("\u05e9\u05dc\u05da")
+        assert fem.text_spoken != masc.text_spoken
+
+    def test_verb_past_asit_vs_asita(self):
+        fem = _addr_female("\u05e2\u05e9\u05d9\u05ea")
+        masc = _addr_male("\u05e2\u05e9\u05d9\u05ea")
+        assert fem.text_spoken != masc.text_spoken
+        assert "F2_VERB_ASIT" in fem.normalization_rules_triggered
+        assert "M2_VERB_ASITA" in masc.normalization_rules_triggered
 
 
 # ---------------------------------------------------------------------------
@@ -187,14 +260,45 @@ class TestMultipleSubstitutions:
 
 class TestNormalizationResult:
     def test_no_rules_gives_identical_text(self):
-        text = "בוקר טוב"
-        result = _agg_vic(text)
+        text = "\u05d1\u05d5\u05e7\u05e8 \u05d8\u05d5\u05d1"
+        result = _addr_female(text)
         assert result.text_spoken == text
         assert result.normalization_rules_triggered == []
 
     def test_result_is_dataclass(self):
-        result = _agg_vic("שלך")
+        result = _addr_female("\u05e9\u05dc\u05da")
         assert isinstance(result, NormalizationResult)
+
+
+# ---------------------------------------------------------------------------
+# check_gender_ambiguity — QA gate
+# ---------------------------------------------------------------------------
+
+
+class TestCheckGenderAmbiguity:
+    def test_clean_text_no_warnings(self):
+        assert check_gender_ambiguity("\u05d1\u05d5\u05e7\u05e8 \u05d8\u05d5\u05d1") == []
+
+    def test_vocalized_text_no_warnings(self):
+        # Already vocalized — the scanner should not match niqqud-bearing text.
+        assert check_gender_ambiguity("\u05e9\u05b6\u05c1\u05dc\u05b8\u05bc\u05da\u05b0") == []
+
+    def test_ambiguous_surface_flagged(self):
+        warnings = check_gender_ambiguity("\u05d0\u05de\u05e8\u05ea\u05d9 \u05e9\u05dc\u05da")
+        assert len(warnings) == 1
+        assert "gender_ambiguity" in warnings[0]
+        assert "\u05e9\u05dc\u05da" in warnings[0]
+
+    def test_multiple_ambiguous_surfaces(self):
+        warnings = check_gender_ambiguity(
+            "\u05e9\u05dc\u05da \u05d5\u05d0\u05d7\u05e8\u05d9 \u05dc\u05da"
+        )
+        assert len(warnings) == 2
+
+    def test_embedded_surface_not_flagged(self):
+        # Surface form inside a longer word — should NOT be flagged.
+        longer = "\u05de\u05e9\u05dc\u05da\u05dd"
+        assert check_gender_ambiguity(longer) == []
 
 
 # ---------------------------------------------------------------------------
@@ -204,102 +308,231 @@ class TestNormalizationResult:
 
 class TestDialogueTurnDefaults:
     def test_text_spoken_defaults_to_text(self):
-        turn = DialogueTurn(speaker_id="AGG_001", text="שלום", intensity=1)
-        assert turn.text_spoken == "שלום"
+        turn = DialogueTurn(speaker_id="AGG_001", text="\u05e9\u05dc\u05d5\u05dd", intensity=1)
+        assert turn.text_spoken == "\u05e9\u05dc\u05d5\u05dd"
 
     def test_text_original_property(self):
-        turn = DialogueTurn(speaker_id="AGG_001", text="שלום", intensity=1)
-        assert turn.text_original == "שלום"
+        turn = DialogueTurn(speaker_id="AGG_001", text="\u05e9\u05dc\u05d5\u05dd", intensity=1)
+        assert turn.text_original == "\u05e9\u05dc\u05d5\u05dd"
 
     def test_explicit_text_spoken_preserved(self):
         turn = DialogueTurn(
             speaker_id="AGG_001",
-            text="שלך",
+            text="\u05e9\u05dc\u05da",
             intensity=1,
-            text_spoken="שֶׁלָּךְ",
-            normalization_rules_triggered=["POSS_SHEL"],
+            text_spoken="\u05e9\u05b6\u05c1\u05dc\u05b8\u05bc\u05da\u05b0",
+            normalization_rules_triggered=["F2_POSS_SHEL"],
         )
-        assert turn.text_spoken == "שֶׁלָּךְ"
-        assert turn.text == "שלך"
+        assert turn.text_spoken == "\u05e9\u05b6\u05c1\u05dc\u05b8\u05bc\u05da\u05b0"
+        assert turn.text == "\u05e9\u05dc\u05da"
 
     def test_normalization_rules_default_empty(self):
-        turn = DialogueTurn(speaker_id="AGG_001", text="שלום", intensity=1)
+        turn = DialogueTurn(speaker_id="AGG_001", text="\u05e9\u05dc\u05d5\u05dd", intensity=1)
         assert turn.normalization_rules_triggered == []
 
 
 # ---------------------------------------------------------------------------
-# disambiguate_turns
+# disambiguate_turns — with explicit genders
 # ---------------------------------------------------------------------------
 
 
 class TestDisambiguateTurns:
     def _make_turns(self) -> list[DialogueTurn]:
         return [
-            DialogueTurn(speaker_id="AGG_001", text="מה עשית?", intensity=2),
-            DialogueTurn(speaker_id="VIC_001", text="לא עשיתי כלום.", intensity=1),
+            DialogueTurn(
+                speaker_id="AGG_001", text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?", intensity=2
+            ),
+            DialogueTurn(
+                speaker_id="VIC_001",
+                text="\u05dc\u05da \u05d6\u05d4 \u05dc\u05d0 \u05de\u05e9\u05e0\u05d4.",
+                intensity=1,
+            ),
         ]
 
     def _roles(self) -> dict[str, str]:
         return {"AGG_001": "AGG", "VIC_001": "VIC"}
 
-    def test_agg_turn_modified(self):
-        turns = disambiguate_turns(self._make_turns(), self._roles())
-        agg_turn = next(t for t in turns if t.speaker_id == "AGG_001")
-        assert "עָשִׂיתְ" in agg_turn.text_spoken
-        assert "VERB_PAST_ASIT" in agg_turn.normalization_rules_triggered
+    def _genders(self) -> dict[str, str]:
+        return {"AGG_001": "male", "VIC_001": "female"}
 
-    def test_vic_turn_not_modified(self):
-        turns = disambiguate_turns(self._make_turns(), self._roles())
+    def test_agg_addressing_female_vic(self):
+        turns = disambiguate_turns(self._make_turns(), self._roles(), self._genders())
+        agg_turn = next(t for t in turns if t.speaker_id == "AGG_001")
+        # AGG (male) addressing VIC (female) — feminine 2P rules fire
+        assert "F2_VERB_ASIT" in agg_turn.normalization_rules_triggered
+
+    def test_vic_addressing_male_agg(self):
+        turns = disambiguate_turns(self._make_turns(), self._roles(), self._genders())
         vic_turn = next(t for t in turns if t.speaker_id == "VIC_001")
-        # VIC→AGG direction: no feminine substitution applied
-        assert vic_turn.text_spoken == vic_turn.text
-        assert vic_turn.normalization_rules_triggered == []
+        # VIC (female) addressing AGG (male) — masculine 2P rules fire
+        assert "M2_PREP_LEKHA" in vic_turn.normalization_rules_triggered
 
     def test_original_turns_not_mutated(self):
         original = self._make_turns()
         original_texts = [t.text for t in original]
-        disambiguate_turns(original, self._roles())
+        disambiguate_turns(original, self._roles(), self._genders())
         assert [t.text for t in original] == original_texts
 
     def test_returns_same_length(self):
         turns = self._make_turns()
-        result = disambiguate_turns(turns, self._roles())
+        result = disambiguate_turns(turns, self._roles(), self._genders())
         assert len(result) == len(turns)
 
     def test_empty_scene(self):
         assert disambiguate_turns([], {}) == []
 
     def test_single_speaker_scene_no_crash(self):
-        turns = [DialogueTurn(speaker_id="AGG_001", text="שלך", intensity=1)]
-        result = disambiguate_turns(turns, {"AGG_001": "AGG"})
-        # Only one speaker — addressee role is UNK; no modification
-        assert result[0].text_spoken == "שלך"
+        turns = [DialogueTurn(speaker_id="AGG_001", text="\u05e9\u05dc\u05da", intensity=1)]
+        result = disambiguate_turns(turns, {"AGG_001": "AGG"}, {"AGG_001": "male"})
+        # Only one speaker — no addressee; no modification but QA gate flags it
+        assert result[0].text_spoken == "\u05e9\u05dc\u05da"
 
-    def test_three_speaker_agg_prefers_vic_over_bys(self):
-        """In a 3-role scene (AGG, VIC, BYS) the AGG turn must be disambiguated
-        toward VIC, not BYS, regardless of dict insertion order."""
-        turns = [DialogueTurn(speaker_id="AGG_001", text="מה עשית?", intensity=2)]
-        # BYS is inserted first — without priority ordering this would be picked
+    def test_three_speaker_agg_prefers_vic(self):
+        turns = [
+            DialogueTurn(
+                speaker_id="AGG_001", text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?", intensity=2
+            )
+        ]
         roles = {"AGG_001": "AGG", "BYS_001": "BYS", "VIC_001": "VIC"}
-        result = disambiguate_turns(turns, roles)
+        genders = {"AGG_001": "male", "BYS_001": "male", "VIC_001": "female"}
+        result = disambiguate_turns(turns, roles, genders)
         agg_turn = result[0]
-        assert "עָשִׂיתְ" in agg_turn.text_spoken, "AGG turn should be disambiguated (addressee is VIC)"
+        assert "F2_VERB_ASIT" in agg_turn.normalization_rules_triggered
 
-    def test_three_speaker_bys_gets_no_disambiguation(self):
-        """A BYS speaker addressing AGG must not receive feminine substitution."""
-        turns = [DialogueTurn(speaker_id="BYS_001", text="מה עשית?", intensity=1)]
+    def test_three_speaker_bys_gets_no_disambiguation_toward_vic(self):
+        """BYS addressing AGG (male) should get masculine rules, not feminine."""
+        turns = [
+            DialogueTurn(
+                speaker_id="BYS_001", text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?", intensity=1
+            )
+        ]
         roles = {"AGG_001": "AGG", "VIC_001": "VIC", "BYS_001": "BYS"}
-        result = disambiguate_turns(turns, roles)
+        genders = {"AGG_001": "male", "VIC_001": "female", "BYS_001": "male"}
+        result = disambiguate_turns(turns, roles, genders)
+        # BYS→VIC (first non-self in priority order is VIC)
         bys_turn = result[0]
-        # BYS→AGG is not AGG→VIC, so no substitution should fire
-        assert bys_turn.text_spoken == bys_turn.text
+        # BYS addresses VIC (female) per priority — feminine rules fire
+        assert "F2_VERB_ASIT" in bys_turn.normalization_rules_triggered
 
-    def test_unknown_role_fallback_does_not_crash(self):
-        """A scene with only custom roles (not in the priority list) must still
-        return a stable addressee via the fallback path (lines 278-279)."""
-        turns = [DialogueTurn(speaker_id="A", text="שלך", intensity=1)]
-        # "WITNESS" is not in _ROLE_PRIORITY; the fallback loop must handle it.
+    def test_unknown_role_fallback(self):
+        turns = [DialogueTurn(speaker_id="A", text="\u05e9\u05dc\u05da", intensity=1)]
         roles = {"A": "CALLER", "B": "WITNESS"}
-        result = disambiguate_turns(turns, roles)
-        # CALLER→WITNESS is not AGG→VIC, so no substitution; just no crash.
-        assert result[0].text_spoken == "שלך"
+        genders = {"A": "male", "B": "female"}
+        result = disambiguate_turns(turns, roles, genders)
+        # Addressee is B (female) — feminine rules fire
+        assert "F2_POSS_SHEL" in result[0].normalization_rules_triggered
+
+
+# ---------------------------------------------------------------------------
+# disambiguate_turns — legacy fallback (no speaker_genders)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyFallback:
+    """When speaker_genders is None, genders are inferred from roles."""
+
+    def test_agg_assumed_male_vic_assumed_female(self):
+        turns = [
+            DialogueTurn(
+                speaker_id="AGG_001", text="\u05de\u05d4 \u05e2\u05e9\u05d9\u05ea?", intensity=2
+            ),
+        ]
+        roles = {"AGG_001": "AGG", "VIC_001": "VIC"}
+        result = disambiguate_turns(turns, roles)  # no genders
+        assert "F2_VERB_ASIT" in result[0].normalization_rules_triggered
+
+    def test_vic_assumed_female_addressing_male_agg(self):
+        turns = [
+            DialogueTurn(
+                speaker_id="VIC_001",
+                text="\u05dc\u05da \u05d6\u05d4 \u05dc\u05d0 \u05de\u05e9\u05e0\u05d4.",
+                intensity=1,
+            ),
+        ]
+        roles = {"AGG_001": "AGG", "VIC_001": "VIC"}
+        result = disambiguate_turns(turns, roles)  # no genders
+        # VIC→AGG: AGG is assumed male, so masculine rules should fire
+        assert "M2_PREP_LEKHA" in result[0].normalization_rules_triggered
+
+
+# ---------------------------------------------------------------------------
+# QA gate integration in disambiguate_turns
+# ---------------------------------------------------------------------------
+
+
+class TestQAGateInTurns:
+    def test_ambiguous_forms_flagged_in_quality_gate_failures(self):
+        """Turns with unknown addressee gender should have QA warnings."""
+        turns = [DialogueTurn(speaker_id="A", text="\u05e9\u05dc\u05da", intensity=1)]
+        # Only one speaker — no addressee gender can be determined.
+        result = disambiguate_turns(turns, {"A": "AGG"}, {"A": "male"})
+        # The unresolved \u05e9\u05dc\u05da should be flagged.
+        assert any("gender_ambiguity" in w for w in result[0].quality_gate_failures)
+
+    def test_resolved_forms_not_flagged(self):
+        """After successful disambiguation, no QA warnings should appear."""
+        turns = [DialogueTurn(speaker_id="AGG_001", text="\u05e9\u05dc\u05da", intensity=1)]
+        roles = {"AGG_001": "AGG", "VIC_001": "VIC"}
+        genders = {"AGG_001": "male", "VIC_001": "female"}
+        result = disambiguate_turns(turns, roles, genders)
+        assert not any("gender_ambiguity" in w for w in result[0].quality_gate_failures)
+
+    def test_existing_gate_failures_preserved(self):
+        """Pre-existing quality_gate_failures must not be overwritten."""
+        turns = [
+            DialogueTurn(
+                speaker_id="AGG_001",
+                text="\u05e9\u05dc\u05d5\u05dd",
+                intensity=1,
+                quality_gate_failures=["f0_check: too high"],
+            )
+        ]
+        roles = {"AGG_001": "AGG", "VIC_001": "VIC"}
+        genders = {"AGG_001": "male", "VIC_001": "female"}
+        result = disambiguate_turns(turns, roles, genders)
+        assert "f0_check: too high" in result[0].quality_gate_failures
+
+
+# ---------------------------------------------------------------------------
+# Lexicon consistency checks
+# ---------------------------------------------------------------------------
+
+
+class TestLexiconConsistency:
+    def test_no_duplicate_rule_ids(self):
+        ids = [e.rule_id for e in _LEXICON]
+        assert len(ids) == len(set(ids)), (
+            f"Duplicate rule IDs: {[x for x in ids if ids.count(x) > 1]}"
+        )
+
+    def test_feminine_and_masculine_cover_same_surfaces(self):
+        """Every surface form in the feminine lexicon should have a masculine counterpart."""
+        fem_surfaces = {e.surface for e in _LEXICON_2P_FEMININE}
+        masc_surfaces = {e.surface for e in _LEXICON_2P_MASCULINE}
+        assert fem_surfaces == masc_surfaces, (
+            f"Mismatched surfaces: fem-only={fem_surfaces - masc_surfaces}, "
+            f"masc-only={masc_surfaces - fem_surfaces}"
+        )
+
+    def test_feminine_entries_target_female(self):
+        for entry in _LEXICON_2P_FEMININE:
+            assert entry.target_gender == "female", f"{entry.rule_id} has wrong target_gender"
+
+    def test_masculine_entries_target_male(self):
+        for entry in _LEXICON_2P_MASCULINE:
+            assert entry.target_gender == "male", f"{entry.rule_id} has wrong target_gender"
+
+    def test_spoken_form_differs_from_surface(self):
+        for entry in _LEXICON:
+            assert entry.spoken_form != entry.surface, (
+                f"{entry.rule_id}: spoken_form is identical to surface — no disambiguation"
+            )
+
+    def test_feminine_and_masculine_produce_different_spoken_forms(self):
+        """For each surface, the fem and masc spoken forms must differ."""
+        fem_by_surface = {e.surface: e.spoken_form for e in _LEXICON_2P_FEMININE}
+        masc_by_surface = {e.surface: e.spoken_form for e in _LEXICON_2P_MASCULINE}
+        for surface in fem_by_surface:
+            assert fem_by_surface[surface] != masc_by_surface[surface], (
+                f"Surface '{surface}': fem and masc spoken forms are identical"
+            )


### PR DESCRIPTION
## Problem

Issue #63: the M1 Hebrew gender disambiguator was role-gated (AGG→VIC only) and hardcoded AGG=male, VIC=female. This caused systematic gender form errors:

- **AGG→VIC direction**: missing verb forms (ענית, אמרת, שמעת, etc.) left many turns uncorrected
- **VIC→AGG direction**: completely unhandled — female speaker addressing male got no disambiguation at all
- **No gender awareness**: used role as proxy for gender instead of actual `SpeakerConfig.gender`

## Solution

Rewrote the disambiguator to be **gender-aware and bidirectional**:

| File | Change |
|------|--------|
| `synthbanshee/script/hebrew_disambiguator.py` | Refactored from role-gated to gender-keyed. Added masculine 2nd-person lexicon (21 entries). Expanded feminine lexicon from 14→21 entries. Added `check_gender_ambiguity()` QA gate. Renamed `feminine_spoken` → `spoken_form`, added `target_gender`/`person` fields to `LexiconEntry`. Legacy fallback preserved when `speaker_genders` not passed. |
| `synthbanshee/cli.py` | Build `speaker_genders_map` from `SpeakerConfig` and pass to `disambiguate_turns()`. |
| `tests/unit/test_hebrew_disambiguator.py` | Rewritten for new API: 332 tests covering feminine lexicon, masculine lexicon, bidirectionality, QA gate, legacy fallback, lexicon consistency. |

### Key design decisions

- **Addressee gender drives 2nd-person rules**: feminine lexicon fires when addressee is female, masculine when male — regardless of speaker role
- **QA gate**: `check_gender_ambiguity()` scans `text_spoken` for unvocalized surface forms that survived disambiguation and records them in `quality_gate_failures`
- **Backward compatible**: `speaker_genders=None` falls back to role→gender inference (AGG→male, VIC→female)

## Test plan

- [x] All 332 disambiguator unit tests pass
- [x] Full test suite passes (1665 tests)
- [x] `ruff check` clean
- [x] `mypy` clean
- [ ] Listen to regenerated clips to verify pronunciation (manual)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)