### PR TITLE
fix(mixer): #65 Lombard spectral tilt at I4–I5

### DIFF
--- a/docs/audio_generation_v3_design.md
+++ b/docs/audio_generation_v3_design.md
@@ -215,7 +215,7 @@ Both sources produce `PhraseProsody` objects; the SSML builder does not distingu
 
 Pure amplitude scaling at high intensity sounds like microphone proximity, not raised voice. Real shouting exhibits the Lombard effect: a high-frequency boost (≈ +2–4 dB above 2–3 kHz) caused by glottal-source flattening. Azure he-IL voices do not honour `<mstts:express-as>`, so the tilt is applied as a post-TTS DSP step.
 
-Implementation: a single RBJ high-shelf biquad (`scipy.signal.lfilter`) at 2.5 kHz with +2.0 dB gain at I4 and +3.5 dB gain at I5. I1–I3 pass through unchanged. The shelf runs in `SceneMixer.mix_sequential()` after per-turn RMS gain (§4.7) and before the edge-fade pass, driven by a 6th element in the segment tuple carrying `turn.intensity`. Peak headroom is left to the preprocessing limiter — the shelf does not perform its own clipping.
+Implementation: a single RBJ high-shelf biquad (`scipy.signal.lfilter`) at 2.5 kHz with +2.0 dB asymptotic gain at I4 and +3.5 dB at I5; at the 2.5 kHz knee the gain is half. All other intensities pass through unchanged. The shelf runs in `SceneMixer.mix_sequential()` after per-turn RMS gain (§4.7) and before the edge-fade pass; the M14 fade-in conveniently masks the filter's startup transient. Coefficients are precomputed once at module load. The mixer's input is a `Segment` dataclass (replaces the historical positional tuple) carrying `intensity` as a named field. Peak headroom is left to the preprocessing limiter — the shelf does not perform its own clipping.
 
 ---
 

--- a/docs/audio_generation_v3_design.md
+++ b/docs/audio_generation_v3_design.md
@@ -211,6 +211,12 @@ class PhraseProsody:
 
 Both sources produce `PhraseProsody` objects; the SSML builder does not distinguish their origin.
 
