### PR TITLE
fix(tts): Azure SSML parsing error on adjacent break elements (#67)

### DIFF
--- a/synthbanshee/tts/ssml_builder.py
+++ b/synthbanshee/tts/ssml_builder.py
@@ -15,11 +15,14 @@ https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthe
 
 from __future__ import annotations
 
+import logging
 import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 
 from synthbanshee.tts.ssml_types import PhraseProsody
+
+_log = logging.getLogger(__name__)
 
 _AZURE_XMLNS = "http://www.w3.org/2001/10/synthesis"
 _MSTTS_XMLNS = "http://www.w3.org/2001/mstts"
@@ -45,7 +48,12 @@ _XML_INVALID_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
 
 
 def _sanitize_text(text: str) -> str:
-    """Remove characters that are invalid in XML 1.0 from *text*."""
+    """Remove characters that are invalid in XML 1.0 from *text*.
+
+    Defense-in-depth: ideally invalid chars should be rejected at the LLM
+    response parsing boundary (script/generator.py).  This guard ensures the
+    SSML builder never produces unparseable XML regardless of upstream bugs.
+    """
     return _XML_INVALID_CHARS_RE.sub("", text)
 
 
@@ -133,33 +141,42 @@ class UtteranceSpec:
 def _semitones_to_percent(st: float) -> str:
     """Convert a semitone shift to the Azure pitch % format (e.g. '+5%' / '-10%').
 
-    Values are clamped to Azure's documented ±50% range.
+    Values are clamped to Azure's documented ±50% range.  A warning is logged
+    when clamping activates — this indicates a speaker config or state-drift bug.
     """
     # Approximation: 1 semitone ≈ 5.946% pitch change
     pct = round(st * 5.946)
-    pct = max(_AZURE_PITCH_MIN_PCT, min(_AZURE_PITCH_MAX_PCT, pct))
-    return f"+{pct}%" if pct >= 0 else f"{pct}%"
+    clamped = max(_AZURE_PITCH_MIN_PCT, min(_AZURE_PITCH_MAX_PCT, pct))
+    if clamped != pct:
+        _log.warning("Pitch %+d%% exceeds Azure range; clamped to %+d%%", pct, clamped)
+    return f"+{clamped}%" if clamped >= 0 else f"{clamped}%"
 
 
 def _rate_to_string(rate: float) -> str:
     """Format a rate multiplier as a percentage string for <prosody rate=...>.
 
-    Values are clamped to Azure's documented -50% to +200% range.
+    Values are clamped to Azure's documented -50% to +200% range.  A warning is
+    logged when clamping activates.
     """
     pct = round((rate - 1.0) * 100)
-    pct = max(_AZURE_RATE_MIN_PCT, min(_AZURE_RATE_MAX_PCT, pct))
-    return f"+{pct}%" if pct >= 0 else f"{pct}%"
+    clamped = max(_AZURE_RATE_MIN_PCT, min(_AZURE_RATE_MAX_PCT, pct))
+    if clamped != pct:
+        _log.warning("Rate %+d%% exceeds Azure range; clamped to %+d%%", pct, clamped)
+    return f"+{clamped}%" if clamped >= 0 else f"{clamped}%"
 
 
 def _volume_to_string(db: float) -> str:
     """Format a dB volume offset as a percentage for <prosody volume=...>.
 
-    Values are clamped to Azure's documented ±50% range.
+    Values are clamped to Azure's documented ±50% range.  A warning is logged
+    when clamping activates.
     """
     # Azure volume is 0–100; default is 100. Map dB linearly (rough).
     pct = round(db * 1.0)
-    pct = max(_AZURE_VOLUME_MIN_PCT, min(_AZURE_VOLUME_MAX_PCT, pct))
-    return f"+{pct}%" if pct >= 0 else f"{pct}%"
+    clamped = max(_AZURE_VOLUME_MIN_PCT, min(_AZURE_VOLUME_MAX_PCT, pct))
+    if clamped != pct:
+        _log.warning("Volume %+d%% exceeds Azure range; clamped to %+d%%", pct, clamped)
+    return f"+{clamped}%" if clamped >= 0 else f"{clamped}%"
 
 
 def _apply_phrase_prosody(
@@ -211,15 +228,20 @@ def _apply_phrase_prosody(
             _append_text(text[cursor : phrase.char_start])
 
         # Optional break before the phrase.  Merge with the preceding
-        # inter-word <break> element (if any) to avoid adjacent breaks that
-        # Azure's SSML parser rejects with error 0x80045003 (#67).
+        # <break> element (if any) to avoid adjacent breaks that Azure's SSML
+        # parser rejects with error 0x80045003 (#67).
         if phrase.break_before_ms > 0:
             if prev is not None and prev.tag == "break":
-                # Merge: replace the preceding word-boundary break with the
-                # longer phrase break (the phrase break subsumes the 50 ms).
-                prev_ms = int(prev.attrib.get("time", "0").replace("ms", ""))
-                merged_ms = max(prev_ms, phrase.break_before_ms)
-                prev.attrib["time"] = f"{merged_ms}ms"
+                prev_time = prev.attrib.get("time", "0ms")
+                prev_ms = int(prev_time.replace("ms", ""))
+                if prev_ms == _WORD_BREAK_MS:
+                    # Word-boundary break: replace with the phrase break
+                    # (the phrase break subsumes the word-boundary intent).
+                    prev.attrib["time"] = f"{phrase.break_before_ms}ms"
+                else:
+                    # Semantic break (e.g. break_after from prior phrase):
+                    # sum durations to preserve both intents.
+                    prev.attrib["time"] = f"{prev_ms + phrase.break_before_ms}ms"
             else:
                 _append_break(phrase.break_before_ms)
 
@@ -331,15 +353,7 @@ class SSMLBuilder:
                 _inject_word_breaks(inner, utt_text)
 
         raw = ET.tostring(speak, encoding="unicode", xml_declaration=False)
-        ssml = '<?xml version="1.0" encoding="UTF-8"?>\n' + raw
-
-        # Validate well-formedness: catch malformed XML before sending to Azure.
-        try:
-            ET.fromstring(raw)
-        except ET.ParseError as exc:
-            raise ValueError(f"Generated SSML is not well-formed XML: {exc}") from exc
-
-        return ssml
+        return '<?xml version="1.0" encoding="UTF-8"?>\n' + raw
 
     def build_from_speaker_config(
         self,

--- a/synthbanshee/tts/ssml_builder.py
+++ b/synthbanshee/tts/ssml_builder.py
@@ -15,6 +15,7 @@ https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthe
 
 from __future__ import annotations
 
+import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 
@@ -29,6 +30,23 @@ _SPEAK_LANG = "he-IL"
 # an audible pause.  This value needs empirical validation with real TTS
 # output — it may need per-provider tuning if engines respond differently.
 _WORD_BREAK_MS = 50
+
+# Azure prosody attribute limits (documented ranges).
+_AZURE_RATE_MIN_PCT = -50  # rate="-50%" → 0.5x
+_AZURE_RATE_MAX_PCT = 200  # rate="+200%" → 3.0x
+_AZURE_PITCH_MIN_PCT = -50
+_AZURE_PITCH_MAX_PCT = 50
+_AZURE_VOLUME_MIN_PCT = -50
+_AZURE_VOLUME_MAX_PCT = 50
+
+# Characters invalid in XML 1.0: U+0000–U+0008, U+000B, U+000C, U+000E–U+001F.
+# These must be stripped before embedding text in SSML.
+_XML_INVALID_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def _sanitize_text(text: str) -> str:
+    """Remove characters that are invalid in XML 1.0 from *text*."""
+    return _XML_INVALID_CHARS_RE.sub("", text)
 
 
 def _inject_word_breaks(
@@ -113,22 +131,34 @@ class UtteranceSpec:
 
 
 def _semitones_to_percent(st: float) -> str:
-    """Convert a semitone shift to the Azure pitch % format (e.g. '+5%' / '-10%')."""
+    """Convert a semitone shift to the Azure pitch % format (e.g. '+5%' / '-10%').
+
+    Values are clamped to Azure's documented ±50% range.
+    """
     # Approximation: 1 semitone ≈ 5.946% pitch change
     pct = round(st * 5.946)
+    pct = max(_AZURE_PITCH_MIN_PCT, min(_AZURE_PITCH_MAX_PCT, pct))
     return f"+{pct}%" if pct >= 0 else f"{pct}%"
 
 
 def _rate_to_string(rate: float) -> str:
-    """Format a rate multiplier as a percentage string for <prosody rate=...>."""
+    """Format a rate multiplier as a percentage string for <prosody rate=...>.
+
+    Values are clamped to Azure's documented -50% to +200% range.
+    """
     pct = round((rate - 1.0) * 100)
+    pct = max(_AZURE_RATE_MIN_PCT, min(_AZURE_RATE_MAX_PCT, pct))
     return f"+{pct}%" if pct >= 0 else f"{pct}%"
 
 
 def _volume_to_string(db: float) -> str:
-    """Format a dB volume offset as a percentage for <prosody volume=...>."""
+    """Format a dB volume offset as a percentage for <prosody volume=...>.
+
+    Values are clamped to Azure's documented ±50% range.
+    """
     # Azure volume is 0–100; default is 100. Map dB linearly (rough).
     pct = round(db * 1.0)
+    pct = max(_AZURE_VOLUME_MIN_PCT, min(_AZURE_VOLUME_MAX_PCT, pct))
     return f"+{pct}%" if pct >= 0 else f"{pct}%"
 
 
@@ -180,9 +210,18 @@ def _apply_phrase_prosody(
         if phrase.char_start > cursor:
             _append_text(text[cursor : phrase.char_start])
 
-        # Optional break before the phrase.
+        # Optional break before the phrase.  Merge with the preceding
+        # inter-word <break> element (if any) to avoid adjacent breaks that
+        # Azure's SSML parser rejects with error 0x80045003 (#67).
         if phrase.break_before_ms > 0:
-            _append_break(phrase.break_before_ms)
+            if prev is not None and prev.tag == "break":
+                # Merge: replace the preceding word-boundary break with the
+                # longer phrase break (the phrase break subsumes the 50 ms).
+                prev_ms = int(prev.attrib.get("time", "0").replace("ms", ""))
+                merged_ms = max(prev_ms, phrase.break_before_ms)
+                prev.attrib["time"] = f"{merged_ms}ms"
+            else:
+                _append_break(phrase.break_before_ms)
 
         # Phrase-level prosody wrapper (omitted when only breaks are requested).
         phrase_attrs: dict[str, str] = {}
@@ -256,6 +295,8 @@ class SSMLBuilder:
         speak = ET.Element("speak", attrib=speak_attribs)
 
         for utt in utterances:
+            # Sanitize text: strip characters invalid in XML 1.0 (#67).
+            utt_text = _sanitize_text(utt.text)
             voice = ET.SubElement(speak, "voice", attrib={"name": utt.voice_id})
 
             # Add express-as only when a non-default style is requested AND
@@ -285,12 +326,20 @@ class SSMLBuilder:
                 inner = parent
 
             if utt.phrase_prosody:
-                _apply_phrase_prosody(inner, utt.text, utt.phrase_prosody)
+                _apply_phrase_prosody(inner, utt_text, utt.phrase_prosody)
             else:
-                _inject_word_breaks(inner, utt.text)
+                _inject_word_breaks(inner, utt_text)
 
         raw = ET.tostring(speak, encoding="unicode", xml_declaration=False)
-        return '<?xml version="1.0" encoding="UTF-8"?>\n' + raw
+        ssml = '<?xml version="1.0" encoding="UTF-8"?>\n' + raw
+
+        # Validate well-formedness: catch malformed XML before sending to Azure.
+        try:
+            ET.fromstring(raw)
+        except ET.ParseError as exc:
+            raise ValueError(f"Generated SSML is not well-formed XML: {exc}") from exc
+
+        return ssml
 
     def build_from_speaker_config(
         self,

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -436,8 +436,48 @@ class TestSSMLParseErrorFix67:
         adjacent_breaks = re.findall(r"<break[^/]*/>\s*<break", ssml)
         assert len(adjacent_breaks) == 0, f"Adjacent breaks found in SSML: {ssml}"
 
-        # The 300ms menace break should appear (merged with the word break).
+        # The 300ms menace break should appear (replaced the 50ms word break).
         assert 'time="300ms"' in ssml
+
+    def test_semantic_break_after_then_break_before_sums(self):
+        """break_after + break_before of consecutive phrases must sum durations."""
+        import re
+
+        from synthbanshee.tts.ssml_types import PhraseProsody
+
+        # Two phrases with break_after on first and break_before on second.
+        # Space between them is " " (no words → no word breaks created).
+        text = "intro phrase_a end_a mid phrase_b outro"
+        phrases = [
+            PhraseProsody(
+                phrase_id="p0",
+                char_start=6,
+                char_end=20,  # "phrase_a end_a"
+                rate="-20%",
+                break_after_ms=250,
+            ),
+            PhraseProsody(
+                phrase_id="p1",
+                char_start=25,
+                char_end=33,  # "phrase_b"
+                rate="-25%",
+                break_before_ms=300,
+            ),
+        ]
+        utt = UtteranceSpec(
+            text=text,
+            voice_id="he-IL-AvriNeural",
+            phrase_prosody=phrases,
+        )
+        ssml = self.builder.build_single(utt, supports_style_tags=False)
+
+        # No adjacent breaks.
+        adjacent_breaks = re.findall(r"<break[^/]*/>\s*<break", ssml)
+        assert len(adjacent_breaks) == 0, f"Adjacent breaks found: {ssml}"
+
+        # The 250ms break_after and 300ms break_before should be summed (550ms)
+        # because the preceding break is semantic (not a word-boundary break).
+        assert 'time="550ms"' in ssml
 
     def test_text_with_invalid_xml_chars_sanitized(self):
         """Characters invalid in XML 1.0 must be stripped before SSML building."""
@@ -454,6 +494,66 @@ class TestSSMLParseErrorFix67:
         assert "world" in ssml
         assert "foo" in ssml
         assert "bar" in ssml
+
+    def test_hebrew_high_intensity_with_menace_hint(self):
+        """Regression: Hebrew I5 turn with menace hint must produce valid SSML.
+
+        Simulates the exact pattern from failing scene sp_sv_a_0001: AGG speaker
+        at intensity 5 with accumulated state drift, multi-word Hebrew text,
+        and a "menace" phrase hint with break_before=300ms.
+        """
+        import re
+        import xml.etree.ElementTree as ET
+
+        from synthbanshee.tts.ssml_types import PhraseProsody
+
+        # Hebrew text simulating an I5 assault-scene turn (3 sentences).
+        # Contains niqqud on one word to test PR #69 interaction.
+        text = (
+            "\u05d0\u05ea \u05dc\u05d0 \u05ea\u05e2\u05e9\u05d4"  # "you don't do"
+            " \u05de\u05d4 \u05e9\u05d0\u05de\u05e8\u05ea\u05d9"  # " what I said"
+            " \u05dc\u05da. "  # " to you. "
+            "\u05ea\u05b4\u05e9\u05b0\u05de\u05e2\u05d9"  # "listen" (with niqqud)
+            " \u05d8\u05d5\u05d1!"  # " well!"
+        )
+        # "menace" hint on the imperative word (with niqqud): char_start/end
+        # covering the niqqud-bearing word.
+        imperative_start = text.index("\u05ea\u05b4\u05e9\u05b0\u05de\u05e2\u05d9")
+        imperative_end = imperative_start + len("\u05ea\u05b4\u05e9\u05b0\u05de\u05e2\u05d9")
+        phrase = PhraseProsody(
+            phrase_id="t5_p0",
+            char_start=imperative_start,
+            char_end=imperative_end,
+            rate="-25%",
+            pitch="-1st",
+            break_before_ms=300,
+        )
+        # AGG_M_30-45_001 at I5 with state drift: rate=1.14*1.05*~1.15=1.38,
+        # pitch=2+~1.5=3.5 st, volume=13+0+~4=17 dB.
+        utt = UtteranceSpec(
+            text=text,
+            voice_id="he-IL-AvriNeural",
+            rate_multiplier=1.38,
+            pitch_delta_st=3.5,
+            volume_delta_db=17.0,
+            phrase_prosody=[phrase],
+        )
+        ssml = self.builder.build_single(utt, supports_style_tags=False)
+
+        # Must be valid XML.
+        ET.fromstring(self._body(ssml))
+
+        # No adjacent breaks.
+        adjacent_breaks = re.findall(r"<break[^/]*/>\s*<break", ssml)
+        assert len(adjacent_breaks) == 0, f"Adjacent breaks in Hebrew SSML: {ssml}"
+
+        # Hebrew text must survive (spot-check key words).
+        assert "\u05ea\u05e2\u05e9\u05d4" in ssml  # "do"
+        assert "\u05ea\u05b4\u05e9\u05b0\u05de\u05e2\u05d9" in ssml  # "listen" with niqqud
+        assert "\u05d8\u05d5\u05d1" in ssml  # "well"
+
+        # The 300ms menace break must appear (merged with preceding word break).
+        assert 'time="300ms"' in ssml
 
     def test_prosody_pitch_clamped_to_azure_range(self):
         """Extreme pitch values must be clamped to ±50%."""

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -331,6 +331,196 @@ class TestWordBoundaryBreaks:
 
 
 # ---------------------------------------------------------------------------
+# SSML parse-error regression tests (#67)
+# ---------------------------------------------------------------------------
+
+
+class TestSSMLParseErrorFix67:
+    """Regression tests for Azure SSML parsing error 0x80045003.
+
+    The root cause is adjacent <break> elements created when inter-word breaks
+    (PR #70) interact with phrase prosody break_before/break_after attributes.
+    Azure's SSML parser rejects adjacent breaks as malformed.
+    """
+
+    def setup_method(self):
+        self.builder = SSMLBuilder()
+
+    def _body(self, ssml: str) -> str:
+        return ssml.split("\n", 1)[1] if ssml.startswith("<?xml") else ssml
+
+    def test_no_adjacent_breaks_with_break_before(self):
+        """Phrase break_before must merge with preceding inter-word break."""
+        import re
+
+        from synthbanshee.tts.ssml_types import PhraseProsody
+
+        # "word1 word2 phrase1 phrase2" — phrase starts at word boundary
+        text = "word1 word2 phrase1 phrase2"
+        phrase = PhraseProsody(
+            phrase_id="p0",
+            char_start=12,  # "phrase1 phrase2"
+            char_end=27,
+            rate="-25%",
+            pitch="-1st",
+            break_before_ms=300,  # "menace" hint
+        )
+        utt = UtteranceSpec(
+            text=text,
+            voice_id="he-IL-AvriNeural",
+            phrase_prosody=[phrase],
+        )
+        ssml = self.builder.build_single(utt, supports_style_tags=False)
+
+        # No two <break .../> elements should be adjacent (only whitespace between).
+        adjacent_breaks = re.findall(r"<break[^/]*/>\s*<break", ssml)
+        assert len(adjacent_breaks) == 0, f"Adjacent breaks found in SSML: {ssml}"
+
+    def test_merged_break_uses_max_duration(self):
+        """When merging breaks, the longer duration wins."""
+        from synthbanshee.tts.ssml_types import PhraseProsody
+
+        text = "before phrase_word"
+        phrase = PhraseProsody(
+            phrase_id="p0",
+            char_start=7,  # "phrase_word"
+            char_end=18,
+            rate="-20%",
+            break_before_ms=150,  # "slow" hint — longer than 50ms word break
+        )
+        utt = UtteranceSpec(
+            text=text,
+            voice_id="he-IL-AvriNeural",
+            phrase_prosody=[phrase],
+        )
+        ssml = self.builder.build_single(utt, supports_style_tags=False)
+
+        # The inter-word break (50ms) between "before" and phrase should be
+        # merged to 150ms (the phrase break_before duration wins).
+        assert 'time="150ms"' in ssml
+        # The original 50ms word break should NOT appear as a separate element.
+        assert ssml.count('time="50ms"') == 0
+
+    def test_menace_hint_no_adjacent_breaks(self):
+        """Menace hint (break_before=300ms) must not create adjacent breaks."""
+        import re
+
+        from synthbanshee.tts.ssml_types import PhraseProsody
+
+        # Simulate a failing pattern: multi-word text with menace-annotated phrase.
+        text = "word1 word2 word3 threat_word1 threat_word2"
+        phrase = PhraseProsody(
+            phrase_id="p0",
+            char_start=18,
+            char_end=44,
+            rate="-25%",
+            pitch="-1st",
+            break_before_ms=300,
+        )
+        utt = UtteranceSpec(
+            text=text,
+            voice_id="he-IL-AvriNeural",
+            rate_multiplier=1.14,
+            pitch_delta_st=2.0,
+            volume_delta_db=13.0,
+            phrase_prosody=[phrase],
+        )
+        ssml = self.builder.build_single(utt, supports_style_tags=False)
+
+        # Must be valid XML.
+        import xml.etree.ElementTree as ET
+
+        ET.fromstring(self._body(ssml))
+
+        # No adjacent breaks.
+        adjacent_breaks = re.findall(r"<break[^/]*/>\s*<break", ssml)
+        assert len(adjacent_breaks) == 0, f"Adjacent breaks found in SSML: {ssml}"
+
+        # The 300ms menace break should appear (merged with the word break).
+        assert 'time="300ms"' in ssml
+
+    def test_text_with_invalid_xml_chars_sanitized(self):
+        """Characters invalid in XML 1.0 must be stripped before SSML building."""
+        # Simulate LLM output with control characters.
+        text = "hello\x00world\x0bfoo\x1fbar"
+        utt = UtteranceSpec(text=text, voice_id="he-IL-AvriNeural")
+        ssml = self.builder.build_single(utt, supports_style_tags=False)
+        # Must not contain invalid chars.
+        assert "\x00" not in ssml
+        assert "\x0b" not in ssml
+        assert "\x1f" not in ssml
+        # Words must still be present.
+        assert "hello" in ssml
+        assert "world" in ssml
+        assert "foo" in ssml
+        assert "bar" in ssml
+
+    def test_prosody_pitch_clamped_to_azure_range(self):
+        """Extreme pitch values must be clamped to ±50%."""
+        # 12 semitones → 71% unclamped, should be clamped to 50%
+        assert _semitones_to_percent(12.0) == "+50%"
+        assert _semitones_to_percent(-12.0) == "-50%"
+        # Moderate values remain unchanged
+        assert _semitones_to_percent(3.0) == "+18%"
+        assert _semitones_to_percent(-2.0) == "-12%"
+
+    def test_prosody_rate_clamped_to_azure_range(self):
+        """Extreme rate values must be clamped to Azure's -50% to +200% range."""
+        # rate=4.0 → +300% unclamped, should be clamped to +200%
+        assert _rate_to_string(4.0) == "+200%"
+        # rate=0.3 → -70% unclamped, should be clamped to -50%
+        assert _rate_to_string(0.3) == "-50%"
+        # Normal values pass through
+        assert _rate_to_string(1.1) == "+10%"
+
+    def test_well_formed_ssml_with_phrase_prosody_and_breaks(self):
+        """Full integration: high-intensity turn with phrase prosody must be valid XML."""
+        import xml.etree.ElementTree as ET
+
+        from synthbanshee.tts.ssml_types import PhraseProsody
+
+        # Simulate a high-intensity assault-scene turn with multiple hints.
+        text = "word1 word2 word3 word4 phrase_a1 phrase_a2 word5 word6 phrase_b1 word7"
+        # Offsets: phrase_a1 phrase_a2 = 24:43, phrase_b1 = 56:65
+        phrases = [
+            PhraseProsody(
+                phrase_id="p0",
+                char_start=24,
+                char_end=43,
+                rate="+15%",
+                volume="+3dB",
+                pitch="+1st",
+                break_before_ms=0,  # "stress" — no break_before
+            ),
+            PhraseProsody(
+                phrase_id="p1",
+                char_start=56,
+                char_end=65,
+                rate="-25%",
+                pitch="-1st",
+                break_before_ms=300,  # "menace" — has break_before
+            ),
+        ]
+        utt = UtteranceSpec(
+            text=text,
+            voice_id="he-IL-AvriNeural",
+            rate_multiplier=1.14,
+            pitch_delta_st=3.5,
+            volume_delta_db=17.0,
+            phrase_prosody=phrases,
+        )
+        ssml = self.builder.build_single(utt, supports_style_tags=False)
+        body = self._body(ssml)
+
+        # Must parse as valid XML.
+        ET.fromstring(body)
+
+        # All words must be present in the output.
+        for word in text.split():
+            assert word in ssml
+
+
+# ---------------------------------------------------------------------------
 # AzureProvider tests (mocked)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Root cause**: PR #70's inter-word `<break time="50ms"/>` elements interact with phrase prosody `break_before_ms` (from "menace"/"slow"/"break_before" hints) to create adjacent `<break>` elements. Azure's SSML parser rejects this pattern with error `0x80045003`.
- **Fix**: Merge adjacent `<break>` elements instead of emitting consecutive breaks. Word-boundary breaks (50ms) are *replaced* by the phrase break; semantic breaks (e.g. a preceding `break_after`) are *summed* to preserve both pause intents.
- **Scope**: Only affects high-intensity turns (I3–I5) in violent scene templates that use hints with `break_before_ms > 0`.

## Changes

| File | Change |
|------|--------|
| `synthbanshee/tts/ssml_builder.py` | Merge adjacent breaks in `_apply_phrase_prosody` (word-boundary → replace, semantic → sum); clamp prosody values to Azure ranges with `logging.warning`; add `_sanitize_text` for XML-invalid chars as defense-in-depth |
| `tests/unit/test_tts.py` | 9 regression tests: adjacent-break merging, duration semantics (replace vs sum), prosody clamping, text sanitization, full Hebrew I5 integration with niqqud and realistic AGG speaker params |

## Design decisions

- **Replace vs sum**: A word-boundary break (50ms) is purely structural — the phrase break subsumes its intent. But a semantic break (e.g. 250ms `break_after`) represents intentional dramatic pause that should be preserved alongside the new phrase's `break_before`.
- **Clamping warns, doesn't silently swallow**: If prosody values hit Azure's ceiling, that's a speaker-config or state-drift bug upstream. The warning makes it visible in logs.
- **`_sanitize_text` stays in the builder**: Ideally invalid chars should be rejected at the LLM parsing boundary, but defense-in-depth here ensures the SSML layer never produces unparseable output regardless of upstream bugs.

## Test plan

- [x] `pytest tests/` — all 1688 tests pass (9 new)
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [ ] Manual: run Azure TTS on previously failing scenes (sp_it_a_0002, sp_sv_a_0001, sp_sv_a_0002, sp_neg_a_0002) to confirm they render successfully

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)