### PR TITLE
fix(tts): insert inter-word <break> tags to prevent Hebrew word merging

### DIFF
--- a/synthbanshee/tts/ssml_builder.py
+++ b/synthbanshee/tts/ssml_builder.py
@@ -6,6 +6,8 @@ Generates SSML 1.1 documents with:
     ``supports_style_tags=False``)
   - <prosody> elements for rate, pitch, and volume control
   - Nested per-phrase <prosody> + <break> elements (M2b)
+  - Inter-word ``<break time="50ms"/>`` elements to prevent Hebrew word
+    merging (#62)
 
 Azure SSML reference:
 https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup-voice
@@ -21,6 +23,78 @@ from synthbanshee.tts.ssml_types import PhraseProsody
 _AZURE_XMLNS = "http://www.w3.org/2001/10/synthesis"
 _MSTTS_XMLNS = "http://www.w3.org/2001/mstts"
 _SPEAK_LANG = "he-IL"
+
+# Inter-word break duration in milliseconds.  50 ms is enough to signal a
+# word boundary to Azure / Google he-IL without introducing an audible pause.
+_WORD_BREAK_MS = 50
+
+
+def _inject_word_breaks(
+    parent: ET.Element,
+    text: str,
+    after: ET.Element | None = None,
+) -> ET.Element | None:
+    """Insert *text* into *parent* with ``<break>`` tags between words.
+
+    Hebrew TTS engines (Azure he-IL, Google Chirp) merge adjacent words into
+    unintelligible speech when no explicit boundary cue exists.  This function
+    splits *text* on whitespace and inserts a short ``<break>`` element between
+    every pair of consecutive words.
+
+    Args:
+        parent: The XML element to add content to.
+        text: The text to inject (may contain multi-word Hebrew).
+        after: If provided, the first text chunk is appended to
+            ``after.tail`` instead of ``parent.text``.
+
+    Returns:
+        The last child element added to *parent*, or *after* if no ``<break>``
+        elements were created (single word or empty text).
+    """
+    if not text or not text.strip():
+        # Pure whitespace or empty — append as-is without inserting breaks.
+        if text:
+            if after is None:
+                parent.text = (parent.text or "") + text
+            else:
+                after.tail = (after.tail or "") + text
+        return after
+
+    words = text.split()
+    last = after
+
+    # Preserve any leading whitespace (e.g. space before a text fragment
+    # that follows a <break> or <prosody> element).
+    leading = text[: len(text) - len(text.lstrip())]
+    if leading:
+        if last is None:
+            parent.text = (parent.text or "") + leading
+        else:
+            last.tail = (last.tail or "") + leading
+
+    for i, word in enumerate(words):
+        if i == 0:
+            # First word: append directly (no break needed before it).
+            if last is None:
+                parent.text = (parent.text or "") + word
+            else:
+                last.tail = (last.tail or "") + word
+        else:
+            # Subsequent words: insert <break/> then the word with a
+            # leading space in the tail to preserve normal spacing.
+            brk = ET.SubElement(parent, "break", attrib={"time": f"{_WORD_BREAK_MS}ms"})
+            brk.tail = " " + word
+            last = brk
+
+    # Preserve any trailing whitespace.
+    trailing = text[len(text.rstrip()) :]
+    if trailing:
+        if last is None:
+            parent.text = (parent.text or "") + trailing
+        else:
+            last.tail = (last.tail or "") + trailing
+
+    return last
 
 
 @dataclass
@@ -65,9 +139,10 @@ def _apply_phrase_prosody(
 
     Splits *text* around phrase spans and wraps each phrase in a nested
     ``<prosody>`` element with optional ``<break time="…"/>`` elements
-    inserted before and/or after.  Overlapping spans are skipped (the span
-    whose ``char_start`` falls before the previous span's ``char_end`` is
-    silently dropped).
+    inserted before and/or after.  Inter-word ``<break>`` elements are
+    inserted within each text fragment to prevent Hebrew word merging (#62).
+    Overlapping spans are skipped (the span whose ``char_start`` falls
+    before the previous span's ``char_end`` is silently dropped).
 
     Args:
         parent: The XML element that will receive the mixed text/element content.
@@ -78,13 +153,13 @@ def _apply_phrase_prosody(
     prev: ET.Element | None = None
 
     def _append_text(s: str) -> None:
+        """Append *s* with inter-word ``<break>`` elements."""
         nonlocal prev
         if not s:
             return
-        if prev is None:
-            parent.text = (parent.text or "") + s
-        else:
-            prev.tail = (prev.tail or "") + s
+        result = _inject_word_breaks(parent, s, after=prev)
+        if result is not None:
+            prev = result
 
     def _append_break(ms: int) -> ET.Element:
         nonlocal prev
@@ -119,7 +194,7 @@ def _apply_phrase_prosody(
         phrase_text = text[phrase.char_start : phrase.char_end]
         if phrase_attrs:
             pe = ET.SubElement(parent, "prosody", attrib=phrase_attrs)
-            pe.text = phrase_text
+            _inject_word_breaks(pe, phrase_text)
             prev = pe
         else:
             _append_text(phrase_text)
@@ -210,7 +285,7 @@ class SSMLBuilder:
             if utt.phrase_prosody:
                 _apply_phrase_prosody(inner, utt.text, utt.phrase_prosody)
             else:
-                inner.text = utt.text
+                _inject_word_breaks(inner, utt.text)
 
         raw = ET.tostring(speak, encoding="unicode", xml_declaration=False)
         return '<?xml version="1.0" encoding="UTF-8"?>\n' + raw

--- a/synthbanshee/tts/ssml_builder.py
+++ b/synthbanshee/tts/ssml_builder.py
@@ -24,8 +24,10 @@ _AZURE_XMLNS = "http://www.w3.org/2001/10/synthesis"
 _MSTTS_XMLNS = "http://www.w3.org/2001/mstts"
 _SPEAK_LANG = "he-IL"
 
-# Inter-word break duration in milliseconds.  50 ms is enough to signal a
-# word boundary to Azure / Google he-IL without introducing an audible pause.
+# Inter-word break duration in milliseconds.  50 ms is the initial estimate
+# for signalling a word boundary to Azure / Google he-IL without introducing
+# an audible pause.  This value needs empirical validation with real TTS
+# output — it may need per-provider tuning if engines respond differently.
 _WORD_BREAK_MS = 50
 
 

--- a/tests/unit/test_phrase_prosody.py
+++ b/tests/unit/test_phrase_prosody.py
@@ -333,8 +333,13 @@ class TestApplyPhraseProsody:
     def test_no_phrases_sets_text(self) -> None:
         parent = _make_parent()
         _apply_phrase_prosody(parent, "hello world", [])
-        assert parent.text == "hello world"
-        assert len(list(parent)) == 0  # no children
+        # Inter-word <break> splits text: parent.text = "hello",
+        # then <break time="50ms"/> with tail " world".
+        assert parent.text == "hello"
+        children = list(parent)
+        assert len(children) == 1
+        assert children[0].tag == "break"
+        assert children[0].tail == " world"
 
     def test_single_phrase_mid_text(self) -> None:
         parent = _make_parent()
@@ -372,8 +377,12 @@ class TestApplyPhraseProsody:
         parent = _make_parent()
         phrase = PhraseProsody("p0", 3, 3)  # zero-length span
         _apply_phrase_prosody(parent, "hello world", [phrase])
-        # Zero-length phrase skipped → text is set as-is
-        assert parent.text == "hello world"
+        # Zero-length phrase skipped → text set with inter-word breaks
+        assert parent.text == "hello"
+        children = list(parent)
+        assert len(children) == 1
+        assert children[0].tag == "break"
+        assert children[0].tail == " world"
 
     def test_phrase_with_pitch_attribute(self) -> None:
         # Covers `if phrase.pitch is not None: phrase_attrs["pitch"] = ...` (line 113-114).

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -16,8 +16,10 @@ from synthbanshee.config.speaker_config import SpeakerConfig
 from synthbanshee.tts.azure_provider import AzureProvider
 from synthbanshee.tts.renderer import TTSRenderer
 from synthbanshee.tts.ssml_builder import (
+    _WORD_BREAK_MS,
     SSMLBuilder,
     UtteranceSpec,
+    _inject_word_breaks,
     _rate_to_string,
     _semitones_to_percent,
 )
@@ -132,6 +134,124 @@ class TestSSMLBuilder:
         # Strip XML declaration for ElementTree
         ssml_body = ssml.split("\n", 1)[1] if ssml.startswith("<?xml") else ssml
         ET.fromstring(ssml_body)  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Word-boundary break tests (#62)
+# ---------------------------------------------------------------------------
+
+
+class TestWordBoundaryBreaks:
+    """Verify that multi-word Hebrew text produces inter-word <break> tags."""
+
+    def setup_method(self):
+        self.builder = SSMLBuilder()
+
+    def _body(self, ssml: str) -> str:
+        """Strip XML declaration to get parseable SSML body."""
+        return ssml.split("\n", 1)[1] if ssml.startswith("<?xml") else ssml
+
+    def test_multi_word_text_has_breaks(self):
+        """Multi-word text must contain <break> elements between words."""
+        utt = UtteranceSpec(
+            text="word1 word2 word3",
+            voice_id="he-IL-AvriNeural",
+        )
+        ssml = self.builder.build_single(utt)
+        # Two word boundaries → two <break> elements
+        assert ssml.count(f'time="{_WORD_BREAK_MS}ms"') == 2
+
+    def test_single_word_no_breaks(self):
+        """Single-word text must not contain any <break> elements."""
+        utt = UtteranceSpec(
+            text="hello",
+            voice_id="he-IL-AvriNeural",
+        )
+        ssml = self.builder.build_single(utt)
+        assert f'time="{_WORD_BREAK_MS}ms"' not in ssml
+
+    def test_text_preserved_after_breaks(self):
+        """All original words must appear in the serialised SSML."""
+        utt = UtteranceSpec(
+            text="word1 word2 word3",
+            voice_id="he-IL-AvriNeural",
+        )
+        ssml = self.builder.build_single(utt)
+        assert "word1" in ssml
+        assert "word2" in ssml
+        assert "word3" in ssml
+
+    def test_breaks_inside_prosody(self):
+        """Word breaks must also appear when a <prosody> wrapper is present."""
+        utt = UtteranceSpec(
+            text="word1 word2",
+            voice_id="he-IL-AvriNeural",
+            rate_multiplier=1.2,
+        )
+        ssml = self.builder.build_single(utt)
+        # One word boundary inside the prosody wrapper
+        assert ssml.count(f'time="{_WORD_BREAK_MS}ms"') == 1
+        assert "prosody" in ssml
+
+    def test_breaks_with_phrase_prosody(self):
+        """Word breaks must appear in text fragments around phrase prosody spans."""
+        from synthbanshee.tts.ssml_types import PhraseProsody
+
+        # "before1 before2 phrase1 phrase2 after1 after2"
+        #  0123456789...
+        # "before1"=0:7, " "=7, "before2"=8:15, " "=15,
+        # "phrase1"=16:23, " "=23, "phrase2"=24:31, " "=31,
+        # "after1"=32:38, " "=38, "after2"=39:45
+        text = "before1 before2 phrase1 phrase2 after1 after2"
+        phrase = PhraseProsody(
+            phrase_id="p0",
+            char_start=16,  # "phrase1 phrase2"
+            char_end=31,
+            rate="+10%",
+        )
+        utt = UtteranceSpec(
+            text=text,
+            voice_id="he-IL-AvriNeural",
+            phrase_prosody=[phrase],
+        )
+        ssml = self.builder.build_single(utt)
+        # All words must appear
+        for word in text.split():
+            assert word in ssml, f"word {word!r} missing from SSML"
+        # Word breaks: 1 (before1-before2) + 1 (phrase1-phrase2) + 1 (after1-after2) = 3
+        # Plus the trailing space before the phrase may or may not add one.
+        assert ssml.count(f'time="{_WORD_BREAK_MS}ms"') >= 3
+
+    def test_xml_well_formed_with_breaks(self):
+        """SSML with word breaks must remain valid XML."""
+        import xml.etree.ElementTree as ET
+
+        utt = UtteranceSpec(
+            text="word1 word2 word3 word4",
+            voice_id="he-IL-AvriNeural",
+            style="angry",
+            rate_multiplier=1.1,
+        )
+        ssml = self.builder.build_single(utt)
+        ET.fromstring(self._body(ssml))  # Should not raise
+
+    def test_inject_word_breaks_empty_text(self):
+        """_inject_word_breaks with empty text should not create elements."""
+        import xml.etree.ElementTree as ET
+
+        parent = ET.Element("test")
+        result = _inject_word_breaks(parent, "")
+        assert result is None
+        assert len(list(parent)) == 0
+
+    def test_inject_word_breaks_whitespace_only(self):
+        """_inject_word_breaks with whitespace-only text should preserve it."""
+        import xml.etree.ElementTree as ET
+
+        parent = ET.Element("test")
+        result = _inject_word_breaks(parent, "  ")
+        assert result is None
+        assert parent.text == "  "
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -218,9 +218,85 @@ class TestWordBoundaryBreaks:
         # All words must appear
         for word in text.split():
             assert word in ssml, f"word {word!r} missing from SSML"
-        # Word breaks: 1 (before1-before2) + 1 (phrase1-phrase2) + 1 (after1-after2) = 3
-        # Plus the trailing space before the phrase may or may not add one.
-        assert ssml.count(f'time="{_WORD_BREAK_MS}ms"') >= 3
+        # Exact break count: 1 (before1↔before2) + 1 (phrase1↔phrase2
+        # inside <prosody>) + 1 (after1↔after2) = 3 word-boundary breaks.
+        assert ssml.count(f'time="{_WORD_BREAK_MS}ms"') == 3
+
+    def test_hebrew_multi_word_text_has_breaks(self):
+        """Hebrew multi-word text must produce inter-word <break> elements."""
+        # Reproduces the core scenario from issue #62.
+        utt = UtteranceSpec(
+            text="\u05d4\u05d9\u05d9, \u05d7\u05e9\u05d1\u05ea\u05d9",
+            voice_id="he-IL-AvriNeural",
+        )
+        ssml = self.builder.build_single(utt)
+        assert ssml.count(f'time="{_WORD_BREAK_MS}ms"') == 1
+        # Both tokens must survive serialization intact.
+        assert "\u05d4\u05d9\u05d9," in ssml
+        assert "\u05d7\u05e9\u05d1\u05ea\u05d9" in ssml
+
+    def test_hebrew_with_niqqud_preserved(self):
+        """Niqqud-bearing Hebrew words must not be corrupted by break injection."""
+        # Two words, the first with niqqud (shin + shva + lamed + dagesh).
+        text = "\u05e9\u05b0\u05dc\u05d5\u05bc\u05dd \u05e2\u05d5\u05dc\u05dd"
+        utt = UtteranceSpec(text=text, voice_id="he-IL-AvriNeural")
+        ssml = self.builder.build_single(utt)
+        assert ssml.count(f'time="{_WORD_BREAK_MS}ms"') == 1
+        assert "\u05e9\u05b0\u05dc\u05d5\u05bc\u05dd" in ssml
+        assert "\u05e2\u05d5\u05dc\u05dd" in ssml
+
+    def test_text_roundtrip_preserves_content(self):
+        """Serialise → parse → extract text: all content must match the input."""
+        import xml.etree.ElementTree as ET
+
+        text = "one two three four"
+        utt = UtteranceSpec(
+            text=text,
+            voice_id="he-IL-AvriNeural",
+        )
+        ssml = self.builder.build_single(utt)
+        root = ET.fromstring(self._body(ssml))
+
+        # Walk the tree and collect every text/tail fragment.
+        fragments: list[str] = []
+
+        def _collect(el: ET.Element) -> None:
+            if el.text:
+                fragments.append(el.text)
+            for child in el:
+                _collect(child)
+                if child.tail:
+                    fragments.append(child.tail)
+
+        _collect(root)
+        recovered = "".join(fragments)
+        # Recovered text (ignoring break elements) must equal the original.
+        assert recovered == text
+
+    def test_hebrew_text_roundtrip(self):
+        """Hebrew content must survive the SSML serialise → parse roundtrip."""
+        import xml.etree.ElementTree as ET
+
+        text = (
+            "\u05d0\u05d2\u05d1 \u05e0\u05d9\u05e1\u05d9\u05ea\u05d9"
+            " \u05dc\u05d3\u05d1\u05e8 \u05d0\u05d9\u05ea\u05da"
+        )
+        utt = UtteranceSpec(text=text, voice_id="he-IL-HilaNeural")
+        ssml = self.builder.build_single(utt)
+        root = ET.fromstring(self._body(ssml))
+
+        fragments: list[str] = []
+
+        def _collect(el: ET.Element) -> None:
+            if el.text:
+                fragments.append(el.text)
+            for child in el:
+                _collect(child)
+                if child.tail:
+                    fragments.append(child.tail)
+
+        _collect(root)
+        assert "".join(fragments) == text
 
     def test_xml_well_formed_with_breaks(self):
         """SSML with word breaks must remain valid XML."""


### PR DESCRIPTION
## Summary

Closes #62.

- Azure and Google he-IL TTS engines merge adjacent Hebrew words into unintelligible speech when no explicit word-boundary cue exists in the SSML
- Added `_inject_word_breaks()` helper in `ssml_builder.py` that splits text on whitespace and inserts `<break time="50ms"/>` elements between every pair of consecutive words
- Applied word-break injection at all three text-insertion points: plain utterance text, phrase-prosody text fragments, and text within prosody wrappers

| File | Change |
|------|--------|
| `synthbanshee/tts/ssml_builder.py` | Added `_WORD_BREAK_MS` constant and `_inject_word_breaks()` helper; replaced all direct text assignment with break-injected variants |
| `tests/unit/test_tts.py` | Added `TestWordBoundaryBreaks` class with 12 tests: multi-word, single-word, prosody-wrapped, phrase-prosody, Hebrew text (with/without niqqud), serialize→parse roundtrip, empty, and whitespace-only cases |
| `tests/unit/test_phrase_prosody.py` | Updated 2 existing tests (`test_no_phrases_sets_text`, `test_zero_length_phrase_skipped`) to expect inter-word break elements |

## ⚠️ Cache invalidation

This change alters the SSML output for every multi-word utterance, which means the SHA-256 cache key changes. **The entire existing render cache (`assets/speech/`) is invalidated.** The first run after merging will re-render all cached utterances against the TTS API. Plan accordingly for API costs and runtime.

## Open tuning question

The 50ms break duration is an initial estimate. It needs empirical validation with actual TTS output — it may need per-provider tuning if Azure and Google respond differently to sub-100ms breaks.

## Test plan

- [x] `pytest` — 1679 passed
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [x] Pre-commit hooks pass (ruff-format, trailing whitespace, etc.)
- [x] Single-word text produces no extra `<break>` elements
- [x] Multi-word text produces correct number of `<break time="50ms"/>` elements
- [x] Hebrew text with niqqud preserved correctly through break injection
- [x] SSML roundtrip (serialize → parse → extract text) matches original input for both English and Hebrew
- [x] SSML output remains well-formed XML after break injection
- [x] Phrase prosody with multi-word spans gets breaks inside the `<prosody>` wrapper — exact count asserted
- [x] Edge cases: empty text, whitespace-only text handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)