+**4.2c — Lombard spectral tilt at I4/I5 (#65)**
+
+Pure amplitude scaling at high intensity sounds like microphone proximity, not raised voice. Real shouting exhibits the Lombard effect: a high-frequency boost (≈ +2–4 dB above 2–3 kHz) caused by glottal-source flattening. Azure he-IL voices do not honour `<mstts:express-as>`, so the tilt is applied as a post-TTS DSP step.
+
+Implementation: a single RBJ high-shelf biquad (`scipy.signal.lfilter`) at 2.5 kHz with +2.0 dB gain at I4 and +3.5 dB gain at I5. I1–I3 pass through unchanged. The shelf runs in `SceneMixer.mix_sequential()` after per-turn RMS gain (§4.7) and before the edge-fade pass, driven by a 6th element in the segment tuple carrying `turn.intensity`. Peak headroom is left to the preprocessing limiter — the shelf does not perform its own clipping.
+
 ---
 
 ### 4.3 Stateful Cross-Turn Emotional Controller

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -1,9 +1,10 @@
 """SceneMixer: concatenate per-speaker TTS WAV segments into a single audio scene.
 
-Each segment is a (wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode) 5-tuple.
-The mixer decodes WAV bytes using soundfile, resamples to 16 kHz if needed, applies
-optional per-turn RMS gain (M3), then places each turn in the output buffer according
-to its MixMode:
+Each segment is a (wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode,
+intensity) 6-tuple. The mixer decodes WAV bytes using soundfile, resamples to
+16 kHz if needed, applies optional per-turn RMS gain (M3) and a Lombard
+spectral tilt at I4–I5 (#65), then places each turn in the output buffer
+according to its MixMode:
 
   SEQUENTIAL  — insert a silence gap of *amount_s* before this turn (existing behaviour).
   OVERLAP     — start *amount_s* seconds before the previous turn ends; both turns are
@@ -32,9 +33,11 @@ Spec reference: docs/audio_generation_v3_design.md §4.6
 from __future__ import annotations
 
 import io
+import math
 
 import numpy as np
 import soundfile as sf
+from scipy.signal import lfilter
 
 from synthbanshee.augment.preprocessing import _resample
 from synthbanshee.script.types import MixedScene
@@ -42,6 +45,13 @@ from synthbanshee.tts.mix_mode import MixMode
 
 _TARGET_SR = 16_000
 _EDGE_FADE_SAMPLES = 160  # 10ms at 16 kHz — eliminates DC-offset clicks at turn boundaries
+
+# #65 Lombard effect: post-TTS spectral tilt at high intensities.
+# Real raised voices boost high-frequency energy; pure amplitude scaling sounds
+# like mic proximity instead of shouting.  Mapping is intentionally narrow —
+# only I4 and I5 get a high-shelf boost, I1–I3 are untouched.
+_LOMBARD_GAIN_DB: dict[int, float] = {4: 2.0, 5: 3.5}
+_LOMBARD_SHELF_HZ = 2500.0
 
 
 def _apply_rms_gain(mono: np.ndarray, rms_target_dbfs: float) -> np.ndarray:
@@ -67,6 +77,62 @@ def _apply_rms_gain(mono: np.ndarray, rms_target_dbfs: float) -> np.ndarray:
     return (mono * gain_linear).astype(np.float32)
 
 
+def _highshelf_biquad(gain_db: float, f0: float, sample_rate: int) -> tuple[np.ndarray, np.ndarray]:
+    """Return (b, a) biquad coefficients for an RBJ high-shelf filter.
+
+    Uses slope S=1, which is the canonical "natural" shelf shape.
+    """
+    a_amp = 10.0 ** (gain_db / 40.0)
+    w0 = 2.0 * math.pi * f0 / sample_rate
+    cos_w0 = math.cos(w0)
+    sin_w0 = math.sin(w0)
+    # alpha for slope S=1 simplifies to sin(w0)/sqrt(2)
+    alpha = sin_w0 / math.sqrt(2.0)
+    sqrt_a = math.sqrt(a_amp)
+    two_sqrt_a_alpha = 2.0 * sqrt_a * alpha
+
+    b0 = a_amp * ((a_amp + 1.0) + (a_amp - 1.0) * cos_w0 + two_sqrt_a_alpha)
+    b1 = -2.0 * a_amp * ((a_amp - 1.0) + (a_amp + 1.0) * cos_w0)
+    b2 = a_amp * ((a_amp + 1.0) + (a_amp - 1.0) * cos_w0 - two_sqrt_a_alpha)
+    a0 = (a_amp + 1.0) - (a_amp - 1.0) * cos_w0 + two_sqrt_a_alpha
+    a1 = 2.0 * ((a_amp - 1.0) - (a_amp + 1.0) * cos_w0)
+    a2 = (a_amp + 1.0) - (a_amp - 1.0) * cos_w0 - two_sqrt_a_alpha
+
+    b = np.array([b0 / a0, b1 / a0, b2 / a0], dtype=np.float64)
+    a = np.array([1.0, a1 / a0, a2 / a0], dtype=np.float64)
+    return b, a
+
+
+def _apply_lombard_tilt(
+    mono: np.ndarray,
+    intensity: int | None,
+    sample_rate: int = _TARGET_SR,
+) -> np.ndarray:
+    """Apply a Lombard-effect spectral tilt for I4/I5 turns (#65).
+
+    A high-shelf biquad above ~2.5 kHz boosts the upper formants so the turn
+    sounds like a raised voice rather than a microphone moved closer.  I1–I3
+    pass through unchanged.
+
+    Args:
+        mono: Float mono audio array.
+        intensity: 1–5 intensity level, or None for no tilt.
+        sample_rate: Sample rate in Hz.
+
+    Returns:
+        float32 array with the shelf applied (or *mono* unchanged at low
+        intensity).  No clipping is performed; downstream peak limiting handles
+        amplitude headroom.
+    """
+    if intensity is None:
+        return mono
+    gain_db = _LOMBARD_GAIN_DB.get(intensity)
+    if gain_db is None or len(mono) == 0:
+        return mono
+    b, a = _highshelf_biquad(gain_db, _LOMBARD_SHELF_HZ, sample_rate)
+    return lfilter(b, a, mono).astype(np.float32)
+
+
 def _apply_edge_fades(mono: np.ndarray, n: int = _EDGE_FADE_SAMPLES) -> np.ndarray:
     """Apply linear fade-in and fade-out of *n* samples to eliminate boundary clicks.
 
@@ -90,13 +156,13 @@ class SceneMixer:
 
     def mix_sequential(
         self,
-        segments: list[tuple[bytes, float, str, float | None, MixMode]],
+        segments: list[tuple[bytes, float, str, float | None, MixMode, int | None]],
     ) -> MixedScene:
         """Place segments in the output buffer according to their MixMode.
 
         Args:
             segments: List of (wav_bytes, amount_s, speaker_id,
-                      rms_target_dbfs, mix_mode) 5-tuples.
+                      rms_target_dbfs, mix_mode, intensity) 6-tuples.
                       wav_bytes — valid WAV data (any SR / channels).
                       amount_s — silence gap for SEQUENTIAL; overlap depth for
                         OVERLAP / BARGE_IN (how far back into the previous turn
@@ -105,6 +171,9 @@ class SceneMixer:
                       rms_target_dbfs — if not None, the segment is gain-adjusted
                         so its RMS matches this target (dBFS).
                       mix_mode — placement strategy (MixMode enum).
+                      intensity — turn intensity 1–5 (or None).  Used to drive
+                        the Lombard high-shelf tilt at I4/I5 (#65); ignored
+                        otherwise.
 
         Returns:
             MixedScene with all segments mixed at 16 kHz mono, carrying three
@@ -128,7 +197,7 @@ class SceneMixer:
         render_cursor_s: float = 0.0
         script_cursor_s: float = 0.0
 
-        for wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode in segments:
+        for wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode, intensity in segments:
             # Clamp amount_s: negative values are nonsensical for all mix modes
             # (gap for SEQUENTIAL; overlap depth for OVERLAP / BARGE_IN).
             amount_s = max(0.0, amount_s)
@@ -147,6 +216,10 @@ class SceneMixer:
             # M3: apply per-turn RMS gain before mixing
             if rms_target_dbfs is not None:
                 mono = _apply_rms_gain(mono, rms_target_dbfs)
+
+            # #65: apply Lombard high-shelf tilt at I4/I5 (no-op below I4).
+            # Runs after RMS gain so the boost shapes the already-loud signal.
+            mono = _apply_lombard_tilt(mono, intensity, _TARGET_SR)
 
             # M14: apply fade-in/fade-out to eliminate DC-offset clicks
             mono = _apply_edge_fades(mono.astype(np.float32))

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -1,10 +1,10 @@
 """SceneMixer: concatenate per-speaker TTS WAV segments into a single audio scene.
 
-Each segment is a (wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode,
-intensity) 6-tuple. The mixer decodes WAV bytes using soundfile, resamples to
-16 kHz if needed, applies optional per-turn RMS gain (M3) and a Lombard
-spectral tilt at I4–I5 (#65), then places each turn in the output buffer
-according to its MixMode:
+Each segment is a ``Segment`` dataclass (wav_bytes, amount_s, speaker_id,
+rms_target_dbfs, mix_mode, intensity).  The mixer decodes WAV bytes using
+soundfile, resamples to 16 kHz if needed, applies optional per-turn RMS
+gain (M3) and a Lombard spectral tilt at I4–I5 (#65), then places each turn
+in the output buffer according to its MixMode:
 
   SEQUENTIAL  — insert a silence gap of *amount_s* before this turn (existing behaviour).
   OVERLAP     — start *amount_s* seconds before the previous turn ends; both turns are
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import io
 import math
+from dataclasses import dataclass
 
 import numpy as np
 import soundfile as sf
@@ -49,9 +50,50 @@ _EDGE_FADE_SAMPLES = 160  # 10ms at 16 kHz — eliminates DC-offset clicks at tu
 # #65 Lombard effect: post-TTS spectral tilt at high intensities.
 # Real raised voices boost high-frequency energy; pure amplitude scaling sounds
 # like mic proximity instead of shouting.  Mapping is intentionally narrow —
-# only I4 and I5 get a high-shelf boost, I1–I3 are untouched.
+# only I4 and I5 get a high-shelf boost; all other intensities are untouched.
+# Values are listening-test-derived placeholders (#65); revisit on re-listening.
 _LOMBARD_GAIN_DB: dict[int, float] = {4: 2.0, 5: 3.5}
 _LOMBARD_SHELF_HZ = 2500.0
+
+
+@dataclass
+class Segment:
+    """A single TTS turn ready to be placed on the scene timeline.
+
+    Carries everything ``SceneMixer.mix_sequential`` needs to decode, condition,
+    and position one turn.  Replaces the historical 5/6-element tuple — fields
+    are named so call sites and reviewers can't transpose them.
+
+    Attributes:
+        wav_bytes: Raw WAV (any SR / channels — the mixer downmixes and resamples).
+        amount_s: Silence gap (SEQUENTIAL) or overlap depth (OVERLAP / BARGE_IN).
+        speaker_id: Stored on the resulting MixedScene for labelling.
+        rms_target_dbfs: If not None, the segment is gain-adjusted to this dBFS.
+        mix_mode: Placement strategy.
+        intensity: 1–5 turn intensity.  Drives the Lombard high-shelf at I4/I5
+            (#65); any other value is a no-op.  Defaults to 1 so test fixtures
+            that don't care about Lombard get the natural "no boost" sentinel.
+    """
+
+    wav_bytes: bytes
+    amount_s: float
+    speaker_id: str
+    rms_target_dbfs: float | None
+    mix_mode: MixMode
+    intensity: int = 1
+
+
+def _precompute_lombard_coeffs() -> dict[int, tuple[np.ndarray, np.ndarray]]:
+    """Pre-bake biquad coefficients for every intensity that gets a shelf.
+
+    The coefficients depend only on (gain_db, f0, sample_rate), and we know all
+    three at import time.  Computing once avoids redundant trig in the per-turn
+    hot loop.
+    """
+    return {
+        intensity: _highshelf_biquad(gain_db, _LOMBARD_SHELF_HZ, _TARGET_SR)
+        for intensity, gain_db in _LOMBARD_GAIN_DB.items()
+    }
 
 
 def _apply_rms_gain(mono: np.ndarray, rms_target_dbfs: float) -> np.ndarray:
@@ -103,34 +145,34 @@ def _highshelf_biquad(gain_db: float, f0: float, sample_rate: int) -> tuple[np.n
     return b, a
 
 
-def _apply_lombard_tilt(
-    mono: np.ndarray,
-    intensity: int | None,
-    sample_rate: int = _TARGET_SR,
-) -> np.ndarray:
+def _apply_lombard_tilt(mono: np.ndarray, intensity: int) -> np.ndarray:
     """Apply a Lombard-effect spectral tilt for I4/I5 turns (#65).
 
-    A high-shelf biquad above ~2.5 kHz boosts the upper formants so the turn
-    sounds like a raised voice rather than a microphone moved closer.  I1–I3
-    pass through unchanged.
+    A high-shelf biquad at 2.5 kHz boosts upper formants so the turn sounds
+    like a raised voice rather than a microphone moved closer.  Asymptotic
+    gain is +2.0 dB at I4 and +3.5 dB at I5; at the 2.5 kHz knee the gain is
+    half that.  Any other intensity is a no-op.
+
+    The input *mono* is assumed to be at ``_TARGET_SR`` (16 kHz) — the mixer
+    resamples before this step, so the precomputed biquad coefficients match.
 
     Args:
-        mono: Float mono audio array.
-        intensity: 1–5 intensity level, or None for no tilt.
-        sample_rate: Sample rate in Hz.
+        mono: Float mono audio array at 16 kHz.
+        intensity: 1–5 intensity level.
 
     Returns:
-        float32 array with the shelf applied (or *mono* unchanged at low
-        intensity).  No clipping is performed; downstream peak limiting handles
-        amplitude headroom.
+        float32 array with the shelf applied, or *mono* unchanged when no
+        shelf is defined for this intensity.  No clipping is performed;
+        downstream peak limiting handles amplitude headroom.
     """
-    if intensity is None:
+    coeffs = _LOMBARD_COEFFS.get(intensity)
+    if coeffs is None or len(mono) == 0:
         return mono
-    gain_db = _LOMBARD_GAIN_DB.get(intensity)
-    if gain_db is None or len(mono) == 0:
-        return mono
-    b, a = _highshelf_biquad(gain_db, _LOMBARD_SHELF_HZ, sample_rate)
+    b, a = coeffs
     return lfilter(b, a, mono).astype(np.float32)
+
+
+_LOMBARD_COEFFS: dict[int, tuple[np.ndarray, np.ndarray]] = _precompute_lombard_coeffs()
 
 
 def _apply_edge_fades(mono: np.ndarray, n: int = _EDGE_FADE_SAMPLES) -> np.ndarray:
@@ -154,26 +196,10 @@ def _apply_edge_fades(mono: np.ndarray, n: int = _EDGE_FADE_SAMPLES) -> np.ndarr
 class SceneMixer:
     """Mix a sequence of TTS segments into a single-track 16 kHz scene."""
 
-    def mix_sequential(
-        self,
-        segments: list[tuple[bytes, float, str, float | None, MixMode, int | None]],
-    ) -> MixedScene:
+    def mix_sequential(self, segments: list[Segment]) -> MixedScene:
         """Place segments in the output buffer according to their MixMode.
 
-        Args:
-            segments: List of (wav_bytes, amount_s, speaker_id,
-                      rms_target_dbfs, mix_mode, intensity) 6-tuples.
-                      wav_bytes — valid WAV data (any SR / channels).
-                      amount_s — silence gap for SEQUENTIAL; overlap depth for
-                        OVERLAP / BARGE_IN (how far back into the previous turn
-                        the current turn starts).
-                      speaker_id — stored in the MixedScene for labelling.
-                      rms_target_dbfs — if not None, the segment is gain-adjusted
-                        so its RMS matches this target (dBFS).
-                      mix_mode — placement strategy (MixMode enum).
-                      intensity — turn intensity 1–5 (or None).  Used to drive
-                        the Lombard high-shelf tilt at I4/I5 (#65); ignored
-                        otherwise.
+        See ``Segment`` for the per-turn input fields.
 
         Returns:
             MixedScene with all segments mixed at 16 kHz mono, carrying three
@@ -197,13 +223,13 @@ class SceneMixer:
         render_cursor_s: float = 0.0
         script_cursor_s: float = 0.0
 
-        for wav_bytes, amount_s, speaker_id, rms_target_dbfs, mix_mode, intensity in segments:
+        for seg in segments:
             # Clamp amount_s: negative values are nonsensical for all mix modes
             # (gap for SEQUENTIAL; overlap depth for OVERLAP / BARGE_IN).
-            amount_s = max(0.0, amount_s)
+            amount_s = max(0.0, seg.amount_s)
 
             # --- Decode WAV ---
-            with io.BytesIO(wav_bytes) as buf:
+            with io.BytesIO(seg.wav_bytes) as buf:
                 data, src_sr = sf.read(buf, dtype="float32", always_2d=True)
 
             # Downmix to mono
@@ -214,19 +240,20 @@ class SceneMixer:
                 mono = _resample(mono, src_sr, _TARGET_SR)
 
             # M3: apply per-turn RMS gain before mixing
-            if rms_target_dbfs is not None:
-                mono = _apply_rms_gain(mono, rms_target_dbfs)
+            if seg.rms_target_dbfs is not None:
+                mono = _apply_rms_gain(mono, seg.rms_target_dbfs)
 
             # #65: apply Lombard high-shelf tilt at I4/I5 (no-op below I4).
             # Runs after RMS gain so the boost shapes the already-loud signal.
-            mono = _apply_lombard_tilt(mono, intensity, _TARGET_SR)
+            mono = _apply_lombard_tilt(mono, seg.intensity)
 
-            # M14: apply fade-in/fade-out to eliminate DC-offset clicks
+            # M14: apply fade-in/fade-out to eliminate DC-offset clicks.
+            # The fade-in also masks the lfilter transient introduced by Lombard.
             mono = _apply_edge_fades(mono.astype(np.float32))
             seg_duration_s = len(mono) / _TARGET_SR
 
             # --- Determine onset position ---
-            if mix_mode == MixMode.SEQUENTIAL:
+            if seg.mix_mode == MixMode.SEQUENTIAL:
                 gap_s = amount_s
                 onset_s = render_cursor_s + gap_s
                 script_onset_s = script_cursor_s + gap_s
@@ -254,7 +281,7 @@ class SceneMixer:
             offset_s = float(onset_sample + len(mono)) / _TARGET_SR
 
             # --- BARGE_IN: truncate the previous segment at the barge-in point ---
-            if mix_mode == MixMode.BARGE_IN and placed:
+            if seg.mix_mode == MixMode.BARGE_IN and placed:
                 prev_mono, prev_onset_sample = placed[-1]
                 max_samples = onset_sample - prev_onset_sample
                 if max_samples <= 0:
@@ -289,8 +316,8 @@ class SceneMixer:
             rendered_offsets.append(offset_s)
             audible_onsets.append(onset_s)
             audible_ends.append(offset_s)
-            speaker_ids.append(speaker_id)
-            mix_modes.append(mix_mode.value)
+            speaker_ids.append(seg.speaker_id)
+            mix_modes.append(seg.mix_mode.value)
 
         # --- Build output buffer ---
         if placed:

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -21,7 +21,6 @@ from synthbanshee.config.speaker_config import SpeakerConfig
 if TYPE_CHECKING:
     from synthbanshee.config.project_profile import ProjectProfile
 from synthbanshee.script.types import DialogueTurn, MixedScene
-from synthbanshee.tts.mix_mode import MixMode
 from synthbanshee.tts.provider import TTSProvider
 from synthbanshee.tts.quality_gates import run_quality_gates
 from synthbanshee.tts.speaker_state import SpeakerState
@@ -264,7 +263,7 @@ class TTSRenderer:
 
         from synthbanshee.script.generator import inject_disfluency
         from synthbanshee.tts.gap_controller import TurnGapController
-        from synthbanshee.tts.mixer import SceneMixer
+        from synthbanshee.tts.mixer import SceneMixer, Segment
 
         rng = random.Random(rng_seed)
         # Separate gap RNG (same seed, isolated stream) so that enabling/
@@ -280,7 +279,7 @@ class TTSRenderer:
         # M7: one SpeakerState per speaker; starts neutral, updated after each turn.
         states: dict[str, SpeakerState] = {sid: SpeakerState() for sid in speakers}
 
-        segments: list[tuple[bytes, float, str, float | None, MixMode, int | None]] = []
+        segments: list[Segment] = []
         prev_turn: DialogueTurn | None = None
         for i, turn in enumerate(turns):
             speaker = speakers[turn.speaker_id]
@@ -375,13 +374,13 @@ class TTSRenderer:
                 elif speaker.role == "VIC":
                     rms_target = project_profile.loudness.vic_rms_dbfs
             segments.append(
-                (
-                    wav_bytes,
-                    gap_s,
-                    turn.speaker_id,
-                    rms_target,
-                    mix_mode,
-                    turn.intensity,
+                Segment(
+                    wav_bytes=wav_bytes,
+                    amount_s=gap_s,
+                    speaker_id=turn.speaker_id,
+                    rms_target_dbfs=rms_target,
+                    mix_mode=mix_mode,
+                    intensity=turn.intensity,
                 )
             )
             prev_turn = turn

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -280,7 +280,7 @@ class TTSRenderer:
         # M7: one SpeakerState per speaker; starts neutral, updated after each turn.
         states: dict[str, SpeakerState] = {sid: SpeakerState() for sid in speakers}
 
-        segments: list[tuple[bytes, float, str, float | None, MixMode]] = []
+        segments: list[tuple[bytes, float, str, float | None, MixMode, int | None]] = []
         prev_turn: DialogueTurn | None = None
         for i, turn in enumerate(turns):
             speaker = speakers[turn.speaker_id]
@@ -381,6 +381,7 @@ class TTSRenderer:
                     turn.speaker_id,
                     rms_target,
                     mix_mode,
+                    turn.intensity,
                 )
             )
             prev_turn = turn

--- a/tests/integration/test_multi_speaker.py
+++ b/tests/integration/test_multi_speaker.py
@@ -19,7 +19,7 @@ from synthbanshee.labels.generator import LabelGenerator, ScriptEvent
 from synthbanshee.script.types import DialogueTurn, MixedScene
 from synthbanshee.tts.azure_provider import AzureProvider
 from synthbanshee.tts.mix_mode import MixMode
-from synthbanshee.tts.mixer import SceneMixer
+from synthbanshee.tts.mixer import SceneMixer, Segment
 from synthbanshee.tts.renderer import TTSRenderer
 
 EXAMPLES_DIR = Path(__file__).parent.parent.parent / "configs" / "examples"
@@ -229,9 +229,9 @@ class TestOverlapLabelIntegration:
         mixer = SceneMixer()
         wav = _make_wav_bytes_16k(duration_s=2.0)
         segments = [
-            (wav, 0.3, "SPK_A", None, MixMode.SEQUENTIAL, None),
-            (wav, 0.3, "SPK_B", None, MixMode.SEQUENTIAL, None),
-            (wav, 0.4, "SPK_A", None, mix_mode_third, None),
+            Segment(wav, 0.3, "SPK_A", None, MixMode.SEQUENTIAL),
+            Segment(wav, 0.3, "SPK_B", None, MixMode.SEQUENTIAL),
+            Segment(wav, 0.4, "SPK_A", None, mix_mode_third),
         ]
         return mixer.mix_sequential(segments)
 

--- a/tests/integration/test_multi_speaker.py
+++ b/tests/integration/test_multi_speaker.py
@@ -229,9 +229,9 @@ class TestOverlapLabelIntegration:
         mixer = SceneMixer()
         wav = _make_wav_bytes_16k(duration_s=2.0)
         segments = [
-            (wav, 0.3, "SPK_A", None, MixMode.SEQUENTIAL),
-            (wav, 0.3, "SPK_B", None, MixMode.SEQUENTIAL),
-            (wav, 0.4, "SPK_A", None, mix_mode_third),
+            (wav, 0.3, "SPK_A", None, MixMode.SEQUENTIAL, None),
+            (wav, 0.3, "SPK_B", None, MixMode.SEQUENTIAL, None),
+            (wav, 0.4, "SPK_A", None, mix_mode_third, None),
         ]
         return mixer.mix_sequential(segments)
 

--- a/tests/unit/test_generation_metadata.py
+++ b/tests/unit/test_generation_metadata.py
@@ -180,7 +180,7 @@ class TestMixedSceneMixModes:
         import soundfile as sf
 
         from synthbanshee.tts.mix_mode import MixMode
-        from synthbanshee.tts.mixer import SceneMixer
+        from synthbanshee.tts.mixer import SceneMixer, Segment
 
         mono = np.zeros(1600, dtype=np.float32)  # 0.1s at 16kHz
         buf = io.BytesIO()
@@ -189,9 +189,9 @@ class TestMixedSceneMixModes:
 
         mixer = SceneMixer()
         segments = [
-            (wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL, None),
-            (wav_bytes, 0.05, "spk_b", None, MixMode.OVERLAP, None),
-            (wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL, None),
+            Segment(wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL),
+            Segment(wav_bytes, 0.05, "spk_b", None, MixMode.OVERLAP),
+            Segment(wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL),
         ]
         scene = mixer.mix_sequential(segments)
         assert scene.mix_modes == ["sequential", "overlap", "sequential"]

--- a/tests/unit/test_generation_metadata.py
+++ b/tests/unit/test_generation_metadata.py
@@ -189,9 +189,9 @@ class TestMixedSceneMixModes:
 
         mixer = SceneMixer()
         segments = [
-            (wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL),
-            (wav_bytes, 0.05, "spk_b", None, MixMode.OVERLAP),
-            (wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL),
+            (wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL, None),
+            (wav_bytes, 0.05, "spk_b", None, MixMode.OVERLAP, None),
+            (wav_bytes, 0.0, "spk_a", None, MixMode.SEQUENTIAL, None),
         ]
         scene = mixer.mix_sequential(segments)
         assert scene.mix_modes == ["sequential", "overlap", "sequential"]

--- a/tests/unit/test_mixer.py
+++ b/tests/unit/test_mixer.py
@@ -12,6 +12,7 @@ from synthbanshee.tts.mixer import (
     _TARGET_SR,
     MixMode,
     SceneMixer,
+    Segment,
     _apply_edge_fades,
     _apply_lombard_tilt,
     _apply_rms_gain,
@@ -74,7 +75,7 @@ class TestSceneMixer:
     def test_single_segment_no_pause(self):
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL, None)])
+        result = mixer.mix_sequential([Segment(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
 
         assert result.sample_rate == _TARGET_SR
         assert len(result.turn_onsets_s) == 1
@@ -87,7 +88,7 @@ class TestSceneMixer:
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         pause_s = 0.3
-        result = mixer.mix_sequential([(wav, pause_s, "SPK_001", None, MixMode.SEQUENTIAL, None)])
+        result = mixer.mix_sequential([Segment(wav, pause_s, "SPK_001", None, MixMode.SEQUENTIAL)])
 
         assert result.turn_onsets_s[0] == pytest.approx(pause_s, abs=0.01)
         assert result.duration_s == pytest.approx(pause_s + 0.5, abs=0.05)
@@ -98,8 +99,8 @@ class TestSceneMixer:
         wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "SPK_A", None, MixMode.SEQUENTIAL, None),
-                (wav2, 0.2, "SPK_B", None, MixMode.SEQUENTIAL, None),
+                Segment(wav1, 0.0, "SPK_A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, 0.2, "SPK_B", None, MixMode.SEQUENTIAL),
             ]
         )
 
@@ -112,29 +113,26 @@ class TestSceneMixer:
     def test_total_duration_matches_samples(self):
         mixer = SceneMixer()
         segments = [
-            (
+            Segment(
                 _sine_wav_bytes(duration_s=0.8, sample_rate=_TARGET_SR),
                 0.1,
                 "S1",
                 None,
                 MixMode.SEQUENTIAL,
-                None,
             ),
-            (
+            Segment(
                 _sine_wav_bytes(duration_s=0.6, sample_rate=_TARGET_SR),
                 0.2,
                 "S2",
                 None,
                 MixMode.SEQUENTIAL,
-                None,
             ),
-            (
+            Segment(
                 _sine_wav_bytes(duration_s=0.4, sample_rate=_TARGET_SR),
                 0.15,
                 "S3",
                 None,
                 MixMode.SEQUENTIAL,
-                None,
             ),
         ]
         result = mixer.mix_sequential(segments)
@@ -145,7 +143,7 @@ class TestSceneMixer:
         """Mixer should downsample 24 kHz input to 16 kHz output."""
         mixer = SceneMixer()
         wav_24k = _sine_wav_bytes(duration_s=0.5, sample_rate=24000)
-        result = mixer.mix_sequential([(wav_24k, 0.0, "SPK_001", None, MixMode.SEQUENTIAL, None)])
+        result = mixer.mix_sequential([Segment(wav_24k, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
 
         assert result.sample_rate == _TARGET_SR
         # Duration should still be approximately 0.5 s
@@ -155,7 +153,7 @@ class TestSceneMixer:
         mixer = SceneMixer()
         stereo_wav = _stereo_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
-            [(stereo_wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL, None)]
+            [Segment(stereo_wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)]
         )
 
         assert result.samples.ndim == 1
@@ -164,27 +162,25 @@ class TestSceneMixer:
     def test_output_samples_are_float32(self):
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL, None)])
+        result = mixer.mix_sequential([Segment(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
         assert result.samples.dtype == np.float32
 
     def test_offsets_greater_than_onsets(self):
         mixer = SceneMixer()
         segments = [
-            (
+            Segment(
                 _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR),
                 0.1,
                 "S1",
                 None,
                 MixMode.SEQUENTIAL,
-                None,
             ),
-            (
+            Segment(
                 _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR),
                 0.2,
                 "S2",
                 None,
                 MixMode.SEQUENTIAL,
-                None,
             ),
         ]
         result = mixer.mix_sequential(segments)
@@ -240,7 +236,7 @@ class TestRmsGainInMixer:
         """Passing None for rms_target_dbfs must not alter the signal level."""
         wav = _sine_wav_bytes(amplitude=0.1, duration_s=1.0, sample_rate=_TARGET_SR)
         mixer = SceneMixer()
-        result = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, None)])
+        result = mixer.mix_sequential([Segment(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL)])
         # RMS of 0.1-amplitude sine = 0.1/sqrt(2) ≈ −23 dBFS; allow ±2 dB
         assert self._rms_dbfs(result.samples) == pytest.approx(-23.0, abs=2.0)
 
@@ -249,7 +245,7 @@ class TestRmsGainInMixer:
         wav = _sine_wav_bytes(amplitude=0.02, duration_s=1.0, sample_rate=_TARGET_SR)
         mixer = SceneMixer()
         target = -20.0
-        result = mixer.mix_sequential([(wav, 0.0, "SPK", target, MixMode.SEQUENTIAL, None)])
+        result = mixer.mix_sequential([Segment(wav, 0.0, "SPK", target, MixMode.SEQUENTIAL)])
         assert self._rms_dbfs(result.samples) == pytest.approx(target, abs=0.5)
 
     def test_escalation_across_two_segments(self):
@@ -259,8 +255,8 @@ class TestRmsGainInMixer:
         mixer = SceneMixer()
         result = mixer.mix_sequential(
             [
-                (wav_quiet, 0.0, "AGG", -28.0, MixMode.SEQUENTIAL, None),
-                (wav_loud, 0.0, "AGG", -15.0, MixMode.SEQUENTIAL, None),
+                Segment(wav_quiet, 0.0, "AGG", -28.0, MixMode.SEQUENTIAL),
+                Segment(wav_loud, 0.0, "AGG", -15.0, MixMode.SEQUENTIAL),
             ]
         )
         # Verify combined duration is correct
@@ -289,8 +285,8 @@ class TestOverlapMixing:
         wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "AGG", None, MixMode.SEQUENTIAL, None),
-                (wav2, overlap_s, "VIC", None, MixMode.OVERLAP, None),
+                Segment(wav1, 0.0, "AGG", None, MixMode.SEQUENTIAL),
+                Segment(wav2, overlap_s, "VIC", None, MixMode.OVERLAP),
             ]
         )
         # rendered onset of turn 2 should be dur - overlap_s
@@ -306,14 +302,14 @@ class TestOverlapMixing:
 
         seq_result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
-                (wav2, 0.0, "B", None, MixMode.SEQUENTIAL, None),
+                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, 0.0, "B", None, MixMode.SEQUENTIAL),
             ]
         )
         olap_result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
-                (wav2, overlap_s, "B", None, MixMode.OVERLAP, None),
+                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, overlap_s, "B", None, MixMode.OVERLAP),
             ]
         )
         assert olap_result.duration_s < seq_result.duration_s
@@ -328,8 +324,8 @@ class TestOverlapMixing:
 
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
-                (wav2, overlap_s, "B", None, MixMode.OVERLAP, None),
+                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, overlap_s, "B", None, MixMode.OVERLAP),
             ]
         )
         # The overlap region lies between rendered_onsets_s[1] and rendered_offsets_s[0].
@@ -350,8 +346,8 @@ class TestOverlapMixing:
 
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
-                (wav2, barge_depth, "B", None, MixMode.BARGE_IN, None),
+                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, barge_depth, "B", None, MixMode.BARGE_IN),
             ]
         )
         # After COPILOT-6: rendered_offsets_s is updated to the truncation point,
@@ -371,8 +367,8 @@ class TestOverlapMixing:
         wav2 = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
-                (wav2, 0.3, "B", None, MixMode.BARGE_IN, None),
+                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, 0.3, "B", None, MixMode.BARGE_IN),
             ]
         )
         assert result.audible_ends_s[0] == pytest.approx(result.rendered_onsets_s[1], abs=1e-4)
@@ -383,8 +379,8 @@ class TestOverlapMixing:
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav, 0.1, "A", None, MixMode.SEQUENTIAL, None),
-                (wav, 0.2, "B", None, MixMode.SEQUENTIAL, None),
+                Segment(wav, 0.1, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav, 0.2, "B", None, MixMode.SEQUENTIAL),
             ]
         )
         for attr in (
@@ -404,8 +400,8 @@ class TestOverlapMixing:
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav, 0.1, "A", None, MixMode.SEQUENTIAL, None),
-                (wav, 0.2, "B", None, MixMode.SEQUENTIAL, None),
+                Segment(wav, 0.1, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav, 0.2, "B", None, MixMode.SEQUENTIAL),
             ]
         )
         for i in range(2):
@@ -421,8 +417,8 @@ class TestOverlapMixing:
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav, 0.0, "A", None, MixMode.SEQUENTIAL, None),
-                (wav, 0.3, "B", None, MixMode.OVERLAP, None),
+                Segment(wav, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav, 0.3, "B", None, MixMode.OVERLAP),
             ]
         )
         assert result.turn_onsets_s == result.audible_onsets_s
@@ -433,7 +429,7 @@ class TestOverlapMixing:
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
         # amount_s would push onset to render_cursor_s(0) - 0.5 = -0.5 → clamped to 0.
-        result = mixer.mix_sequential([(wav, 0.5, "A", None, MixMode.OVERLAP, None)])
+        result = mixer.mix_sequential([Segment(wav, 0.5, "A", None, MixMode.OVERLAP)])
         assert result.rendered_onsets_s[0] == pytest.approx(0.0, abs=1e-4)
         assert result.duration_s == pytest.approx(1.0, abs=0.05)
 
@@ -441,7 +437,7 @@ class TestOverlapMixing:
         """BARGE_IN as first segment (no previous turn in buffer) must clamp onset to ≥ 0."""
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.5, "A", None, MixMode.BARGE_IN, None)])
+        result = mixer.mix_sequential([Segment(wav, 0.5, "A", None, MixMode.BARGE_IN)])
         assert result.rendered_onsets_s[0] == pytest.approx(0.0, abs=1e-4)
 
     def test_barge_in_full_depth_truncates_entirely(self):
@@ -452,8 +448,8 @@ class TestOverlapMixing:
         # overlap depth (1.0) > prev duration (0.5): onset_sample == prev_onset_sample → max_samples == 0.
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
-                (wav2, 1.0, "B", None, MixMode.BARGE_IN, None),
+                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, 1.0, "B", None, MixMode.BARGE_IN),
             ]
         )
         # The interrupted turn's audible end should collapse to its onset.
@@ -468,8 +464,8 @@ class TestOverlapMixing:
         # amount_s=0 → onset is clamped to prev_offset_s → max_samples == len(prev_mono) → no truncation.
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
-                (wav2, 0.0, "B", None, MixMode.BARGE_IN, None),
+                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, 0.0, "B", None, MixMode.BARGE_IN),
             ]
         )
         # Previous turn plays its full duration (audible end == script end).
@@ -531,7 +527,12 @@ class TestApplyEdgeFades:
 # ---------------------------------------------------------------------------
 
 
-def _hf_lf_band_ratio(samples: np.ndarray, sr: int, split_hz: float = 2500.0) -> float:
+# 3500 Hz sits clearly above the 2.5 kHz shelf knee and inside the asymptotic-gain
+# region of the high-shelf, so HF/LF band ratios actually reflect the boost.
+_HF_LF_SPLIT_HZ = 3500.0
+
+
+def _hf_lf_band_ratio(samples: np.ndarray, sr: int, split_hz: float = _HF_LF_SPLIT_HZ) -> float:
     """Energy in the >split_hz band divided by energy in the <split_hz band."""
     spectrum = np.abs(np.fft.rfft(samples))
     freqs = np.fft.rfftfreq(len(samples), d=1.0 / sr)
@@ -546,46 +547,62 @@ def _white_noise(n: int, seed: int = 0, amp: float = 0.1) -> np.ndarray:
     return (amp * rng.standard_normal(n)).astype(np.float32)
 
 
+def _noise_wav_bytes(seed: int = 1, duration_s: float = 1.0) -> bytes:
+    """Return WAV bytes for white noise — broadband enough for spectral tests."""
+    n = int(_TARGET_SR * duration_s)
+    samples = (_white_noise(n, seed=seed) * 32767).astype(np.int16)
+    buf = io.BytesIO()
+    with wave.open(buf, "w") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(_TARGET_SR)
+        w.writeframes(samples.tobytes())
+    return buf.getvalue()
+
+
 class TestLombardTilt:
     """Tests for _apply_lombard_tilt (#65)."""
 
     def test_low_intensity_passes_through(self):
-        """I1–I3 must leave the signal bit-exact."""
+        """I1–I3 must leave the signal bit-exact (object identity, no copy)."""
         signal = _white_noise(8000)
         for intensity in (1, 2, 3):
-            out = _apply_lombard_tilt(signal, intensity, _TARGET_SR)
+            out = _apply_lombard_tilt(signal, intensity)
             np.testing.assert_array_equal(out, signal)
 
-    def test_none_intensity_passes_through(self):
-        """intensity=None must leave the signal unchanged."""
+    def test_unmapped_intensity_passes_through(self):
+        """Out-of-range intensities (e.g. 0, 6, -1) must no-op rather than crash."""
         signal = _white_noise(8000)
-        out = _apply_lombard_tilt(signal, None, _TARGET_SR)
-        np.testing.assert_array_equal(out, signal)
+        for intensity in (-1, 0, 6, 99):
+            out = _apply_lombard_tilt(signal, intensity)
+            np.testing.assert_array_equal(out, signal)
 
     def test_i5_boosts_high_frequencies(self):
-        """I5 must raise the >2.5 kHz / <2.5 kHz energy ratio vs. I1."""
+        """I5 must materially raise the >3.5 kHz / <3.5 kHz energy ratio."""
         signal = _white_noise(_TARGET_SR)  # 1 second of band-flat noise
         baseline_ratio = _hf_lf_band_ratio(signal, _TARGET_SR)
-        i5 = _apply_lombard_tilt(signal, 5, _TARGET_SR)
+        i5 = _apply_lombard_tilt(signal, 5)
         i5_ratio = _hf_lf_band_ratio(i5, _TARGET_SR)
-        # +3.5 dB shelf → HF/LF ratio should rise by ≥ 50 % in linear power.
+        # +3.5 dB asymptotic shelf yields a power factor ≈ 2.24× *deep* in the HF
+        # band, blended with partial-gain energy near the 2.5 kHz knee.  The
+        # whole-band HF/LF ratio rises by ~1.7× — assert ≥ 1.5× for margin.
         assert i5_ratio > 1.5 * baseline_ratio
 
     def test_i5_boost_exceeds_i4(self):
         """The I5 shelf must raise HF energy more than the I4 shelf."""
         signal = _white_noise(_TARGET_SR)
-        i4 = _apply_lombard_tilt(signal, 4, _TARGET_SR)
-        i5 = _apply_lombard_tilt(signal, 5, _TARGET_SR)
+        i4 = _apply_lombard_tilt(signal, 4)
+        i5 = _apply_lombard_tilt(signal, 5)
         assert _hf_lf_band_ratio(i5, _TARGET_SR) > _hf_lf_band_ratio(i4, _TARGET_SR)
 
     def test_returns_float32(self):
         signal = _white_noise(4000)
-        out = _apply_lombard_tilt(signal, 5, _TARGET_SR)
+        out = _apply_lombard_tilt(signal, 5)
         assert out.dtype == np.float32
 
     def test_empty_array_no_crash(self):
         empty = np.zeros(0, dtype=np.float32)
-        out = _apply_lombard_tilt(empty, 5, _TARGET_SR)
+        out = _apply_lombard_tilt(empty, 5)
         assert len(out) == 0
 
     def test_low_band_largely_preserved(self):
@@ -594,50 +611,48 @@ class TestLombardTilt:
         n = _TARGET_SR
         t = np.arange(n) / _TARGET_SR
         signal = (0.3 * np.sin(2 * np.pi * 200.0 * t)).astype(np.float32)
-        out = _apply_lombard_tilt(signal, 5, _TARGET_SR)
-        # Skip the filter's transient by trimming the first 200 samples.
-        in_rms = float(np.sqrt(np.mean(signal[200:] ** 2)))
-        out_rms = float(np.sqrt(np.mean(out[200:] ** 2)))
+        out = _apply_lombard_tilt(signal, 5)
+        # Skip the filter's startup transient (~50 ms at 16 kHz).
+        skip = 800
+        in_rms = float(np.sqrt(np.mean(signal[skip:] ** 2)))
+        out_rms = float(np.sqrt(np.mean(out[skip:] ** 2)))
         assert out_rms == pytest.approx(in_rms, rel=0.1)
 
 
 class TestLombardInMixer:
-    """Integration: intensity 6th-tuple element drives Lombard tilt in mix_sequential."""
+    """Integration: Segment.intensity drives Lombard tilt in mix_sequential."""
 
     def test_i5_segment_has_more_hf_than_i1(self):
         """A scene rendered at I5 has a higher HF/LF ratio than the same scene at I1."""
-        wav = _sine_wav_bytes(freq=440, duration_s=1.0, sample_rate=_TARGET_SR)
-        # Replace the sine with broadband noise so the spectral change is observable.
-        noise = _white_noise(_TARGET_SR, seed=1)
-        buf = io.BytesIO()
-        with wave.open(buf, "w") as w:
-            w.setnchannels(1)
-            w.setsampwidth(2)
-            w.setframerate(_TARGET_SR)
-            w.writeframes((noise * 32767).astype(np.int16).tobytes())
-        wav = buf.getvalue()
-
+        wav = _noise_wav_bytes()
         mixer = SceneMixer()
-        i1_scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, 1)])
-        i5_scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, 5)])
-
+        i1_scene = mixer.mix_sequential(
+            [Segment(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, intensity=1)]
+        )
+        i5_scene = mixer.mix_sequential(
+            [Segment(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, intensity=5)]
+        )
         i1_ratio = _hf_lf_band_ratio(i1_scene.samples, _TARGET_SR)
         i5_ratio = _hf_lf_band_ratio(i5_scene.samples, _TARGET_SR)
