### PR TITLE
test(tts): #40 add real-API Google TTS round-trip integration test

### DIFF
--- a/.github/workflows/live-tts.yml
+++ b/.github/workflows/live-tts.yml
@@ -1,0 +1,64 @@
+name: Live TTS regression
+
+# Runs the live_tts-marked integration tests (real Google / Azure TTS API
+# calls) on a schedule and on manual dispatch.  These are gated out of the
+# default CI matrix because they bill real money — see tests/conftest.py
+# (the --run-live-tts flag) and tests/integration/test_google_tts.py.
+#
+# Required secrets:
+#   GOOGLE_APPLICATION_CREDENTIALS_JSON  — full contents of a GCP service
+#     account JSON with `roles/cloudtexttospeech.user`.  Written to a temp
+#     file at runtime; GOOGLE_APPLICATION_CREDENTIALS is pointed at it.
+
+on:
+  schedule:
+    # Weekly, Sunday 04:00 UTC.  Catches Google API / voice deprecation
+    # drift within ~7 days without per-PR billing.
+    - cron: "0 4 * * 0"
+  workflow_dispatch: {}
+
+jobs:
+  live-tts:
+    name: "Live TTS (Python 3.12)"
+    runs-on: ubuntu-latest
+    # Gate: only run when the GCP creds secret is configured.  Forks and
+    # PRs from contributors who don't have the secret won't fail noisily.
+    if: ${{ github.repository == 'DataHackIL/SynthBanshee' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install dependencies (incl. google-tts extra)
+        run: |
+          uv pip install \
+            pydantic pyyaml jinja2 soundfile numpy scipy \
+            click rich jsonlines \
+            pyroomacoustics \
+            librosa pyloudnorm \
+            pytest pytest-asyncio pytest-cov \
+            google-cloud-texttospeech
+
+      - name: Install package
+        run: uv pip install --no-deps -e .
+
+      - name: Write GCP service account JSON
+        env:
+          GCP_SA_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
+        run: |
+          if [ -z "$GCP_SA_JSON" ]; then
+            echo "::error::GOOGLE_APPLICATION_CREDENTIALS_JSON secret is not set"
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/gcp"
+          printf '%s' "$GCP_SA_JSON" > "$RUNNER_TEMP/gcp/sa.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/gcp/sa.json" >> "$GITHUB_ENV"
+
+      - name: Run live TTS tests
+        run: .venv/bin/pytest -v --tb=short --run-live-tts -m live_tts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "live_tts: integration tests that hit a real TTS API (skip with -m 'not live_tts')",
+]
 
 [tool.coverage.run]
 source = ["synthbanshee"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+"""Shared pytest configuration for the SynthBanshee test suite.
+
+Adds a ``--run-live-tts`` flag that gates tests marked
+``@pytest.mark.live_tts`` (real TTS API calls — they cost real money).
+Default ``pytest`` runs skip them; opt-in is explicit:
+
+    pytest --run-live-tts                           # run live tests
+    pytest tests/integration/test_google_tts.py --run-live-tts
+
+This protects CI and contributors who happen to have ADC credentials
+and the optional TTS SDKs installed from being billed on every test
+run.  The existing ``-m "not live_tts"`` filter still works for the
+inverse use case.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--run-live-tts",
+        action="store_true",
+        default=False,
+        help=(
+            "Run tests marked @pytest.mark.live_tts (real TTS API calls; "
+            "bills real money on services like Google Cloud TTS / Azure)."
+        ),
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    if config.getoption("--run-live-tts"):
+        return
+    skip_live = pytest.mark.skip(
+        reason="live_tts test — pass --run-live-tts to run (real API call)"
+    )
+    for item in items:
+        if "live_tts" in item.keywords:
+            item.add_marker(skip_live)

--- a/tests/integration/test_google_tts.py
+++ b/tests/integration/test_google_tts.py
@@ -1,0 +1,119 @@
+"""Integration test: real Google Cloud TTS round-trip (issue #40).
+
+Verifies that the SSML produced by ``SSMLBuilder(supports_style_tags=False)``
+is accepted by Google's API, and that ``GoogleProvider._pcm_to_wav``
+produces audio that round-trips through ``soundfile`` as a 24 kHz mono
+16-bit PCM WAV with non-silent content.
+
+The mocked unit tests in ``tests/unit/test_google_provider.py`` cover
+parsing, dispatch, and error handling; this test covers the contract
+between our SSML and the actual Google service.
+
+Marked with ``@pytest.mark.live_tts`` so it can be skipped in fast loops:
+
+    pytest -m "not live_tts"      # skip live API calls
+    pytest tests/integration/test_google_tts.py   # run only this test
+
+Skipped automatically when ``GOOGLE_APPLICATION_CREDENTIALS`` is unset
+or the optional ``google-cloud-texttospeech`` extra is not installed.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import wave
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from synthbanshee.tts.google_provider import GoogleProvider
+from synthbanshee.tts.ssml_builder import SSMLBuilder
+
+# Short Hebrew utterance — kept brief to keep the test cheap.
+_HEBREW_UTTERANCE = "שלום, זאת בדיקה."
+
+# Real Google he-IL Chirp 3 HD voice — verify with scripts/check_google_voices.py.
+_VOICE_ID = "he-IL-Chirp3-HD-Achird"
+
+# Google TTS LINEAR16 output rate, wrapped by GoogleProvider._pcm_to_wav.
+_EXPECTED_SAMPLE_RATE_HZ = 24_000
+
+# Floor for "clearly non-silent" speech on a [-1, 1] float32 scale.
+_RMS_FLOOR = 0.005
+
+
+def _credentials_available() -> bool:
+    return bool(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"))
+
+
+def _google_sdk_available() -> bool:
+    try:
+        import google.cloud.texttospeech  # type: ignore[import-untyped]  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+_SKIP_REASON = (
+    "Live Google TTS test: requires GOOGLE_APPLICATION_CREDENTIALS and the "
+    "google-cloud-texttospeech extra (`pip install 'synthbanshee[google-tts]'`)."
+)
+
+
+@pytest.mark.live_tts
+@pytest.mark.skipif(
+    not (_credentials_available() and _google_sdk_available()),
+    reason=_SKIP_REASON,
+)
+def test_google_tts_round_trip_returns_valid_non_silent_wav() -> None:
+    """One short Hebrew utterance survives the SSMLBuilder → Google → WAV path."""
+    builder = SSMLBuilder()
+    ssml = builder.build_from_speaker_config(
+        text=_HEBREW_UTTERANCE,
+        voice_id=_VOICE_ID,
+        style="General",
+        rate_multiplier=1.0,
+        supports_style_tags=False,
+    )
+
+    # Regression guard: SSML for Google must never carry Azure-only mstts tags.
+    assert "mstts" not in ssml
+    assert "express-as" not in ssml
+
+    wav_bytes = GoogleProvider().synthesize(ssml)
+
+    assert wav_bytes[:4] == b"RIFF", "Output must start with a RIFF/WAV header"
+    with wave.open(io.BytesIO(wav_bytes), "r") as w:
+        assert w.getnchannels() == 1, "Output must be mono"
+        assert w.getsampwidth() == 2, "Output must be 16-bit (sampwidth=2)"
+        assert w.getframerate() == _EXPECTED_SAMPLE_RATE_HZ
+        assert w.getnframes() > 0
+
+    audio, sample_rate = sf.read(io.BytesIO(wav_bytes), dtype="float32")
+    assert sample_rate == _EXPECTED_SAMPLE_RATE_HZ
+    assert audio.ndim == 1, "Output must be mono (single channel)"
+
+    rms = float(np.sqrt(np.mean(audio**2)))
+    assert rms > _RMS_FLOOR, f"Audio appears silent (RMS={rms:.5f})"
+
+
+def test_ssml_builder_google_mode_emits_no_mstts() -> None:
+    """Cheap regression guard for the ``supports_style_tags=False`` path.
+
+    Runs without API access so it always executes — the round-trip test
+    is gated on credentials, but this snapshot check is not.
+    """
+    builder = SSMLBuilder()
+    ssml = builder.build_from_speaker_config(
+        text=_HEBREW_UTTERANCE,
+        voice_id=_VOICE_ID,
+        style="angry",  # non-General style still must not produce express-as
+        rate_multiplier=1.1,
+        pitch_delta_st=2.0,
+        supports_style_tags=False,
+    )
+    assert "mstts" not in ssml
+    assert "express-as" not in ssml
+    assert _VOICE_ID in ssml

--- a/tests/integration/test_google_tts.py
+++ b/tests/integration/test_google_tts.py
@@ -6,22 +6,26 @@ test fills the remaining gap: that the SSML our code generates is
 actually accepted by Google's API and that synthesizing a real Hebrew
 utterance returns plausible, non-silent audio.
 
-Skip behavior:
+Opt-in: this test is gated by the ``--run-live-tts`` flag wired in
+``tests/conftest.py``.  Default ``pytest`` invocations skip it so that
+CI and contributors with ADC + the SDK installed are not billed on
+every test run.
 
-- Skipped when ``google-cloud-texttospeech`` is not installed (mirrors
-  the lazy-import guard in ``google_provider.py``).
-- Skipped when ``GOOGLE_APPLICATION_CREDENTIALS`` is unset.
+    pytest --run-live-tts tests/integration/test_google_tts.py
+    pytest -m "not live_tts"     # inverse: still works
 
-Marker filter:
+Additional skip conditions (when opted in):
 
-    pytest -m "not live_tts"   # skip live API calls in fast loops
+- ``google-cloud-texttospeech`` not installed.
+- No discoverable ADC credentials (env var, gcloud login, or metadata
+  server) — surfaced via ``google.auth.exceptions.DefaultCredentialsError``
+  at synthesis time.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import io
-import os
 from pathlib import Path
 
 import numpy as np
@@ -55,27 +59,25 @@ _DURATION_MIN_S = 1.0
 _DURATION_MAX_S = 15.0
 
 
-def _credentials_available() -> bool:
-    return bool(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"))
-
-
 def _google_sdk_installed() -> bool:
     """True iff ``google-cloud-texttospeech`` is importable.
 
-    Uses ``find_spec`` so we don't trigger the SDK's import side effects
-    at pytest collection time — same reason ``GoogleProvider`` lazy-imports.
+    Uses ``find_spec`` so the SDK is not actually loaded at collection
+    time.  ``find_spec`` raises ``ModuleNotFoundError`` (a subclass of
+    ``ImportError``) when a parent package is missing — e.g. the
+    ``google`` namespace is absent entirely on a CI machine without the
+    optional extra — so we catch that and treat it as "not installed".
     """
-    return importlib.util.find_spec("google.cloud.texttospeech") is not None
+    try:
+        return importlib.util.find_spec("google.cloud.texttospeech") is not None
+    except (ImportError, ValueError):
+        return False
 
 
 @pytest.mark.live_tts
 @pytest.mark.skipif(
     not _google_sdk_installed(),
     reason="google-cloud-texttospeech not installed (`pip install 'synthbanshee[google-tts]'`)",
-)
-@pytest.mark.skipif(
-    not _credentials_available(),
-    reason="GOOGLE_APPLICATION_CREDENTIALS is not set",
 )
 def test_google_tts_round_trip_returns_plausible_non_silent_audio() -> None:
     """A short Hebrew utterance synthesizes to plausible, non-silent audio.
@@ -103,7 +105,17 @@ def test_google_tts_round_trip_returns_plausible_non_silent_audio() -> None:
         supports_style_tags=False,
     )
 
-    wav_bytes = GoogleProvider().synthesize(ssml)
+    # Skip with a precise reason if no ADC credentials are discoverable.
+    # Covers the full chain that GoogleProvider supports — service-account
+    # JSON via env var, `gcloud auth application-default login`, and
+    # GCE / Workload Identity metadata — not just the env var.
+    from google.auth.exceptions import DefaultCredentialsError
+
+    try:
+        wav_bytes = GoogleProvider().synthesize(ssml)
+    except DefaultCredentialsError as exc:
+        pytest.skip(f"No Google ADC credentials discoverable: {exc}")
+
     audio, sample_rate = sf.read(io.BytesIO(wav_bytes), dtype="float32")
 
     assert sample_rate == _EXPECTED_SAMPLE_RATE_HZ

--- a/tests/integration/test_google_tts.py
+++ b/tests/integration/test_google_tts.py
@@ -1,41 +1,47 @@
 """Integration test: real Google Cloud TTS round-trip (issue #40).
 
-Verifies that the SSML produced by ``SSMLBuilder(supports_style_tags=False)``
-is accepted by Google's API, and that ``GoogleProvider._pcm_to_wav``
-produces audio that round-trips through ``soundfile`` as a 24 kHz mono
-16-bit PCM WAV with non-silent content.
+The unit tests in ``tests/unit/test_google_provider.py`` cover SSML shape,
+provider dispatch, and error handling — all with a mocked client.  This
+test fills the remaining gap: that the SSML our code generates is
+actually accepted by Google's API and that synthesizing a real Hebrew
+utterance returns plausible, non-silent audio.
 
-The mocked unit tests in ``tests/unit/test_google_provider.py`` cover
-parsing, dispatch, and error handling; this test covers the contract
-between our SSML and the actual Google service.
+Skip behavior:
 
-Marked with ``@pytest.mark.live_tts`` so it can be skipped in fast loops:
+- Skipped when ``google-cloud-texttospeech`` is not installed (mirrors
+  the lazy-import guard in ``google_provider.py``).
+- Skipped when ``GOOGLE_APPLICATION_CREDENTIALS`` is unset.
 
-    pytest -m "not live_tts"      # skip live API calls
-    pytest tests/integration/test_google_tts.py   # run only this test
+Marker filter:
 
-Skipped automatically when ``GOOGLE_APPLICATION_CREDENTIALS`` is unset
-or the optional ``google-cloud-texttospeech`` extra is not installed.
+    pytest -m "not live_tts"   # skip live API calls in fast loops
 """
 
 from __future__ import annotations
 
+import importlib.util
 import io
 import os
-import wave
+from pathlib import Path
 
 import numpy as np
 import pytest
 import soundfile as sf
 
+from synthbanshee.config.speaker_config import SpeakerConfig
 from synthbanshee.tts.google_provider import GoogleProvider
 from synthbanshee.tts.ssml_builder import SSMLBuilder
 
-# Short Hebrew utterance — kept brief to keep the test cheap.
-_HEBREW_UTTERANCE = "שלום, זאת בדיקה."
+# A known Google-voiced speaker YAML.  Drives the test from real config so
+# that voice deprecation in YAMLs (or removal of the Google provider from
+# this speaker) breaks this test instead of silently passing against a
+# stale hard-coded voice ID.
+_GOOGLE_SPEAKER_YAML = (
+    Path(__file__).parent.parent.parent / "configs" / "speakers" / "speaker_BEN_M_40-55_004.yaml"
+)
 
-# Real Google he-IL Chirp 3 HD voice — verify with scripts/check_google_voices.py.
-_VOICE_ID = "he-IL-Chirp3-HD-Achird"
+# Short Hebrew utterance — kept brief to keep the test cheap.  ~4 words.
+_HEBREW_UTTERANCE = "שלום, זאת בדיקה."
 
 # Google TTS LINEAR16 output rate, wrapped by GoogleProvider._pcm_to_wav.
 _EXPECTED_SAMPLE_RATE_HZ = 24_000
@@ -43,77 +49,71 @@ _EXPECTED_SAMPLE_RATE_HZ = 24_000
 # Floor for "clearly non-silent" speech on a [-1, 1] float32 scale.
 _RMS_FLOOR = 0.005
 
+# Plausibility window for a ~4-word Hebrew utterance.  A degenerate response
+# (silence sliver, error fallback, partial audio) falls outside this range.
+_DURATION_MIN_S = 1.0
+_DURATION_MAX_S = 15.0
+
 
 def _credentials_available() -> bool:
     return bool(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"))
 
 
-def _google_sdk_available() -> bool:
-    try:
-        import google.cloud.texttospeech  # type: ignore[import-untyped]  # noqa: F401
-    except ImportError:
-        return False
-    return True
+def _google_sdk_installed() -> bool:
+    """True iff ``google-cloud-texttospeech`` is importable.
 
-
-_SKIP_REASON = (
-    "Live Google TTS test: requires GOOGLE_APPLICATION_CREDENTIALS and the "
-    "google-cloud-texttospeech extra (`pip install 'synthbanshee[google-tts]'`)."
-)
+    Uses ``find_spec`` so we don't trigger the SDK's import side effects
+    at pytest collection time — same reason ``GoogleProvider`` lazy-imports.
+    """
+    return importlib.util.find_spec("google.cloud.texttospeech") is not None
 
 
 @pytest.mark.live_tts
 @pytest.mark.skipif(
-    not (_credentials_available() and _google_sdk_available()),
-    reason=_SKIP_REASON,
+    not _google_sdk_installed(),
+    reason="google-cloud-texttospeech not installed (`pip install 'synthbanshee[google-tts]'`)",
 )
-def test_google_tts_round_trip_returns_valid_non_silent_wav() -> None:
-    """One short Hebrew utterance survives the SSMLBuilder → Google → WAV path."""
+@pytest.mark.skipif(
+    not _credentials_available(),
+    reason="GOOGLE_APPLICATION_CREDENTIALS is not set",
+)
+def test_google_tts_round_trip_returns_plausible_non_silent_audio() -> None:
+    """A short Hebrew utterance synthesizes to plausible, non-silent audio.
+
+    Asserts only what Google actually controls: the call succeeds, the
+    returned audio is decodable as a 24 kHz mono float waveform, its
+    duration is plausible for the input, and it is not silent.  WAV
+    container shape is owned by ``_pcm_to_wav`` and covered by unit tests
+    — not re-asserted here.
+    """
+    speaker = SpeakerConfig.from_yaml(_GOOGLE_SPEAKER_YAML)
+    assert speaker.tts_provider == "google", (
+        f"Test fixture speaker must use Google TTS, got {speaker.tts_provider!r}"
+    )
+    style_entry = speaker.style_for_intensity(2)
+
     builder = SSMLBuilder()
     ssml = builder.build_from_speaker_config(
         text=_HEBREW_UTTERANCE,
-        voice_id=_VOICE_ID,
-        style="General",
-        rate_multiplier=1.0,
+        voice_id=speaker.tts_voice_id,
+        style=style_entry.style,
+        rate_multiplier=style_entry.rate_multiplier,
+        pitch_delta_st=style_entry.pitch_delta_st,
+        volume_delta_db=style_entry.volume_delta_db,
         supports_style_tags=False,
     )
-
-    # Regression guard: SSML for Google must never carry Azure-only mstts tags.
-    assert "mstts" not in ssml
-    assert "express-as" not in ssml
 
     wav_bytes = GoogleProvider().synthesize(ssml)
-
-    assert wav_bytes[:4] == b"RIFF", "Output must start with a RIFF/WAV header"
-    with wave.open(io.BytesIO(wav_bytes), "r") as w:
-        assert w.getnchannels() == 1, "Output must be mono"
-        assert w.getsampwidth() == 2, "Output must be 16-bit (sampwidth=2)"
-        assert w.getframerate() == _EXPECTED_SAMPLE_RATE_HZ
-        assert w.getnframes() > 0
-
     audio, sample_rate = sf.read(io.BytesIO(wav_bytes), dtype="float32")
+
     assert sample_rate == _EXPECTED_SAMPLE_RATE_HZ
-    assert audio.ndim == 1, "Output must be mono (single channel)"
+    assert audio.ndim == 1, "expected mono audio"
+
+    duration_s = audio.shape[0] / sample_rate
+    assert _DURATION_MIN_S < duration_s < _DURATION_MAX_S, (
+        f"audio duration {duration_s:.3f}s outside plausible window "
+        f"[{_DURATION_MIN_S}, {_DURATION_MAX_S}] for utterance {_HEBREW_UTTERANCE!r}"
+    )
 
     rms = float(np.sqrt(np.mean(audio**2)))
-    assert rms > _RMS_FLOOR, f"Audio appears silent (RMS={rms:.5f})"
-
-
-def test_ssml_builder_google_mode_emits_no_mstts() -> None:
-    """Cheap regression guard for the ``supports_style_tags=False`` path.
-
-    Runs without API access so it always executes — the round-trip test
-    is gated on credentials, but this snapshot check is not.
-    """
-    builder = SSMLBuilder()
-    ssml = builder.build_from_speaker_config(
-        text=_HEBREW_UTTERANCE,
-        voice_id=_VOICE_ID,
-        style="angry",  # non-General style still must not produce express-as
-        rate_multiplier=1.1,
-        pitch_delta_st=2.0,
-        supports_style_tags=False,
-    )
-    assert "mstts" not in ssml
-    assert "express-as" not in ssml
-    assert _VOICE_ID in ssml
+    assert rms > _RMS_FLOOR, f"audio appears silent (RMS={rms:.5f})"


### PR DESCRIPTION
## Summary

Closes #40.

Every existing `GoogleProvider` test mocks the TTS client, so there was no test verifying that the SSML our code generates is actually accepted by Google's API or that synthesis returns plausible, non-silent audio. This PR adds `tests/integration/test_google_tts.py` to fill that gap, plus the plumbing to opt into the live test safely and to run it on a schedule so drift gets caught automatically.

## What's in the PR

**`tests/integration/test_google_tts.py`** — one live round-trip test:
- Loads a real Google-voiced speaker YAML via `SpeakerConfig.from_yaml(...)` and derives voice + prosody from it (so YAML drift or voice deprecation breaks the test instead of silently passing against a stale literal).
- Builds SSML via `SSMLBuilder.build_from_speaker_config(supports_style_tags=False)`.
- Calls real `GoogleProvider().synthesize` (no mocks).
- Reads the response with `soundfile`, asserts the call succeeded, sample rate is 24 kHz, **duration is plausible** for the input (1–15 s — guards against degenerate slivers), and audio is non-silent (RMS > 0.005 on a [-1, 1] scale).
- Does **not** re-assert WAV container shape (channels, sampwidth, RIFF). Those bytes are written by our own `_pcm_to_wav`, not by Google, and are covered by unit tests in `tests/unit/test_google_provider.py`.

**`tests/conftest.py`** — opt-in flag for live tests:
- `pytest --run-live-tts` runs `live_tts`-marked tests; without the flag they're auto-skipped.
- Default `pytest tests/ -v` (what existing CI runs) is now safe — never bills.

**`.github/workflows/live-tts.yml`** — scheduled regression workflow:
- Weekly cron (Sun 04:00 UTC) plus `workflow_dispatch`.
- Installs the `[google-tts]` extra (default CI matrix doesn't).
- Writes `secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON` to a temp file and points `GOOGLE_APPLICATION_CREDENTIALS` at it.
- Runs `pytest --run-live-tts -m live_tts`.
- Gated on `github.repository == 'DataHackIL/SynthBanshee'` so forks without the secret don't fail noisily.

**`pyproject.toml`** — registers the `live_tts` pytest marker.

## Skip behavior

| Invocation | Live test |
|---|---|
| `pytest` (default) | skipped — `live_tts` marker auto-skipped without `--run-live-tts` |
| `pytest --run-live-tts` | runs (real Google API call) |
| `pytest --run-live-tts` (no creds discoverable) | runtime-skipped via `DefaultCredentialsError` (covers env var, gcloud login, metadata server) |
| `pytest -m "not live_tts"` | deselected |
| `pytest` without `google-cloud-texttospeech` installed | skipped — SDK absent |

## Action required after merge

A maintainer must add a repo secret before the scheduled workflow can pass:

- **Secret name:** `GOOGLE_APPLICATION_CREDENTIALS_JSON`
- **Value:** full JSON contents of a GCP service-account key with `roles/cloudtexttospeech.user`.

Until then, scheduled runs will fail fast at the "Write GCP service account JSON" step with a clear error. The PR is mergeable without this — the per-PR matrix isn't affected.

## Test plan

- [x] `pytest --run-live-tts tests/integration/test_google_tts.py -v` (with creds) — **1 passed** (~3.4 s of audio, RMS ≈ 0.076)
- [x] `pytest tests/integration/test_google_tts.py -v` (no flag) — **1 skipped** ("live_tts test — pass --run-live-tts to run")
- [x] `pytest tests/integration/test_google_tts.py -m "not live_tts"` — **1 deselected**
- [x] `pytest -q` (full suite, no flag) — **1707 passed, 1 skipped** (no regressions, live test correctly skipped)
- [x] `ruff check`, `ruff format --check` — clean
- [x] Pre-commit hooks (ruff, ruff format, mypy, yaml) — pass

## Review iterations

1. **Self-review** (commit `3207edb`) — dropped duplicated SSML-snapshot test, removed tautological WAV-shape asserts, added duration-plausibility window, switched to YAML-driven voice, used `find_spec` for SDK detection, split skipif decorators.
2. **CI fix + Copilot review pass 1** (commit `caa06c4`) — `find_spec` raised `ModuleNotFoundError` on CI machines without the parent `google` package installed; wrapped in try/except. Replaced env-var cred check with runtime catch on `google.auth.exceptions.DefaultCredentialsError` (covers full ADC chain). Added `tests/conftest.py` with `--run-live-tts` opt-in so CI doesn't silently bill.
3. **Copilot review pass 2** (commit `cb8f925`) — added scheduled live-tts workflow so the regression check actually runs (weekly + dispatch); without it the test was manual-only and drift would still slip through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)