### PR TITLE
fix(mixer): #66 BARGE_IN audible-overlap crossfade past TTS trailing silence

### DIFF
--- a/docs/audio_generation_v3_design.md
+++ b/docs/audio_generation_v3_design.md
@@ -310,9 +310,15 @@ Values are seeded-RNG draws for reproducibility. The `TurnGapController` is inst
 ```python
 class MixMode(Enum):
     SEQUENTIAL = "sequential"   # current behavior
-    OVERLAP = "overlap"         # next starts before prev ends
-    BARGE_IN = "barge_in"       # prev is cut off; next starts immediately
+    OVERLAP = "overlap"         # next starts before prev ends; both play through
+    BARGE_IN = "barge_in"       # prev plays through its speech end then is cut with a 60 ms fade
 ```
+
+**Speech-end anchoring (#66).** TTS engines pad each utterance with 100–300 ms of trailing near-silence. Anchoring overlap onset against the WAV's *file end* therefore puts the overlap inside the silence — listeners hear the previous speaker stop, then a gap, then the new speaker start, sounding like polite turn-taking instead of an interruption.
+
+The mixer measures speech end via a 10 ms sliding RMS scan with a *signal-relative* threshold (40 dB below the segment's own peak window RMS). The anchor for both `OVERLAP` and `BARGE_IN` onset is **speech end**, not file end. Trailing silence in the WAV is invisible to placement logic.
+
+**BARGE_IN crossfade behaviour.** The previous turn plays at full volume through the entire overlap region, all the way to its speech end. A short 60 ms linear fade-out is applied at the truncation boundary to avoid a click. This models a real interruption (the prior speaker keeps talking until overpowered) better than a long fade spanning the overlap region (which sounds like a console fader).
 
 **Three distinct time concepts** — once turns overlap, the label generator must track all three:
 
@@ -322,9 +328,11 @@ class MixMode(Enum):
 | Rendered interval | `rendered_onset_s` / `rendered_offset_s` | What the TTS actually produced before mixing |
 | Audible interval | `audible_onset_s` / `audible_end_s` | What is audible in the final waveform after overlap/barge-in |
 
-For `BARGE_IN`, `audible_end_s` of the interrupted turn is earlier than `rendered_offset_s`. The label generator **must use `audible_onset_s` / `audible_end_s`** for all event timestamp outputs — not the scripted or rendered values. If a speaker is cut off mid-utterance, any label for an event in the tail of that utterance must either be dropped or marked as `truncated: true`.
+For `BARGE_IN`, the interrupted turn's `audible_end_s` lies at the previous turn's *speech* end (#66). Because the next turn onsets earlier, **`audible_end_s[i]` is greater than `audible_onset_s[i+1]` for BARGE_IN-interrupted turns**: consecutive audible windows can overlap by the overlap-region length. Consumers must not assume non-overlap.
 
-`MixedScene` must expose all three sets of timestamps.
+The label generator **must use `audible_onset_s` / `audible_end_s`** for all event timestamp outputs — not the scripted or rendered values. The `truncated` flag is set when the next turn's `mix_mode == BARGE_IN` (read from `MixedScene.mix_modes`), not from an audible-vs-script-duration heuristic — the heuristic was unreliable when WAVs lacked trailing silence.
+
+`MixedScene` must expose all three sets of timestamps and the per-turn `mix_modes` list.
 
 **Asymmetric overlap probabilities (initial defaults — configurable):**
 

--- a/synthbanshee/labels/generator.py
+++ b/synthbanshee/labels/generator.py
@@ -26,6 +26,7 @@ from synthbanshee.labels.schema import (
     SpeakerInfo,
     WeakLabel,
 )
+from synthbanshee.tts.mix_mode import MixMode
 
 if TYPE_CHECKING:
     from synthbanshee.script.types import MixedScene
@@ -123,14 +124,19 @@ class LabelGenerator:
 
         Onset/offset for each label comes from ``scene.audible_onsets_s`` /
         ``scene.audible_ends_s`` rather than the ScriptEvent's own onset/offset.
-        When ``scene.script_offsets_s`` is populated and a turn's audible
-        duration (``audible_end - audible_onset``) is shorter than its script
-        duration (``script_offset - script_onset``) by more than
-        ``TRUNCATION_THRESHOLD_S`` (a two-sample tolerance to avoid sample-
-        quantization false positives), ``truncated=True`` is set on the
-        resulting label.  This captures BARGE_IN-interrupted turns without
-        falsely flagging OVERLAP turns whose absolute audible end may be
-        earlier than the script offset for reasons unrelated to truncation.
+
+        ``truncated`` is set when **either** of the following holds:
+
+        1. The next turn's mix mode is ``BARGE_IN`` (read from
+           ``scene.mix_modes[idx+1]``) — i.e. this turn was deliberately
+           interrupted by an overlapping speaker.  This is the primary signal
+           and is independent of whether the WAV happened to carry trailing
+           silence: a turn marked BARGE_IN by the script is *always*
+           interrupted in the user-meaningful sense.
+        2. As a defensive fallback, the audible duration is shorter than the
+           script duration by more than ``TRUNCATION_THRESHOLD_S`` (two
+           samples).  This catches any future case where the mixer truncates
+           a turn without the next turn being BARGE_IN.
 
         For fully-barged-in turns where the audible end equals the onset (zero
         audible duration), the label offset is floored to
@@ -163,10 +169,16 @@ class LabelGenerator:
         for idx, (evt, onset, end) in enumerate(
             zip(events, scene.audible_onsets_s, scene.audible_ends_s, strict=True)
         ):
-            # Detect truncation by comparing the *audible duration* against the
-            # *script duration* for this turn.  Using absolute onset vs. script
-            # onset would incorrectly flag OVERLAP/BARGE_IN turns that started
-            # early but spoke their full audio.
+            # Primary truncation signal: the *next* turn is a BARGE_IN, which
+            # means this turn was interrupted by design.  This is robust to
+            # whether the WAV carried trailing silence (older heuristic was
+            # "audible_duration < script_duration", which silently went False
+            # for tight TTS clips even when the script said BARGE_IN).
+            next_mix_mode = scene.mix_modes[idx + 1] if idx + 1 < len(scene.mix_modes) else None
+            interrupted_by_next = next_mix_mode == MixMode.BARGE_IN.value
+            # Defensive fallback: if the audible duration is meaningfully shorter
+            # than the script duration we still flag it, so any future mixer
+            # truncation that isn't tagged as BARGE_IN is still captured.
             script_onset = scene.script_onsets_s[idx] if idx < len(scene.script_onsets_s) else None
             script_offset = (
                 scene.script_offsets_s[idx] if idx < len(scene.script_offsets_s) else None
@@ -174,10 +186,10 @@ class LabelGenerator:
             if script_onset is not None and script_offset is not None:
                 script_duration = script_offset - script_onset
                 audible_duration = end - onset
-                scene_truncated = audible_duration < script_duration - _TRUNCATION_THRESHOLD_S
+                duration_truncated = audible_duration < script_duration - _TRUNCATION_THRESHOLD_S
             else:
-                scene_truncated = False
-            truncated = evt.truncated or scene_truncated
+                duration_truncated = False
+            truncated = evt.truncated or interrupted_by_next or duration_truncated
             # Floor zero-duration audible spans (fully-barged-in turns) to one
             # sample so the offset > onset validator is satisfied.
             safe_end = max(end, onset + _MIN_LABEL_DURATION_S)

--- a/synthbanshee/script/types.py
+++ b/synthbanshee/script/types.py
@@ -78,7 +78,8 @@ class MixedScene:
             always within the final waveform duration).
         turn_offsets_s: Per-turn audible end in seconds (backward-compat alias
             for ``audible_ends_s``; for BARGE_IN-interrupted turns this is the
-            truncation point, not the original TTS end).
+            truncation point at the previous turn's *speech* end, which sits
+            *after* the next turn's onset by the overlap-region length).
         duration_s: Total scene duration in seconds.
         speaker_ids: Speaker ID for each turn (parallel with onsets/offsets).
         script_onsets_s: Sequential-world onset — where the turn would start if
@@ -87,13 +88,17 @@ class MixedScene:
         rendered_onsets_s: Actual onset in the output buffer, accounting for
             overlap/barge-in positioning.
         rendered_offsets_s: Actual offset in the output buffer after any
-            barge-in truncation has been applied.  For uninterrupted turns this
-            is ``rendered_onset + TTS duration``; for turns interrupted by a
-            BARGE_IN it is the truncation point in the final mixed output.
+            barge-in truncation has been applied.  For uninterrupted turns
+            this is ``rendered_onset + TTS duration``; for turns interrupted
+            by a BARGE_IN it is the previous turn's speech end (§4.6, #66).
+            **Important: for BARGE_IN-interrupted turns,
+            ``rendered_offsets_s[i] > rendered_onsets_s[i+1]`` — consecutive
+            turns can overlap.  Consumers must not assume non-overlap.**
         audible_onsets_s: Same as ``rendered_onsets_s`` for all turns.
         audible_ends_s: End of the audible portion.  Matches
             ``rendered_offsets_s`` for all turns, including BARGE_IN-interrupted
-            turns where both fields reflect the truncation point.
+            turns; like ``rendered_offsets_s``, it can exceed the next turn's
+            ``audible_onsets_s`` for interrupted turns.
     """
 
     samples: np.ndarray

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -7,12 +7,15 @@ gain (M3) and a Lombard spectral tilt at I4–I5 (#65), then places each turn
 in the output buffer according to its MixMode:
 
   SEQUENTIAL  — insert a silence gap of *amount_s* before this turn (existing behaviour).
-  OVERLAP     — start *amount_s* seconds before the previous turn ends; both turns are
-                audible in the overlap region.
-  BARGE_IN    — the new turn onsets inside the previous turn (anchored against the
-                previous turn's *speech* end, not file end — #66); the previous turn
-                continues through its natural speech end with a linear fade-out spanning
-                the overlap region, producing an audible crossfade between the two voices.
+  OVERLAP     — start *amount_s* seconds before the previous turn's *speech* end (#66 —
+                anchored at speech end, not file end, to skip TTS trailing-silence
+                padding).  Both turns play to their natural file end; they sum in the
+                overlap region.
+  BARGE_IN    — same speech-end-anchored onset as OVERLAP, plus the previous turn is
+                truncated at its speech end with a short (60 ms) fade-out at the cut.
+                The previous voice plays at full volume through the entire overlap
+                region, then a quick fade-out — modelling a real interruption rather
+                than a smooth crossfade.
 
 The output MixedScene carries per-turn timing metadata on three timelines (§4.6):
 
@@ -21,11 +24,16 @@ The output MixedScene carries per-turn timing metadata on three timelines (§4.6
                                           even for BARGE_IN-truncated turns.
   rendered_onsets_s / rendered_offsets_s — actual onset/offset in the output buffer;
                                           for BARGE_IN-interrupted turns, rendered_offsets_s
-                                          is updated to the truncation point (the previous
-                                          turn's speech end), which sits *after* the new
-                                          turn's rendered onset by the overlap-region length.
-  audible_onsets_s / audible_ends_s     — what is audible (same as rendered; both at the
-                                          truncation point for interrupted turns).
+                                          equals the truncation point (the previous turn's
+                                          speech end), which sits *after* the next turn's
+                                          rendered_onsets_s by the overlap-region length.
+                                          (Consumers that previously assumed
+                                          ``rendered_offsets_s[i] <= rendered_onsets_s[i+1]``
+                                          must be updated — the invariant no longer holds for
+                                          BARGE_IN.  The label generator already handles this
+                                          correctly via ``mix_modes``.)
+  audible_onsets_s / audible_ends_s     — what is audible.  Equal to the rendered timeline
+                                          for all turns including BARGE_IN-interrupted ones.
 
 For backward compatibility, turn_onsets_s and turn_offsets_s mirror the *audible* timeline
 (audible_onsets_s and audible_ends_s respectively) so that all offsets stay within the
@@ -50,14 +58,28 @@ from synthbanshee.tts.mix_mode import MixMode
 
 _TARGET_SR = 16_000
 _EDGE_FADE_SAMPLES = 160  # 10ms at 16 kHz — eliminates DC-offset clicks at turn boundaries
+# Length of the BARGE_IN truncation fade-out applied at the prev turn's speech
+# end.  Real interruptions don't span the whole overlap region with a slow ramp
+# — the previous speaker keeps talking at full volume right up until they're
+# overpowered, then stops.  60 ms is long enough to avoid clicks but short
+# enough to preserve that abruptness.
+_BARGE_IN_FADE_OUT_SAMPLES = 960  # 60 ms at 16 kHz
 
-# #66 BARGE_IN tail-trim: TTS voices pad the end of an utterance with 100–300 ms
-# of near-silence (Azure ~150 ms, Google ~200 ms).  Anchoring BARGE_IN onset to
-# file end therefore lands the overlap inside that padding — listener hears the
+# #66 BARGE_IN/OVERLAP tail-trim: TTS voices pad the end of an utterance with
+# 100–300 ms of near-silence (Azure ~150 ms, Google ~200 ms).  Anchoring the
+# overlap onset to file end lands it inside that padding — listener hears the
 # previous speaker stop, then a gap, then the new speaker start.  We measure
-# speech end via a windowed RMS scan and anchor the overlap to that instead.
-_SPEECH_END_WINDOW_MS = 30.0
-_SPEECH_END_THRESHOLD_DBFS = -40.0
+# speech end via a short-window RMS scan and anchor the overlap to that.
+#
+# Window choice: 10 ms matches _EDGE_FADE_SAMPLES; smaller windows give
+# tighter offset precision (≤ 10 ms uncertainty propagates into label offsets
+# of interrupted turns).
+_SPEECH_END_WINDOW_SAMPLES = 160  # 10 ms at 16 kHz
+# Threshold is signal-relative — 40 dB below the segment's own peak window RMS.
+# This auto-scales for whisper turns, normal turns, and Lombard-tilted turns
+# (#65) without a hardcoded dBFS knob, and avoids cutting word-final fricatives
+# (which can sit 30+ dB below the syllable nucleus).
+_SPEECH_END_DB_BELOW_PEAK = 40.0
 
 # #65 Lombard effect: post-TTS spectral tilt at high intensities.
 # Real raised voices boost high-frequency energy; pure amplitude scaling sounds
@@ -187,32 +209,46 @@ def _apply_lombard_tilt(mono: np.ndarray, intensity: int) -> np.ndarray:
 _LOMBARD_COEFFS: dict[int, tuple[np.ndarray, np.ndarray]] = _precompute_lombard_coeffs()
 
 
-def _speech_end_sample(
-    mono: np.ndarray,
-    sample_rate: int = _TARGET_SR,
-    window_ms: float = _SPEECH_END_WINDOW_MS,
-    threshold_dbfs: float = _SPEECH_END_THRESHOLD_DBFS,
-) -> int:
+def _speech_end_sample(mono: np.ndarray) -> int:
     """Return the sample index just after the last window of speech-level energy.
 
-    Walks the tail backwards in non-overlapping windows; returns the end index
-    of the first window (from the tail) whose RMS exceeds *threshold_dbfs*.
-    Returns ``len(mono)`` when the input is empty (defensive: caller already
-    handles the empty case but the contract stays safe under refactors), and
-    ``0`` when no window crosses the threshold (silent input).
+    Skips trailing silence introduced by TTS engines (#66).  The threshold is
+    *signal-relative* — 40 dB below this segment's own peak window RMS — so it
+    auto-scales for whisper, normal, and Lombard-tilted turns without a
+    hardcoded dBFS knob.
 
-    Used by BARGE_IN onset placement (#66) to skip TTS trailing-silence padding.
+    Walks all 10 ms windows once to find peak RMS, then walks the tail
+    backwards and returns the end of the first window above
+    ``peak_rms / 100`` (i.e. ‑40 dB below the loudest part of the segment).
+
+    Returns 0 for empty or fully-silent input.
     """
-    if len(mono) == 0:
+    n = len(mono)
+    if n == 0:
         return 0
-    win = max(1, int(window_ms * sample_rate / 1000.0))
-    threshold = 10.0 ** (threshold_dbfs / 20.0)
-    for end in range(len(mono), 0, -win):
-        start = max(0, end - win)
-        rms = float(np.sqrt(np.mean(mono[start:end] ** 2)))
-        if rms >= threshold:
-            return end
-    return 0
+    win = _SPEECH_END_WINDOW_SAMPLES
+    # Squared-RMS per non-overlapping tail-aligned window.  Walking from the
+    # tail keeps the boundary windows at the (interesting) end of the buffer.
+    n_windows = n // win
+    if n_windows == 0:
+        # Shorter than one window — treat the whole thing as one window.
+        rms = float(np.sqrt(np.mean(mono.astype(np.float64) ** 2)))
+        return n if rms > 0.0 else 0
+    # Trim leading samples so windows align to the tail.
+    tail = mono[n - n_windows * win :]
+    frames = tail.reshape(n_windows, win).astype(np.float64)
+    frame_rms = np.sqrt((frames * frames).mean(axis=1))
+    peak_rms = float(frame_rms.max())
+    if peak_rms <= 0.0:
+        return 0
+    threshold = peak_rms * (10.0 ** (-_SPEECH_END_DB_BELOW_PEAK / 20.0))
+    # Last frame whose RMS exceeds threshold; result is its end sample.
+    above = np.where(frame_rms >= threshold)[0]
+    if len(above) == 0:
+        return 0
+    last_idx = int(above[-1])
+    leading_skipped = n - n_windows * win
+    return leading_skipped + (last_idx + 1) * win
 
 
 def _apply_edge_fades(mono: np.ndarray, n: int = _EDGE_FADE_SAMPLES) -> np.ndarray:
@@ -304,13 +340,11 @@ class SceneMixer:
                 if placed:
                     prev_mono, prev_onset_sample = placed[-1]
                     prev_onset_s = prev_onset_sample / _TARGET_SR
-                    if seg.mix_mode == MixMode.BARGE_IN:
-                        # #66: anchor against speech end, not file end — TTS
-                        # trailing-silence padding would otherwise eat the
-                        # entire overlap and produce an audible turn-taking gap.
-                        anchor_samples = _speech_end_sample(prev_mono, _TARGET_SR)
-                    else:
-                        anchor_samples = len(prev_mono)
+                    # #66: anchor against speech end, not file end — TTS trailing
+                    # silence would otherwise eat the overlap and produce an
+                    # audible turn-taking gap.  Applies to both BARGE_IN and
+                    # OVERLAP since both intend audible co-occurrence.
+                    anchor_samples = _speech_end_sample(prev_mono)
                     anchor_duration_s = float(anchor_samples) / _TARGET_SR
                     overlap_s = min(amount_s, anchor_duration_s)
                     onset_s = max(prev_onset_s, prev_onset_s + anchor_duration_s - overlap_s)
@@ -326,18 +360,18 @@ class SceneMixer:
             onset_s = float(onset_sample) / _TARGET_SR
             offset_s = float(onset_sample + len(mono)) / _TARGET_SR
 
-            # --- BARGE_IN: continue prev through its speech end, fade out across overlap ---
-            # Old behaviour cut prev *at* the new onset, leaving zero audible overlap and
-            # (worse) a perceptual gap when the cut landed inside TTS trailing silence (#66).
-            # New behaviour: prev plays through its natural speech end (or the file end —
-            # whichever is reached first), with a linear fade-out applied across the overlap
-            # region so the two voices crossfade naturally.
+            # --- BARGE_IN: prev plays through its speech end, then fades out ---
+            # Old behaviour cut prev exactly at the new onset, leaving zero audible
+            # overlap and (worse) a perceptual gap when the cut landed inside TTS
+            # trailing silence (#66).  New behaviour: prev plays at full volume past
+            # the new onset, all the way to its natural speech end, then a short
+            # 60 ms fade-out at that boundary.  The two voices co-occur for the full
+            # overlap region; prev_mono is mutated in place because _apply_edge_fades
+            # already returned a fresh array — no other reference exists.
             if seg.mix_mode == MixMode.BARGE_IN and placed:
                 prev_mono, prev_onset_sample = placed[-1]
                 onset_offset_in_prev = onset_sample - prev_onset_sample
-                # Truncate at speech end so trailing TTS silence doesn't leak into the buffer
-                # past the new turn's onset.
-                speech_end_in_prev = _speech_end_sample(prev_mono, _TARGET_SR)
+                speech_end_in_prev = _speech_end_sample(prev_mono)
                 truncate_at = min(speech_end_in_prev, len(prev_mono))
                 if onset_offset_in_prev <= 0:
                     # Full-depth barge-in: new turn starts at or before prev's onset —
@@ -347,18 +381,18 @@ class SceneMixer:
                     rendered_offsets[-1] = prev_onset_s_f
                     audible_ends[-1] = prev_onset_s_f
                 elif truncate_at > onset_offset_in_prev:
-                    # Standard overlap path: prev extends past the new onset by the
-                    # overlap region; fade out across that region.
-                    truncated = prev_mono[:truncate_at].copy()
-                    fade_n = truncate_at - onset_offset_in_prev
-                    truncated[-fade_n:] *= np.linspace(1.0, 0.0, fade_n, dtype=np.float32)
-                    placed[-1] = (truncated, prev_onset_sample)
+                    # Audible-overlap path: prev extends past the new onset to its
+                    # speech end; apply a short fade-out at the truncation boundary
+                    # to avoid clicks without smearing prev across the whole overlap.
+                    fade_n = min(_BARGE_IN_FADE_OUT_SAMPLES, truncate_at)
+                    fade = np.linspace(1.0, 0.0, fade_n, dtype=np.float32)
+                    prev_mono[truncate_at - fade_n : truncate_at] *= fade
+                    placed[-1] = (prev_mono[:truncate_at], prev_onset_sample)
                     new_offset_s = float(prev_onset_sample + truncate_at) / _TARGET_SR
                     rendered_offsets[-1] = new_offset_s
                     audible_ends[-1] = new_offset_s
-                # Else (truncate_at <= onset_offset_in_prev): prev's speech already ended
-                # before the new onset.  Leave prev untouched — its trailing silence (if any)
-                # will simply sum with the new turn at low energy, producing no audible gap.
+                # Else (truncate_at <= onset_offset_in_prev): prev's speech already
+                # ended at or before the new onset; leave prev untouched.
 
             placed.append((mono, onset_sample))
 

--- a/synthbanshee/tts/mixer.py
+++ b/synthbanshee/tts/mixer.py
@@ -9,8 +9,10 @@ in the output buffer according to its MixMode:
   SEQUENTIAL  — insert a silence gap of *amount_s* before this turn (existing behaviour).
   OVERLAP     — start *amount_s* seconds before the previous turn ends; both turns are
                 audible in the overlap region.
-  BARGE_IN    — same positioning as OVERLAP but the previous turn's audio is truncated
-                at the point where the current turn begins.
+  BARGE_IN    — the new turn onsets inside the previous turn (anchored against the
+                previous turn's *speech* end, not file end — #66); the previous turn
+                continues through its natural speech end with a linear fade-out spanning
+                the overlap region, producing an audible crossfade between the two voices.
 
 The output MixedScene carries per-turn timing metadata on three timelines (§4.6):
 
@@ -19,9 +21,11 @@ The output MixedScene carries per-turn timing metadata on three timelines (§4.6
                                           even for BARGE_IN-truncated turns.
   rendered_onsets_s / rendered_offsets_s — actual onset/offset in the output buffer;
                                           for BARGE_IN-interrupted turns, rendered_offsets_s
-                                          is updated to the truncation point.
-  audible_onsets_s / audible_ends_s     — what is audible (same as rendered; both are
-                                          at the truncation point for interrupted turns).
+                                          is updated to the truncation point (the previous
+                                          turn's speech end), which sits *after* the new
+                                          turn's rendered onset by the overlap-region length.
+  audible_onsets_s / audible_ends_s     — what is audible (same as rendered; both at the
+                                          truncation point for interrupted turns).
 
 For backward compatibility, turn_onsets_s and turn_offsets_s mirror the *audible* timeline
 (audible_onsets_s and audible_ends_s respectively) so that all offsets stay within the
@@ -46,6 +50,14 @@ from synthbanshee.tts.mix_mode import MixMode
 
 _TARGET_SR = 16_000
 _EDGE_FADE_SAMPLES = 160  # 10ms at 16 kHz — eliminates DC-offset clicks at turn boundaries
+
+# #66 BARGE_IN tail-trim: TTS voices pad the end of an utterance with 100–300 ms
+# of near-silence (Azure ~150 ms, Google ~200 ms).  Anchoring BARGE_IN onset to
+# file end therefore lands the overlap inside that padding — listener hears the
+# previous speaker stop, then a gap, then the new speaker start.  We measure
+# speech end via a windowed RMS scan and anchor the overlap to that instead.
+_SPEECH_END_WINDOW_MS = 30.0
+_SPEECH_END_THRESHOLD_DBFS = -40.0
 
 # #65 Lombard effect: post-TTS spectral tilt at high intensities.
 # Real raised voices boost high-frequency energy; pure amplitude scaling sounds
@@ -175,6 +187,34 @@ def _apply_lombard_tilt(mono: np.ndarray, intensity: int) -> np.ndarray:
 _LOMBARD_COEFFS: dict[int, tuple[np.ndarray, np.ndarray]] = _precompute_lombard_coeffs()
 
 
+def _speech_end_sample(
+    mono: np.ndarray,
+    sample_rate: int = _TARGET_SR,
+    window_ms: float = _SPEECH_END_WINDOW_MS,
+    threshold_dbfs: float = _SPEECH_END_THRESHOLD_DBFS,
+) -> int:
+    """Return the sample index just after the last window of speech-level energy.
+
+    Walks the tail backwards in non-overlapping windows; returns the end index
+    of the first window (from the tail) whose RMS exceeds *threshold_dbfs*.
+    Returns ``len(mono)`` when the input is empty (defensive: caller already
+    handles the empty case but the contract stays safe under refactors), and
+    ``0`` when no window crosses the threshold (silent input).
+
+    Used by BARGE_IN onset placement (#66) to skip TTS trailing-silence padding.
+    """
+    if len(mono) == 0:
+        return 0
+    win = max(1, int(window_ms * sample_rate / 1000.0))
+    threshold = 10.0 ** (threshold_dbfs / 20.0)
+    for end in range(len(mono), 0, -win):
+        start = max(0, end - win)
+        rms = float(np.sqrt(np.mean(mono[start:end] ** 2)))
+        if rms >= threshold:
+            return end
+    return 0
+
+
 def _apply_edge_fades(mono: np.ndarray, n: int = _EDGE_FADE_SAMPLES) -> np.ndarray:
     """Apply linear fade-in and fade-out of *n* samples to eliminate boundary clicks.
 
@@ -264,10 +304,16 @@ class SceneMixer:
                 if placed:
                     prev_mono, prev_onset_sample = placed[-1]
                     prev_onset_s = prev_onset_sample / _TARGET_SR
-                    prev_duration_s = len(prev_mono) / _TARGET_SR
-                    prev_offset_s = prev_onset_s + prev_duration_s
-                    overlap_s = min(amount_s, prev_duration_s)
-                    onset_s = max(prev_onset_s, prev_offset_s - overlap_s)
+                    if seg.mix_mode == MixMode.BARGE_IN:
+                        # #66: anchor against speech end, not file end — TTS
+                        # trailing-silence padding would otherwise eat the
+                        # entire overlap and produce an audible turn-taking gap.
+                        anchor_samples = _speech_end_sample(prev_mono, _TARGET_SR)
+                    else:
+                        anchor_samples = len(prev_mono)
+                    anchor_duration_s = float(anchor_samples) / _TARGET_SR
+                    overlap_s = min(amount_s, anchor_duration_s)
+                    onset_s = max(prev_onset_s, prev_onset_s + anchor_duration_s - overlap_s)
                 else:
                     onset_s = max(0.0, render_cursor_s - amount_s)
                 # In script space the turn still follows the previous one (no gap).
@@ -280,28 +326,39 @@ class SceneMixer:
             onset_s = float(onset_sample) / _TARGET_SR
             offset_s = float(onset_sample + len(mono)) / _TARGET_SR
 
-            # --- BARGE_IN: truncate the previous segment at the barge-in point ---
+            # --- BARGE_IN: continue prev through its speech end, fade out across overlap ---
+            # Old behaviour cut prev *at* the new onset, leaving zero audible overlap and
+            # (worse) a perceptual gap when the cut landed inside TTS trailing silence (#66).
+            # New behaviour: prev plays through its natural speech end (or the file end —
+            # whichever is reached first), with a linear fade-out applied across the overlap
+            # region so the two voices crossfade naturally.
             if seg.mix_mode == MixMode.BARGE_IN and placed:
                 prev_mono, prev_onset_sample = placed[-1]
-                max_samples = onset_sample - prev_onset_sample
-                if max_samples <= 0:
-                    # Full-depth barge-in: new turn starts at or before the previous
-                    # turn's onset — replace it with an empty array.
+                onset_offset_in_prev = onset_sample - prev_onset_sample
+                # Truncate at speech end so trailing TTS silence doesn't leak into the buffer
+                # past the new turn's onset.
+                speech_end_in_prev = _speech_end_sample(prev_mono, _TARGET_SR)
+                truncate_at = min(speech_end_in_prev, len(prev_mono))
+                if onset_offset_in_prev <= 0:
+                    # Full-depth barge-in: new turn starts at or before prev's onset —
+                    # replace it with an empty array.
                     placed[-1] = (np.zeros(0, dtype=np.float32), prev_onset_sample)
                     prev_onset_s_f = float(prev_onset_sample) / _TARGET_SR
                     rendered_offsets[-1] = prev_onset_s_f
                     audible_ends[-1] = prev_onset_s_f
-                elif max_samples < len(prev_mono):
-                    truncated = prev_mono[:max_samples].copy()
-                    # Re-apply fade-out at the new truncation boundary so the
-                    # hard cut doesn't reintroduce the click we're trying to fix.
-                    fade_n = min(_EDGE_FADE_SAMPLES, len(truncated))
-                    if fade_n > 0:
-                        truncated[-fade_n:] *= np.linspace(1.0, 0.0, fade_n, dtype=np.float32)
+                elif truncate_at > onset_offset_in_prev:
+                    # Standard overlap path: prev extends past the new onset by the
+                    # overlap region; fade out across that region.
+                    truncated = prev_mono[:truncate_at].copy()
+                    fade_n = truncate_at - onset_offset_in_prev
+                    truncated[-fade_n:] *= np.linspace(1.0, 0.0, fade_n, dtype=np.float32)
                     placed[-1] = (truncated, prev_onset_sample)
-                    # onset_s is already quantised to the sample boundary above.
-                    rendered_offsets[-1] = onset_s
-                    audible_ends[-1] = onset_s
+                    new_offset_s = float(prev_onset_sample + truncate_at) / _TARGET_SR
+                    rendered_offsets[-1] = new_offset_s
+                    audible_ends[-1] = new_offset_s
+                # Else (truncate_at <= onset_offset_in_prev): prev's speech already ended
+                # before the new onset.  Leave prev untouched — its trailing silence (if any)
+                # will simply sum with the new turn at low energy, producing no audible gap.
 
             placed.append((mono, onset_sample))
 

--- a/tests/integration/test_multi_speaker.py
+++ b/tests/integration/test_multi_speaker.py
@@ -206,19 +206,12 @@ class TestRenderScene:
 # ---------------------------------------------------------------------------
 
 
-def _make_wav_bytes_16k(duration_s: float = 2.0, trailing_silence_s: float = 0.0) -> bytes:
-    """Minimal 16 kHz mono WAV for direct use with SceneMixer.
-
-    *trailing_silence_s* appends silence after the sine (mimics TTS padding).
-    The total file duration is ``duration_s + trailing_silence_s``.
-    """
+def _make_wav_bytes_16k(duration_s: float = 2.0) -> bytes:
+    """Minimal 16 kHz mono WAV for direct use with SceneMixer."""
     sample_rate = 16_000
-    n_speech = int(sample_rate * duration_s)
-    n_silence = int(sample_rate * trailing_silence_s)
-    t = np.linspace(0, duration_s, n_speech, endpoint=False)
-    speech = (0.3 * np.sin(2 * np.pi * 440.0 * t) * 32767).astype(np.int16)
-    silence = np.zeros(n_silence, dtype=np.int16)
-    samples = np.concatenate([speech, silence])
+    n = int(sample_rate * duration_s)
+    t = np.linspace(0, duration_s, n, endpoint=False)
+    samples = (0.3 * np.sin(2 * np.pi * 440.0 * t) * 32767).astype(np.int16)
     buf = io.BytesIO()
     with wave.open(buf, "w") as w:
         w.setnchannels(1)
@@ -232,15 +225,9 @@ class TestOverlapLabelIntegration:
     """Integration: SceneMixer audible timeline → LabelGenerator → EventLabel timestamps."""
 
     def _three_turn_scene(self, mix_mode_third: MixMode) -> MixedScene:
-        """Mix three turns where the third uses the specified mix_mode.
-
-        Each turn carries 0.3 s of trailing silence to mimic TTS padding —
-        BARGE_IN truncates that padding, so the interrupted middle turn's
-        audible duration is shorter than its script duration (which is what
-        the LabelGenerator's ``truncated`` flag measures).
-        """
+        """Mix three turns where the third uses the specified mix_mode."""
         mixer = SceneMixer()
-        wav = _make_wav_bytes_16k(duration_s=2.0, trailing_silence_s=0.3)
+        wav = _make_wav_bytes_16k(duration_s=2.0)
         segments = [
             Segment(wav, 0.3, "SPK_A", None, MixMode.SEQUENTIAL),
             Segment(wav, 0.3, "SPK_B", None, MixMode.SEQUENTIAL),

--- a/tests/integration/test_multi_speaker.py
+++ b/tests/integration/test_multi_speaker.py
@@ -206,12 +206,19 @@ class TestRenderScene:
 # ---------------------------------------------------------------------------
 
 
-def _make_wav_bytes_16k(duration_s: float = 2.0) -> bytes:
-    """Minimal 16 kHz mono WAV for direct use with SceneMixer."""
+def _make_wav_bytes_16k(duration_s: float = 2.0, trailing_silence_s: float = 0.0) -> bytes:
+    """Minimal 16 kHz mono WAV for direct use with SceneMixer.
+
+    *trailing_silence_s* appends silence after the sine (mimics TTS padding).
+    The total file duration is ``duration_s + trailing_silence_s``.
+    """
     sample_rate = 16_000
-    n = int(sample_rate * duration_s)
-    t = np.linspace(0, duration_s, n, endpoint=False)
-    samples = (0.3 * np.sin(2 * np.pi * 440.0 * t) * 32767).astype(np.int16)
+    n_speech = int(sample_rate * duration_s)
+    n_silence = int(sample_rate * trailing_silence_s)
+    t = np.linspace(0, duration_s, n_speech, endpoint=False)
+    speech = (0.3 * np.sin(2 * np.pi * 440.0 * t) * 32767).astype(np.int16)
+    silence = np.zeros(n_silence, dtype=np.int16)
+    samples = np.concatenate([speech, silence])
     buf = io.BytesIO()
     with wave.open(buf, "w") as w:
         w.setnchannels(1)
@@ -225,9 +232,15 @@ class TestOverlapLabelIntegration:
     """Integration: SceneMixer audible timeline → LabelGenerator → EventLabel timestamps."""
 
     def _three_turn_scene(self, mix_mode_third: MixMode) -> MixedScene:
-        """Mix three turns where the third uses the specified mix_mode."""
+        """Mix three turns where the third uses the specified mix_mode.
+
+        Each turn carries 0.3 s of trailing silence to mimic TTS padding —
+        BARGE_IN truncates that padding, so the interrupted middle turn's
+        audible duration is shorter than its script duration (which is what
+        the LabelGenerator's ``truncated`` flag measures).
+        """
         mixer = SceneMixer()
-        wav = _make_wav_bytes_16k(duration_s=2.0)
+        wav = _make_wav_bytes_16k(duration_s=2.0, trailing_silence_s=0.3)
         segments = [
             Segment(wav, 0.3, "SPK_A", None, MixMode.SEQUENTIAL),
             Segment(wav, 0.3, "SPK_B", None, MixMode.SEQUENTIAL),

--- a/tests/unit/test_mixer.py
+++ b/tests/unit/test_mixer.py
@@ -510,52 +510,72 @@ class TestOverlapMixing:
         # New turn starts right where the previous one ended.
         assert result.rendered_onsets_s[1] == pytest.approx(dur, abs=0.02)
 
-    def test_barge_in_overlaps_speech_through_trailing_silence(self):
-        """#66: BARGE_IN onset must land in the speech region of the previous turn,
-        even when that turn has trailing silence padding (TTS-style)."""
+    def test_barge_in_both_speakers_audible_through_trailing_silence(self):
+        """#66 acceptance: BARGE_IN produces audible energy from BOTH speakers
+        through the overlap region, even when prev has TTS trailing silence.
+
+        Property-based: the overlap region's RMS must exceed the maximum of
+        either speaker's solo RMS by at least 30 % — a conservative bound
+        that holds regardless of fade shape, speaker frequencies, or window
+        length.  Two simultaneous sources of independent energy add (in RMS
+        terms) to ~sqrt(2) ≈ 1.41× a single source, so the > 1.30× check
+        passes comfortably as long as the previous voice is genuinely audible
+        and fails decisively if it falls into trailing silence.
+        """
         mixer = SceneMixer()
         speech_s = 1.0
         silence_s = 0.3  # mimics Azure / Google trailing-silence padding
         barge_depth_s = 0.25  # smaller than silence_s — the bug scenario
-        wav1 = _sine_with_trailing_silence_wav_bytes(
+        wav_a = _sine_with_trailing_silence_wav_bytes(
             speech_s=speech_s,
             silence_s=silence_s,
             freq=440,
             sample_rate=_TARGET_SR,
             amplitude=0.4,
         )
-        wav2 = _sine_wav_bytes(freq=880, duration_s=0.6, sample_rate=_TARGET_SR, amplitude=0.4)
+        wav_b = _sine_wav_bytes(freq=880, duration_s=0.6, sample_rate=_TARGET_SR, amplitude=0.4)
+
+        # Solo references — each voice rendered alone in its own scene.
+        solo_a = mixer.mix_sequential([Segment(wav_a, 0.0, "A", None, MixMode.SEQUENTIAL)])
+        solo_b = mixer.mix_sequential([Segment(wav_b, 0.0, "B", None, MixMode.SEQUENTIAL)])
+
         result = mixer.mix_sequential(
             [
-                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
-                Segment(wav2, barge_depth_s, "B", None, MixMode.BARGE_IN),
+                Segment(wav_a, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav_b, barge_depth_s, "B", None, MixMode.BARGE_IN),
             ]
         )
-        # The new turn must onset *before* the previous turn's speech ended,
-        # not somewhere inside its trailing silence.
+
+        # The new turn must onset before prev's speech ended.
         new_onset_s = result.rendered_onsets_s[1]
         assert new_onset_s < speech_s, (
-            f"BARGE_IN onset {new_onset_s:.3f}s landed at/after speech end "
-            f"{speech_s:.3f}s — overlap fell inside trailing silence (#66)."
-        )
-        # And there must be audible energy from BOTH speakers in the first
-        # 100 ms of the overlap region (acceptance criterion).
-        n_check = int(0.1 * _TARGET_SR)
-        onset_sample = int(new_onset_s * _TARGET_SR)
-        # Sum of both turns in the overlap window must clearly exceed wav2 alone:
-        # we check that the buffer's RMS in this window is at least ~1.4x wav2's
-        # contribution (two uncorrelated sines at the same amplitude → ~sqrt(2)x RMS).
-        overlap_window = result.samples[onset_sample : onset_sample + n_check]
-        overlap_rms = float(np.sqrt(np.mean(overlap_window**2)))
-        # wav2's contribution alone (0.4 amp sine) has RMS ≈ 0.283.
-        assert overlap_rms > 0.32, (
-            f"Overlap-region RMS {overlap_rms:.3f} is no louder than a single "
-            "speaker — previous turn was inaudible at the barge-in point."
+            f"BARGE_IN onset {new_onset_s:.3f}s landed at/after speech end — "
+            "overlap fell inside trailing silence (#66)."
         )
 
-    def test_overlap_unaffected_by_speech_end_anchor(self):
-        """OVERLAP must continue to anchor against file end, not speech end —
-        regression guard for #66 to confirm the fix is BARGE_IN-only."""
+        # Property: in the first 100 ms after the new onset, the mixed buffer
+        # carries energy from BOTH speakers.  Compare against either solo.
+        check_n = int(0.1 * _TARGET_SR)
+        onset_sample = int(new_onset_s * _TARGET_SR)
+        overlap_window = result.samples[onset_sample : onset_sample + check_n]
+        overlap_rms = float(np.sqrt(np.mean(overlap_window**2)))
+
+        # Solo RMS of A in the same time slice (where prev was speaking solo).
+        a_window = solo_a.samples[onset_sample : onset_sample + check_n]
+        a_rms = float(np.sqrt(np.mean(a_window**2)))
+        # Solo RMS of B in its first 100 ms (after fade-in).
+        b_rms = float(np.sqrt(np.mean(solo_b.samples[:check_n] ** 2)))
+
+        single_rms = max(a_rms, b_rms)
+        assert overlap_rms > 1.30 * single_rms, (
+            f"Overlap RMS {overlap_rms:.3f} not appreciably louder than max "
+            f"solo RMS ({single_rms:.3f}) — one speaker was inaudible during "
+            "the overlap region."
+        )
+
+    def test_overlap_anchored_on_speech_end_through_trailing_silence(self):
+        """#66: OVERLAP also anchors on speech end, not file end — same trailing-
+        silence trap applies if both speakers are meant to be heard."""
         mixer = SceneMixer()
         speech_s = 1.0
         silence_s = 0.3
@@ -570,32 +590,34 @@ class TestOverlapMixing:
                 Segment(wav2, overlap_s, "B", None, MixMode.OVERLAP),
             ]
         )
-        # Anchor is file end (speech_s + silence_s) → onset is at that minus depth.
-        expected_onset_s = (speech_s + silence_s) - overlap_s
-        assert result.rendered_onsets_s[1] == pytest.approx(expected_onset_s, abs=0.02)
+        # Anchor is speech end (speech_s), not file end (speech_s + silence_s).
+        expected_onset_s = speech_s - overlap_s
+        assert result.rendered_onsets_s[1] == pytest.approx(expected_onset_s, abs=0.02), (
+            "OVERLAP onset should anchor against speech end (#66), not file end."
+        )
 
 
 class TestSpeechEndSample:
     """Tests for _speech_end_sample (#66 — TTS trailing-silence trim)."""
 
     def test_returns_zero_for_empty(self):
-        assert _speech_end_sample(np.zeros(0, dtype=np.float32), _TARGET_SR) == 0
+        assert _speech_end_sample(np.zeros(0, dtype=np.float32)) == 0
 
     def test_returns_zero_for_silent_array(self):
         mono = np.zeros(_TARGET_SR, dtype=np.float32)
-        assert _speech_end_sample(mono, _TARGET_SR) == 0
+        assert _speech_end_sample(mono) == 0
 
     def test_skips_trailing_silence(self):
-        """An array of speech-level energy followed by silence returns ≈ speech end."""
+        """Speech then silence: detected end ≈ end of speech, within one window."""
         sr = _TARGET_SR
         speech = (0.3 * np.sin(2 * np.pi * 440 * np.linspace(0, 1.0, sr))).astype(np.float32)
         silence = np.zeros(int(0.3 * sr), dtype=np.float32)
         mono = np.concatenate([speech, silence])
-        end = _speech_end_sample(mono, sr)
-        # Tolerance: one window (30 ms = 480 samples) plus quantisation slack.
-        assert abs(end - len(speech)) <= int(0.04 * sr), (
+        end = _speech_end_sample(mono)
+        # 10 ms window → ≤ 10 ms uncertainty (160 samples).
+        assert abs(end - len(speech)) <= 160, (
             f"Detected speech end {end} differs from expected {len(speech)} by "
-            f"more than one window."
+            f"more than one 10 ms window."
         )
 
     def test_full_array_when_no_trailing_silence(self):
@@ -604,7 +626,54 @@ class TestSpeechEndSample:
             np.float32
         )
         # With no trailing silence, the last window is loud → returns len(mono).
-        assert _speech_end_sample(mono, sr) == len(mono)
+        assert _speech_end_sample(mono) == len(mono)
+
+    def test_does_not_clip_quiet_fricative_tail(self):
+        """Hebrew word-final fricatives (e.g. /ʃ/, /χ/) sit ~25 dB below the
+        syllable nucleus.  A signal-relative threshold (40 dB below peak) must
+        keep them inside the speech region, not cut them off as silence."""
+        sr = _TARGET_SR
+        rng = np.random.default_rng(0)
+        # Loud vowel-like sustain at amp 0.4 for 500 ms.
+        vowel = (0.4 * np.sin(2 * np.pi * 220 * np.linspace(0, 0.5, int(0.5 * sr)))).astype(
+            np.float32
+        )
+        # Fricative-style noise burst at much lower amplitude (-25 dB ≈ 0.022),
+        # for 150 ms — quieter than the vowel but still genuinely "speech".
+        fricative_amp = 0.4 * (10.0 ** (-25.0 / 20.0))
+        fricative = (fricative_amp * rng.standard_normal(int(0.15 * sr))).astype(np.float32)
+        # Then 200 ms of true TTS-padding silence.
+        silence = np.zeros(int(0.2 * sr), dtype=np.float32)
+        mono = np.concatenate([vowel, fricative, silence])
+        end = _speech_end_sample(mono)
+        speech_end_expected = len(vowel) + len(fricative)
+        # Detected end must reach into the fricative region — not stop at vowel end.
+        assert end > len(vowel), (
+            f"Detected end {end} stopped at the vowel boundary ({len(vowel)}) — "
+            "quiet fricative tail was incorrectly classified as silence."
+        )
+        # And must not extend past the speech into the silence.
+        assert end <= speech_end_expected + 160, (
+            f"Detected end {end} ran past speech end ({speech_end_expected}) into silence."
+        )
+
+    def test_threshold_is_signal_relative(self):
+        """A whisper-level signal (peak −30 dBFS) should still have its
+        speech end correctly detected — the threshold scales with the signal,
+        not against an absolute dBFS floor."""
+        sr = _TARGET_SR
+        # Peak amplitude ~0.03 (≈ −30 dBFS); without signal-relative scaling an
+        # absolute −40 dBFS threshold would treat the whole thing as silence.
+        speech = (0.03 * np.sin(2 * np.pi * 440 * np.linspace(0, 0.5, int(0.5 * sr)))).astype(
+            np.float32
+        )
+        silence = np.zeros(int(0.2 * sr), dtype=np.float32)
+        mono = np.concatenate([speech, silence])
+        end = _speech_end_sample(mono)
+        assert abs(end - len(speech)) <= 160, (
+            f"Whisper-level speech end {end} not detected near {len(speech)} — "
+            "threshold may not be signal-relative."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mixer.py
+++ b/tests/unit/test_mixer.py
@@ -16,6 +16,7 @@ from synthbanshee.tts.mixer import (
     _apply_edge_fades,
     _apply_lombard_tilt,
     _apply_rms_gain,
+    _speech_end_sample,
 )
 
 # ---------------------------------------------------------------------------
@@ -33,6 +34,29 @@ def _sine_wav_bytes(
     n = int(sample_rate * duration_s)
     t = np.linspace(0, duration_s, n, endpoint=False)
     samples = (amplitude * np.sin(2 * np.pi * freq * t) * 32767).astype(np.int16)
+    buf = io.BytesIO()
+    with wave.open(buf, "w") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(samples.tobytes())
+    return buf.getvalue()
+
+
+def _sine_with_trailing_silence_wav_bytes(
+    speech_s: float,
+    silence_s: float,
+    freq: float = 440.0,
+    sample_rate: int = 16000,
+    amplitude: float = 0.4,
+) -> bytes:
+    """Sine of *speech_s* followed by *silence_s* of zeros — repro for #66."""
+    n_speech = int(sample_rate * speech_s)
+    n_silence = int(sample_rate * silence_s)
+    t = np.linspace(0, speech_s, n_speech, endpoint=False)
+    speech = (amplitude * np.sin(2 * np.pi * freq * t) * 32767).astype(np.int16)
+    silence = np.zeros(n_silence, dtype=np.int16)
+    samples = np.concatenate([speech, silence])
     buf = io.BytesIO()
     with wave.open(buf, "w") as w:
         w.setnchannels(1)
@@ -336,12 +360,14 @@ class TestOverlapMixing:
         overlap_region = result.samples[overlap_start:overlap_end]
         assert float(np.max(np.abs(overlap_region))) > 0.3
 
-    def test_barge_in_previous_turn_truncated(self):
-        """BARGE_IN: the previous turn's audio must be zero after the barge-in point."""
+    def test_barge_in_previous_turn_truncated_at_speech_end(self):
+        """BARGE_IN: the previous turn extends through speech end with a fade-out
+        across the overlap region, then is silent past speech end (#66)."""
         mixer = SceneMixer()
         dur = 1.5
         barge_depth = 0.4
         wav1 = _sine_wav_bytes(freq=440, duration_s=dur, sample_rate=_TARGET_SR, amplitude=0.4)
+        # Silent wav2 so any non-zero buffer energy comes from wav1 alone.
         wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR, amplitude=0.0)
 
         result = mixer.mix_sequential(
@@ -350,18 +376,25 @@ class TestOverlapMixing:
                 Segment(wav2, barge_depth, "B", None, MixMode.BARGE_IN),
             ]
         )
-        # After COPILOT-6: rendered_offsets_s is updated to the truncation point,
-        # so audible_ends_s[0] == rendered_offsets_s[0] < script_offsets_s[0].
+        # Truncation point sits at wav1's speech end (~ file end here, no trailing
+        # silence) — i.e. AT script_offsets_s[0], not at the new onset.
         assert result.audible_ends_s[0] == pytest.approx(result.rendered_offsets_s[0], abs=1e-4)
-        assert result.audible_ends_s[0] < result.script_offsets_s[0]
-        # No audio from the first turn must remain after the barge-in point.
-        barge_sample = int(result.rendered_onsets_s[1] * _TARGET_SR)
-        # Buffer from barge-in point onward is zero (silent wav2 added, prev truncated).
-        tail = result.samples[barge_sample : int(result.script_offsets_s[0] * _TARGET_SR)]
+        assert result.audible_ends_s[0] == pytest.approx(result.script_offsets_s[0], abs=0.04)
+        # Prev's audible_end is now AFTER the new onset by ~ barge_depth.
+        assert result.audible_ends_s[0] > result.rendered_onsets_s[1]
+        # Buffer past the truncation point must be silent (wav2 is silent, prev truncated).
+        tail_start = int(result.audible_ends_s[0] * _TARGET_SR)
+        tail = result.samples[tail_start:]
         assert np.allclose(tail, 0.0, atol=1e-5)
+        # And the overlap region is non-zero (fade-out of wav1 still audible).
+        overlap_start = int(result.rendered_onsets_s[1] * _TARGET_SR)
+        overlap_end = int(result.audible_ends_s[0] * _TARGET_SR)
+        assert overlap_end > overlap_start
+        assert float(np.max(np.abs(result.samples[overlap_start:overlap_end]))) > 0.05
 
-    def test_barge_in_audible_end_equals_onset_of_next(self):
-        """Interrupted turn's audible_end_s == barge-in turn's rendered_onset_s."""
+    def test_barge_in_audible_end_after_onset_of_next(self):
+        """Interrupted turn's audible_end_s lands AFTER the new turn's onset by the
+        overlap-region length (#66)."""
         mixer = SceneMixer()
         wav1 = _sine_wav_bytes(duration_s=1.0, sample_rate=_TARGET_SR)
         wav2 = _sine_wav_bytes(duration_s=0.5, sample_rate=_TARGET_SR)
@@ -371,7 +404,11 @@ class TestOverlapMixing:
                 Segment(wav2, 0.3, "B", None, MixMode.BARGE_IN),
             ]
         )
-        assert result.audible_ends_s[0] == pytest.approx(result.rendered_onsets_s[1], abs=1e-4)
+        # Audible end of prev is at its speech end; new onset is barge_depth before that.
+        assert result.audible_ends_s[0] > result.rendered_onsets_s[1]
+        assert result.audible_ends_s[0] == pytest.approx(
+            result.rendered_onsets_s[1] + 0.3, abs=0.05
+        )
 
     def test_three_timeline_fields_populated(self):
         """MixedScene must expose script / rendered / audible timeline fields."""
@@ -472,6 +509,102 @@ class TestOverlapMixing:
         assert result.audible_ends_s[0] == pytest.approx(result.script_offsets_s[0], abs=1e-4)
         # New turn starts right where the previous one ended.
         assert result.rendered_onsets_s[1] == pytest.approx(dur, abs=0.02)
+
+    def test_barge_in_overlaps_speech_through_trailing_silence(self):
+        """#66: BARGE_IN onset must land in the speech region of the previous turn,
+        even when that turn has trailing silence padding (TTS-style)."""
+        mixer = SceneMixer()
+        speech_s = 1.0
+        silence_s = 0.3  # mimics Azure / Google trailing-silence padding
+        barge_depth_s = 0.25  # smaller than silence_s — the bug scenario
+        wav1 = _sine_with_trailing_silence_wav_bytes(
+            speech_s=speech_s,
+            silence_s=silence_s,
+            freq=440,
+            sample_rate=_TARGET_SR,
+            amplitude=0.4,
+        )
+        wav2 = _sine_wav_bytes(freq=880, duration_s=0.6, sample_rate=_TARGET_SR, amplitude=0.4)
+        result = mixer.mix_sequential(
+            [
+                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, barge_depth_s, "B", None, MixMode.BARGE_IN),
+            ]
+        )
+        # The new turn must onset *before* the previous turn's speech ended,
+        # not somewhere inside its trailing silence.
+        new_onset_s = result.rendered_onsets_s[1]
+        assert new_onset_s < speech_s, (
+            f"BARGE_IN onset {new_onset_s:.3f}s landed at/after speech end "
+            f"{speech_s:.3f}s — overlap fell inside trailing silence (#66)."
+        )
+        # And there must be audible energy from BOTH speakers in the first
+        # 100 ms of the overlap region (acceptance criterion).
+        n_check = int(0.1 * _TARGET_SR)
+        onset_sample = int(new_onset_s * _TARGET_SR)
+        # Sum of both turns in the overlap window must clearly exceed wav2 alone:
+        # we check that the buffer's RMS in this window is at least ~1.4x wav2's
+        # contribution (two uncorrelated sines at the same amplitude → ~sqrt(2)x RMS).
+        overlap_window = result.samples[onset_sample : onset_sample + n_check]
+        overlap_rms = float(np.sqrt(np.mean(overlap_window**2)))
+        # wav2's contribution alone (0.4 amp sine) has RMS ≈ 0.283.
+        assert overlap_rms > 0.32, (
+            f"Overlap-region RMS {overlap_rms:.3f} is no louder than a single "
+            "speaker — previous turn was inaudible at the barge-in point."
+        )
+
+    def test_overlap_unaffected_by_speech_end_anchor(self):
+        """OVERLAP must continue to anchor against file end, not speech end —
+        regression guard for #66 to confirm the fix is BARGE_IN-only."""
+        mixer = SceneMixer()
+        speech_s = 1.0
+        silence_s = 0.3
+        overlap_s = 0.25
+        wav1 = _sine_with_trailing_silence_wav_bytes(
+            speech_s=speech_s, silence_s=silence_s, freq=440, sample_rate=_TARGET_SR
+        )
+        wav2 = _sine_wav_bytes(freq=880, duration_s=0.5, sample_rate=_TARGET_SR)
+        result = mixer.mix_sequential(
+            [
+                Segment(wav1, 0.0, "A", None, MixMode.SEQUENTIAL),
+                Segment(wav2, overlap_s, "B", None, MixMode.OVERLAP),
+            ]
+        )
+        # Anchor is file end (speech_s + silence_s) → onset is at that minus depth.
+        expected_onset_s = (speech_s + silence_s) - overlap_s
+        assert result.rendered_onsets_s[1] == pytest.approx(expected_onset_s, abs=0.02)
+
+
+class TestSpeechEndSample:
+    """Tests for _speech_end_sample (#66 — TTS trailing-silence trim)."""
+
+    def test_returns_zero_for_empty(self):
+        assert _speech_end_sample(np.zeros(0, dtype=np.float32), _TARGET_SR) == 0
+
+    def test_returns_zero_for_silent_array(self):
+        mono = np.zeros(_TARGET_SR, dtype=np.float32)
+        assert _speech_end_sample(mono, _TARGET_SR) == 0
+
+    def test_skips_trailing_silence(self):
+        """An array of speech-level energy followed by silence returns ≈ speech end."""
+        sr = _TARGET_SR
+        speech = (0.3 * np.sin(2 * np.pi * 440 * np.linspace(0, 1.0, sr))).astype(np.float32)
+        silence = np.zeros(int(0.3 * sr), dtype=np.float32)
+        mono = np.concatenate([speech, silence])
+        end = _speech_end_sample(mono, sr)
+        # Tolerance: one window (30 ms = 480 samples) plus quantisation slack.
+        assert abs(end - len(speech)) <= int(0.04 * sr), (
+            f"Detected speech end {end} differs from expected {len(speech)} by "
+            f"more than one window."
+        )
+
+    def test_full_array_when_no_trailing_silence(self):
+        sr = _TARGET_SR
+        mono = (0.3 * np.sin(2 * np.pi * 440 * np.linspace(0, 0.5, int(0.5 * sr)))).astype(
+            np.float32
+        )
+        # With no trailing silence, the last window is loud → returns len(mono).
+        assert _speech_end_sample(mono, sr) == len(mono)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #66.

> **Verified on real audio.** Re-rendered `sp_it_a_0001_00` with both the old mixer (against a fresh script + cached TTS turns) and the fix; matched-script comparison at every BARGE_IN onset shows the silent gap is gone. Numbers below.

## Problem

In a BARGE_IN turn pair, listeners heard the previous speaker stop, then a noticeable pause, then the new speaker start — sounding like polite turn-taking instead of an interruption. Reported in the 2026-05-03 listening test against `sp_it_a_0001_00`:

> "At ~1:19 the woman audibly stops speaking BEFORE the man starts, with a noticeable time gap. Sounds like polite turn-taking, not an interruption."

Two compounding causes:

1. **Onset anchored at file end, not speech end.** Azure / Google TTS pad each utterance with 100–300 ms of trailing near-silence. With BARGE_IN depth in the 200–500 ms range, the overlap landed mostly *inside* that silence — the man overlapped the woman's silence, not her speech.
2. **Hard cut at the new onset.** Even with onset moved earlier, the previous turn was truncated *exactly at* the new turn's onset, so there was zero audible overlap.

## Solution

In `SceneMixer.mix_sequential`:

- Add `_speech_end_sample()` — windowed RMS scan (10 ms windows; threshold is 40 dB below the segment's *own peak window RMS*, so it auto-scales for whisper, normal, and Lombard-tilted turns), scipy + numpy only.
- Anchor **both BARGE_IN and OVERLAP** onset against speech end instead of file end. Both modes intend audible co-occurrence; OVERLAP had the identical bug.
- For BARGE_IN, the previous turn plays at full volume through the entire overlap region (= up to its speech end), then a short 60 ms fade-out at the truncation boundary. Models a real interruption — the prior speaker keeps talking until overpowered, not a long fade pulled by a console fader.
- Tail is mutated in place (the array is already a fresh copy from `_apply_edge_fades`); no whole-array copy in the hot path.

In `LabelGenerator.generate_events_from_scene`:

- `truncated=True` when the *next* turn's `mix_mode == BARGE_IN` (read from `scene.mix_modes`). This is robust to whether the WAV carried trailing silence — a turn marked BARGE_IN by the script is *always* interrupted in the user-meaningful sense. The previous heuristic ("audible_duration < script_duration") silently produced `truncated=False` for tight-TTS clips even when the script said BARGE_IN. The duration heuristic is retained as a defensive fallback.

The previous turn's `audible_ends_s` for an interrupted turn now sits **after** the next turn's `rendered_onsets_s` by the overlap-region length. The module docstring, `MixedScene` dataclass docstring, and `docs/audio_generation_v3_design.md` §4.6 all flag the change explicitly: *consumers must not assume `rendered_offsets_s[i] <= rendered_onsets_s[i+1]`*.

## Real-audio verification

Re-rendered `configs/scenes/she_proves/sp_it_a_0001.yaml` twice against the same script and TTS cache: once with the mixer at `main` (BEFORE), once with the fix (AFTER). Same 17-turn script in both renders; the only difference is the mixer logic. Both runs produced 2 BARGE_IN turn pairs (turns 10→11 and 12→13).

Measured RMS (in dBFS) in 100 ms windows around each new-turn onset, plus the minimum 30 ms-window RMS in ±50 ms straddling the cut (= "is there silence at the boundary?"):

| BARGE_IN | Render | pre-onset 100 ms | post-onset 100 ms | min 30 ms within ±50 ms of onset |
|---|---|---|---|---|
| turn 10→11 (AGG→VIC, I3) | **BEFORE** | −101 dBFS | −97 dBFS | **−200 dBFS** (literal silence) |
| turn 10→11 (AGG→VIC, I3) | **AFTER**  | −22 dBFS | −22 dBFS | **−22 dBFS** (continuous speech) |
| turn 12→13 (AGG→VIC, I4) | **BEFORE** | −93 dBFS | −98 dBFS | **−200 dBFS** (literal silence) |
| turn 12→13 (AGG→VIC, I4) | **AFTER**  | −17 dBFS | −29 dBFS | **−31 dBFS** (no silent gap) |

The `−200 dBFS` floor (= zero samples in float32 → log saturation) at the cut in BEFORE is the bug: a real silent gap straddling the BARGE_IN boundary. AFTER, the boundary region is continuously at speech-level energy — both speakers active across the cut.

A/B listening snippets are at `/tmp/sb_66_listen/`:
- `barge_10_AB_stitched.wav` (BEFORE — 0.5 s gap — AFTER, AGG→VIC at I3)
- `barge_12_AB_stitched.wav` (BEFORE — 0.5 s gap — AFTER, AGG→VIC at I4)

## Audit of `audible_ends_s` consumers

| Consumer | Status |
|---|---|
| `synthbanshee/labels/generator.py` | Updated — `truncated` now driven by `mix_modes`, not audible-vs-script duration |
| `synthbanshee/script/types.py` (dataclass) | Docstring updated to flag the new invariant |
| `synthbanshee/tts/mixer.py` (producer) | Updated — full design described in module docstring |
| Tests | Updated; brittle invariant assertions replaced |

No other source-tree consumer reads `audible_ends_s`. (`grep -rn audible_ends_s synthbanshee/`)

## Changes per file

| File | Change |
|---|---|
| `synthbanshee/tts/mixer.py` | `_speech_end_sample()` (signal-relative, 10 ms window); anchor BARGE_IN+OVERLAP at speech end; 60 ms fade at truncation boundary; in-place tail mutation; module docstring updated |
| `synthbanshee/labels/generator.py` | `truncated` driven by next-turn `mix_mode == BARGE_IN`; duration heuristic kept as fallback; docstring updated |
| `synthbanshee/script/types.py` | `MixedScene` docstring: flag that `rendered_offsets_s[i]` may exceed `rendered_onsets_s[i+1]` for interrupted turns |
| `docs/audio_generation_v3_design.md` | §4.6 rewritten — speech-end anchoring, fade design, audible-window overlap, mix-mode-driven `truncated` |
| `tests/unit/test_mixer.py` | New `TestSpeechEndSample` (incl. fricative-tail and whisper tests); property-based acceptance test (overlap RMS > 1.30× louder solo); OVERLAP-fix test; existing barge-in tests updated for new audible-end semantic |
| `tests/integration/test_multi_speaker.py` | Restored to original (no-trailing-silence) fixture; assertions still pass via the new mix-mode-driven `truncated` flag |

## Test plan

- [x] `pytest` — full suite: **1707 passed**, 2 pre-existing warnings
- [x] `ruff check` — passes (incl. pre-commit `ruff format`)
- [x] `mypy` — clean on every changed file
- [x] **Acceptance** (BARGE_IN, property-based): overlap RMS > 1.30× louder solo voice — both speakers genuinely co-present after the new onset
- [x] **OVERLAP fix verified**: `test_overlap_anchored_on_speech_end_through_trailing_silence` — OVERLAP onset lands at speech end, not file end
- [x] **Threshold robustness**: `test_does_not_clip_quiet_fricative_tail` — vowel + −25 dB fricative + silence; detector includes the fricative
- [x] **Threshold scaling**: `test_threshold_is_signal_relative` — peak-relative threshold correctly detects whisper-level (−30 dBFS) speech end
- [x] **Label semantic**: `test_barge_in_previous_turn_label_truncated` — `truncated=True` even with no trailing silence in the source WAV
- [x] **Existing edge cases preserved**: full-depth BARGE_IN, zero-depth, as-first-segment, SEQUENTIAL three-timeline equality
- [x] **Real-audio verification on `sp_it_a_0001_00`** — both BARGE_IN moments verified numerically (table above); A/B snippets at `/tmp/sb_66_listen/`

## Out of scope

- TTS / SSML parameter changes (silence padding is upstream; we work around it in the mixer)
- Preprocessing changes — `augment/preprocessing.py` is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)