-        assert i5_ratio > i1_ratio * 1.4
+        assert i5_ratio > i1_ratio * 1.6
 
-    def test_intensity_none_does_not_alter_signal(self):
-        """intensity=None must leave the signal unchanged vs. an I1 baseline."""
+    def test_default_intensity_does_not_alter_signal(self):
+        """Omitting intensity (default I1) must produce the same waveform as explicit I1."""
         wav = _sine_wav_bytes(freq=440, duration_s=0.5, sample_rate=_TARGET_SR)
         mixer = SceneMixer()
-        none_scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, None)])
-        i1_scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, 1)])
-        np.testing.assert_allclose(none_scene.samples, i1_scene.samples, atol=1e-6)
+        default_scene = mixer.mix_sequential([Segment(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL)])
+        i1_scene = mixer.mix_sequential(
+            [Segment(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, intensity=1)]
+        )
+        np.testing.assert_allclose(default_scene.samples, i1_scene.samples, atol=1e-6)
 
     def test_i5_does_not_clip_typical_signal(self):
         """A typical-amplitude turn at I5 must stay within the unity-amplitude budget."""
         wav = _sine_wav_bytes(freq=1000, duration_s=0.5, amplitude=0.3, sample_rate=_TARGET_SR)
         mixer = SceneMixer()
-        scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, 5)])
+        scene = mixer.mix_sequential(
+            [Segment(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, intensity=5)]
+        )
         # Lombard adds +3.5 dB above 2.5 kHz; 1 kHz is under the shelf so the
         # peak should remain comfortably below 1.0 — preprocessing's peak
         # limiter handles the few dB of ceiling that may be needed.

--- a/tests/unit/test_mixer.py
+++ b/tests/unit/test_mixer.py
@@ -13,6 +13,7 @@ from synthbanshee.tts.mixer import (
     MixMode,
     SceneMixer,
     _apply_edge_fades,
+    _apply_lombard_tilt,
     _apply_rms_gain,
 )
 
@@ -73,7 +74,7 @@ class TestSceneMixer:
     def test_single_segment_no_pause(self):
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL, None)])
 
         assert result.sample_rate == _TARGET_SR
         assert len(result.turn_onsets_s) == 1
@@ -86,7 +87,7 @@ class TestSceneMixer:
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         pause_s = 0.3
-        result = mixer.mix_sequential([(wav, pause_s, "SPK_001", None, MixMode.SEQUENTIAL)])
+        result = mixer.mix_sequential([(wav, pause_s, "SPK_001", None, MixMode.SEQUENTIAL, None)])
 
         assert result.turn_onsets_s[0] == pytest.approx(pause_s, abs=0.01)
         assert result.duration_s == pytest.approx(pause_s + 0.5, abs=0.05)
@@ -97,8 +98,8 @@ class TestSceneMixer:
         wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "SPK_A", None, MixMode.SEQUENTIAL),
-                (wav2, 0.2, "SPK_B", None, MixMode.SEQUENTIAL),
+                (wav1, 0.0, "SPK_A", None, MixMode.SEQUENTIAL, None),
+                (wav2, 0.2, "SPK_B", None, MixMode.SEQUENTIAL, None),
             ]
         )
 
@@ -117,6 +118,7 @@ class TestSceneMixer:
                 "S1",
                 None,
                 MixMode.SEQUENTIAL,
+                None,
             ),
             (
                 _sine_wav_bytes(duration_s=0.6, sample_rate=_TARGET_SR),
@@ -124,6 +126,7 @@ class TestSceneMixer:
                 "S2",
                 None,
                 MixMode.SEQUENTIAL,
+                None,
             ),
             (
                 _sine_wav_bytes(duration_s=0.4, sample_rate=_TARGET_SR),
@@ -131,6 +134,7 @@ class TestSceneMixer:
                 "S3",
                 None,
                 MixMode.SEQUENTIAL,
+                None,
             ),
         ]
         result = mixer.mix_sequential(segments)
@@ -141,7 +145,7 @@ class TestSceneMixer:
         """Mixer should downsample 24 kHz input to 16 kHz output."""
         mixer = SceneMixer()
         wav_24k = _sine_wav_bytes(duration_s=0.5, sample_rate=24000)
-        result = mixer.mix_sequential([(wav_24k, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
+        result = mixer.mix_sequential([(wav_24k, 0.0, "SPK_001", None, MixMode.SEQUENTIAL, None)])
 
         assert result.sample_rate == _TARGET_SR
         # Duration should still be approximately 0.5 s
@@ -150,7 +154,9 @@ class TestSceneMixer:
     def test_downmixes_stereo_to_mono(self):
         mixer = SceneMixer()
         stereo_wav = _stereo_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(stereo_wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
+        result = mixer.mix_sequential(
+            [(stereo_wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL, None)]
+        )
 
         assert result.samples.ndim == 1
         assert result.duration_s == pytest.approx(1.0, abs=0.05)
@@ -158,7 +164,7 @@ class TestSceneMixer:
     def test_output_samples_are_float32(self):
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL)])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK_001", None, MixMode.SEQUENTIAL, None)])
         assert result.samples.dtype == np.float32
 
     def test_offsets_greater_than_onsets(self):
@@ -170,6 +176,7 @@ class TestSceneMixer:
                 "S1",
                 None,
                 MixMode.SEQUENTIAL,
+                None,
             ),
             (
                 _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR),
@@ -177,6 +184,7 @@ class TestSceneMixer:
                 "S2",
                 None,
                 MixMode.SEQUENTIAL,
+                None,
             ),
         ]
         result = mixer.mix_sequential(segments)
@@ -232,7 +240,7 @@ class TestRmsGainInMixer:
         """Passing None for rms_target_dbfs must not alter the signal level."""
         wav = _sine_wav_bytes(amplitude=0.1, duration_s=1.0, sample_rate=_TARGET_SR)
         mixer = SceneMixer()
-        result = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL)])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, None)])
         # RMS of 0.1-amplitude sine = 0.1/sqrt(2) ≈ −23 dBFS; allow ±2 dB
         assert self._rms_dbfs(result.samples) == pytest.approx(-23.0, abs=2.0)
 
@@ -241,7 +249,7 @@ class TestRmsGainInMixer:
         wav = _sine_wav_bytes(amplitude=0.02, duration_s=1.0, sample_rate=_TARGET_SR)
         mixer = SceneMixer()
         target = -20.0
-        result = mixer.mix_sequential([(wav, 0.0, "SPK", target, MixMode.SEQUENTIAL)])
+        result = mixer.mix_sequential([(wav, 0.0, "SPK", target, MixMode.SEQUENTIAL, None)])
         assert self._rms_dbfs(result.samples) == pytest.approx(target, abs=0.5)
 
     def test_escalation_across_two_segments(self):
@@ -251,8 +259,8 @@ class TestRmsGainInMixer:
         mixer = SceneMixer()
         result = mixer.mix_sequential(
             [
-                (wav_quiet, 0.0, "AGG", -28.0, MixMode.SEQUENTIAL),
-                (wav_loud, 0.0, "AGG", -15.0, MixMode.SEQUENTIAL),
+                (wav_quiet, 0.0, "AGG", -28.0, MixMode.SEQUENTIAL, None),
+                (wav_loud, 0.0, "AGG", -15.0, MixMode.SEQUENTIAL, None),
             ]
         )
         # Verify combined duration is correct
@@ -281,8 +289,8 @@ class TestOverlapMixing:
         wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "AGG", None, MixMode.SEQUENTIAL),
-                (wav2, overlap_s, "VIC", None, MixMode.OVERLAP),
+                (wav1, 0.0, "AGG", None, MixMode.SEQUENTIAL, None),
+                (wav2, overlap_s, "VIC", None, MixMode.OVERLAP, None),
             ]
         )
         # rendered onset of turn 2 should be dur - overlap_s
@@ -298,14 +306,14 @@ class TestOverlapMixing:
 
         seq_result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
-                (wav2, 0.0, "B", None, MixMode.SEQUENTIAL),
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
+                (wav2, 0.0, "B", None, MixMode.SEQUENTIAL, None),
             ]
         )
         olap_result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
-                (wav2, overlap_s, "B", None, MixMode.OVERLAP),
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
+                (wav2, overlap_s, "B", None, MixMode.OVERLAP, None),
             ]
         )
         assert olap_result.duration_s < seq_result.duration_s
@@ -320,8 +328,8 @@ class TestOverlapMixing:
 
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
-                (wav2, overlap_s, "B", None, MixMode.OVERLAP),
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
+                (wav2, overlap_s, "B", None, MixMode.OVERLAP, None),
             ]
         )
         # The overlap region lies between rendered_onsets_s[1] and rendered_offsets_s[0].
@@ -342,8 +350,8 @@ class TestOverlapMixing:
 
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
-                (wav2, barge_depth, "B", None, MixMode.BARGE_IN),
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
+                (wav2, barge_depth, "B", None, MixMode.BARGE_IN, None),
             ]
         )
         # After COPILOT-6: rendered_offsets_s is updated to the truncation point,
@@ -363,8 +371,8 @@ class TestOverlapMixing:
         wav2 = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
-                (wav2, 0.3, "B", None, MixMode.BARGE_IN),
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
+                (wav2, 0.3, "B", None, MixMode.BARGE_IN, None),
             ]
         )
         assert result.audible_ends_s[0] == pytest.approx(result.rendered_onsets_s[1], abs=1e-4)
@@ -375,8 +383,8 @@ class TestOverlapMixing:
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav, 0.1, "A", None, MixMode.SEQUENTIAL),
-                (wav, 0.2, "B", None, MixMode.SEQUENTIAL),
+                (wav, 0.1, "A", None, MixMode.SEQUENTIAL, None),
+                (wav, 0.2, "B", None, MixMode.SEQUENTIAL, None),
             ]
         )
         for attr in (
@@ -396,8 +404,8 @@ class TestOverlapMixing:
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav, 0.1, "A", None, MixMode.SEQUENTIAL),
-                (wav, 0.2, "B", None, MixMode.SEQUENTIAL),
+                (wav, 0.1, "A", None, MixMode.SEQUENTIAL, None),
+                (wav, 0.2, "B", None, MixMode.SEQUENTIAL, None),
             ]
         )
         for i in range(2):
@@ -413,8 +421,8 @@ class TestOverlapMixing:
         wav = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
         result = mixer.mix_sequential(
             [
-                (wav, 0.0, "A", None, MixMode.SEQUENTIAL),
-                (wav, 0.3, "B", None, MixMode.OVERLAP),
+                (wav, 0.0, "A", None, MixMode.SEQUENTIAL, None),
+                (wav, 0.3, "B", None, MixMode.OVERLAP, None),
             ]
         )
         assert result.turn_onsets_s == result.audible_onsets_s
@@ -425,7 +433,7 @@ class TestOverlapMixing:
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
         # amount_s would push onset to render_cursor_s(0) - 0.5 = -0.5 → clamped to 0.
-        result = mixer.mix_sequential([(wav, 0.5, "A", None, MixMode.OVERLAP)])
+        result = mixer.mix_sequential([(wav, 0.5, "A", None, MixMode.OVERLAP, None)])
         assert result.rendered_onsets_s[0] == pytest.approx(0.0, abs=1e-4)
         assert result.duration_s == pytest.approx(1.0, abs=0.05)
 
@@ -433,7 +441,7 @@ class TestOverlapMixing:
         """BARGE_IN as first segment (no previous turn in buffer) must clamp onset to ≥ 0."""
         mixer = SceneMixer()
         wav = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
-        result = mixer.mix_sequential([(wav, 0.5, "A", None, MixMode.BARGE_IN)])
+        result = mixer.mix_sequential([(wav, 0.5, "A", None, MixMode.BARGE_IN, None)])
         assert result.rendered_onsets_s[0] == pytest.approx(0.0, abs=1e-4)
 
     def test_barge_in_full_depth_truncates_entirely(self):
@@ -444,8 +452,8 @@ class TestOverlapMixing:
         # overlap depth (1.0) > prev duration (0.5): onset_sample == prev_onset_sample → max_samples == 0.
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
-                (wav2, 1.0, "B", None, MixMode.BARGE_IN),
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
+                (wav2, 1.0, "B", None, MixMode.BARGE_IN, None),
             ]
         )
         # The interrupted turn's audible end should collapse to its onset.
@@ -460,8 +468,8 @@ class TestOverlapMixing:
         # amount_s=0 → onset is clamped to prev_offset_s → max_samples == len(prev_mono) → no truncation.
         result = mixer.mix_sequential(
             [
-                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
-                (wav2, 0.0, "B", None, MixMode.BARGE_IN),
+                (wav1, 0.0, "A", None, MixMode.SEQUENTIAL, None),
+                (wav2, 0.0, "B", None, MixMode.BARGE_IN, None),
             ]
         )
         # Previous turn plays its full duration (audible end == script end).
@@ -516,3 +524,121 @@ class TestApplyEdgeFades:
         result = _apply_edge_fades(mono, n=160)
         assert len(result) == 1
         assert result[0] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# #65: Lombard tilt (high-shelf at I4/I5)
+# ---------------------------------------------------------------------------
+
+
+def _hf_lf_band_ratio(samples: np.ndarray, sr: int, split_hz: float = 2500.0) -> float:
+    """Energy in the >split_hz band divided by energy in the <split_hz band."""
+    spectrum = np.abs(np.fft.rfft(samples))
+    freqs = np.fft.rfftfreq(len(samples), d=1.0 / sr)
+    hf = float(np.sum(spectrum[freqs >= split_hz] ** 2))
+    lf = float(np.sum(spectrum[freqs < split_hz] ** 2)) + 1e-12
+    return hf / lf
+
+
+def _white_noise(n: int, seed: int = 0, amp: float = 0.1) -> np.ndarray:
+    """Reproducible band-flat test signal — the spectrum is what matters."""
+    rng = np.random.default_rng(seed)
+    return (amp * rng.standard_normal(n)).astype(np.float32)
+
+
+class TestLombardTilt:
+    """Tests for _apply_lombard_tilt (#65)."""
+
+    def test_low_intensity_passes_through(self):
+        """I1–I3 must leave the signal bit-exact."""
+        signal = _white_noise(8000)
+        for intensity in (1, 2, 3):
+            out = _apply_lombard_tilt(signal, intensity, _TARGET_SR)
+            np.testing.assert_array_equal(out, signal)
+
+    def test_none_intensity_passes_through(self):
+        """intensity=None must leave the signal unchanged."""
+        signal = _white_noise(8000)
+        out = _apply_lombard_tilt(signal, None, _TARGET_SR)
+        np.testing.assert_array_equal(out, signal)
+
+    def test_i5_boosts_high_frequencies(self):
+        """I5 must raise the >2.5 kHz / <2.5 kHz energy ratio vs. I1."""
+        signal = _white_noise(_TARGET_SR)  # 1 second of band-flat noise
+        baseline_ratio = _hf_lf_band_ratio(signal, _TARGET_SR)
+        i5 = _apply_lombard_tilt(signal, 5, _TARGET_SR)
+        i5_ratio = _hf_lf_band_ratio(i5, _TARGET_SR)
+        # +3.5 dB shelf → HF/LF ratio should rise by ≥ 50 % in linear power.
+        assert i5_ratio > 1.5 * baseline_ratio
+
+    def test_i5_boost_exceeds_i4(self):
+        """The I5 shelf must raise HF energy more than the I4 shelf."""
+        signal = _white_noise(_TARGET_SR)
+        i4 = _apply_lombard_tilt(signal, 4, _TARGET_SR)
+        i5 = _apply_lombard_tilt(signal, 5, _TARGET_SR)
+        assert _hf_lf_band_ratio(i5, _TARGET_SR) > _hf_lf_band_ratio(i4, _TARGET_SR)
+
+    def test_returns_float32(self):
+        signal = _white_noise(4000)
+        out = _apply_lombard_tilt(signal, 5, _TARGET_SR)
+        assert out.dtype == np.float32
+
+    def test_empty_array_no_crash(self):
+        empty = np.zeros(0, dtype=np.float32)
+        out = _apply_lombard_tilt(empty, 5, _TARGET_SR)
+        assert len(out) == 0
+
+    def test_low_band_largely_preserved(self):
+        """A high-shelf must leave low-frequency energy roughly intact."""
+        # 200 Hz tone — well below the 2.5 kHz shelf knee.
+        n = _TARGET_SR
+        t = np.arange(n) / _TARGET_SR
+        signal = (0.3 * np.sin(2 * np.pi * 200.0 * t)).astype(np.float32)
+        out = _apply_lombard_tilt(signal, 5, _TARGET_SR)
+        # Skip the filter's transient by trimming the first 200 samples.
+        in_rms = float(np.sqrt(np.mean(signal[200:] ** 2)))
+        out_rms = float(np.sqrt(np.mean(out[200:] ** 2)))
+        assert out_rms == pytest.approx(in_rms, rel=0.1)
+
+
+class TestLombardInMixer:
+    """Integration: intensity 6th-tuple element drives Lombard tilt in mix_sequential."""
+
+    def test_i5_segment_has_more_hf_than_i1(self):
+        """A scene rendered at I5 has a higher HF/LF ratio than the same scene at I1."""
+        wav = _sine_wav_bytes(freq=440, duration_s=1.0, sample_rate=_TARGET_SR)
+        # Replace the sine with broadband noise so the spectral change is observable.
+        noise = _white_noise(_TARGET_SR, seed=1)
+        buf = io.BytesIO()
+        with wave.open(buf, "w") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(_TARGET_SR)
+            w.writeframes((noise * 32767).astype(np.int16).tobytes())
+        wav = buf.getvalue()
+
+        mixer = SceneMixer()
+        i1_scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, 1)])
+        i5_scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, 5)])
+
+        i1_ratio = _hf_lf_band_ratio(i1_scene.samples, _TARGET_SR)
+        i5_ratio = _hf_lf_band_ratio(i5_scene.samples, _TARGET_SR)
+        assert i5_ratio > i1_ratio * 1.4
+
+    def test_intensity_none_does_not_alter_signal(self):
+        """intensity=None must leave the signal unchanged vs. an I1 baseline."""
+        wav = _sine_wav_bytes(freq=440, duration_s=0.5, sample_rate=_TARGET_SR)
+        mixer = SceneMixer()
+        none_scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, None)])
+        i1_scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, 1)])
+        np.testing.assert_allclose(none_scene.samples, i1_scene.samples, atol=1e-6)
+
+    def test_i5_does_not_clip_typical_signal(self):
+        """A typical-amplitude turn at I5 must stay within the unity-amplitude budget."""
+        wav = _sine_wav_bytes(freq=1000, duration_s=0.5, amplitude=0.3, sample_rate=_TARGET_SR)
+        mixer = SceneMixer()
+        scene = mixer.mix_sequential([(wav, 0.0, "SPK", None, MixMode.SEQUENTIAL, 5)])
+        # Lombard adds +3.5 dB above 2.5 kHz; 1 kHz is under the shelf so the
+        # peak should remain comfortably below 1.0 — preprocessing's peak
+        # limiter handles the few dB of ceiling that may be needed.
+        assert float(np.max(np.abs(scene.samples))) < 0.95

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -752,6 +752,45 @@ class TestTTSRenderer:
         assert len(log_messages) >= 1
         assert any("turn" in m for m in log_messages)
 
+    def test_render_scene_forwards_turn_intensity_to_mixer(self, tmp_path):
+        """Each turn's intensity must arrive on the corresponding Segment (#65).
+
+        Without this guarantee the Lombard tilt becomes invisible from
+        ``render_scene``: the mixer-level tests would still pass even if
+        ``render_scene`` hard-coded ``intensity=1`` on every Segment.
+        """
+        from unittest.mock import patch
+
+        from synthbanshee.script.types import DialogueTurn
+        from synthbanshee.tts.mixer import SceneMixer
+
+        renderer = self._make_renderer(tmp_path)
+        speaker = SpeakerConfig.from_yaml(EXAMPLES_DIR / "speaker_AGG_M_30-45_001.yaml")
+        turns = [
+            DialogueTurn(speaker_id="AGG_M_30-45_001", text="שלום", intensity=1),
+            DialogueTurn(speaker_id="AGG_M_30-45_001", text="תפסיק", intensity=5),
+            DialogueTurn(speaker_id="AGG_M_30-45_001", text="עכשיו", intensity=4),
+        ]
+        speakers = {"AGG_M_30-45_001": speaker}
+
+        # Spy that captures the segment list and delegates to the real mixer
+        # so the function still returns a valid MixedScene.
+        captured: list[list[object]] = []
+        real_mix = SceneMixer.mix_sequential
+
+        def _spy(self, segments):
+            captured.append(list(segments))
+            return real_mix(self, segments)
+
+        with patch.object(SceneMixer, "mix_sequential", _spy):
+            renderer.render_scene(turns, speakers)
+
+        assert len(captured) == 1
+        intensities = [seg.intensity for seg in captured[0]]
+        assert intensities == [1, 5, 4], (
+            f"render_scene must forward each turn's intensity to the mixer; got {intensities!r}"
+        )
+
     def test_render_scene_disfluency_with_phrase_hints_rebases(self, tmp_path):
         """disfluency=True + phrase_hints: rebase_phrase_prosody is called when text changes."""
         from unittest.mock import patch


### PR DESCRIPTION
Closes #65.

## Problem

At I4–I5 the volume increase was applied via pure amplitude scaling
(`StyleEntry.volume_delta_db` + per-turn RMS gain in the mixer). Both are
amplitude-only operations — they don't change the spectral envelope, so the
result sounds like the speaker moved closer to the microphone, not like they
raised their voice. Azure he-IL voices don't honour `<mstts:express-as>`
(disabled in M14), so SSML can't request a shouting style; the fix has to be
a post-TTS DSP step.

## Solution

Add a Lombard-effect spectral tilt as a post-TTS step in `SceneMixer.mix_sequential`:

- An RBJ high-shelf biquad at **2.5 kHz**, slope S=1.
- **+2.0 dB** at I4, **+3.5 dB** at I5; **no-op for I1–I3** (and `intensity=None`).
- Runs **after** per-turn RMS gain (so the boost shapes the already-loud signal)
  and **before** the M14 edge fades.
- The intensity is threaded through the `mix_sequential` segment tuple as a
  6th element (`int | None`).

No clipping is performed inside the shelf — preprocessing's peak limiter
handles ceiling enforcement, consistent with `_apply_rms_gain`.

## Changes per file

| File | Change |
|---|---|
| `synthbanshee/tts/mixer.py` | Add `_apply_lombard_tilt()` and `_highshelf_biquad()`; extend `mix_sequential` segment tuple to 6 elements; apply tilt after RMS gain |
| `synthbanshee/tts/renderer.py` | Pass `turn.intensity` into the segment tuple |
| `tests/unit/test_mixer.py` | New `TestLombardTilt` and `TestLombardInMixer` classes; update existing 5-tuples to 6-tuples |
| `tests/unit/test_generation_metadata.py` | Update segment tuples to 6 elements |
| `tests/integration/test_multi_speaker.py` | Update segment tuples to 6 elements |
| `docs/audio_generation_v3_design.md` | New §4.2c documenting the Lombard tilt |

## Test plan

- [x] `pytest` — full suite: **1698 passed**
- [x] `ruff check` — passes (incl. pre-commit `ruff format`)
- [x] `mypy` — passes on changed files
- [x] Spectral verification: I5 raises HF/LF (>2.5 kHz vs. <2.5 kHz) energy ratio by ≥ 50 % vs. baseline white noise (`test_i5_boosts_high_frequencies`)
- [x] Monotonicity: I5 boost > I4 boost (`test_i5_boost_exceeds_i4`)
- [x] No regression at low intensity: I1, I2, I3, and `None` are bit-exact passthrough (`test_low_intensity_passes_through`, `test_none_intensity_passes_through`)
- [x] Low-frequency content preserved (`test_low_band_largely_preserved`)
- [x] No clipping introduced for typical-amplitude turns (`test_i5_does_not_clip_typical_signal`)

## Out of scope

- Formant shifting (more complex; deferred per issue #65).
- SSML / TTS parameter changes.
- Preprocessing changes (`augment/preprocessing.py` is untouched — the tilt is a TTS-output characteristic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)