### PR TITLE
fix(tts): #87 partial — effective-prosody cap addresses Whisper backdoor + helium range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ SFX onset/offset times come **only** from the Stage 3b augmentation log. Speech-
 - **Cache key: SHA-256 of the full rendered SSML string** — not `(voice_id, text)`
 - **M3a — per-turn RMS gain:** `StyleEntry.rms_target_dbfs` → module-level `_apply_rms_gain()` in `synthbanshee/tts/mixer.py`; 4-tuple segment API `(wav_bytes, pause_s, speaker_id, rms_target_dbfs)`
 - **Temp WAV from mixer must be `subtype="FLOAT"`** — never `PCM_16` before `preprocess()` to avoid hard-clipping M3 gain
+- **#87 effective-prosody cap:** `synthbanshee/tts/renderer._apply_effective_prosody_cap` clamps post-state, post-randomization prosody to `pitch ∈ [−3.0, +2.0] st`, `rate ∈ [0.85, 1.20]`. Volume is left to `_volume_to_string`'s ±50% Azure clamp (Whisper internally normalizes loudness; #82 lever probe). Cap activations are recorded per-turn in `DialogueTurn.effective_prosody_caps` and rolled up into `ClipMetadata.generation_metadata.effective_prosody_caps`. Caps are anchored to the pre-#51 effective envelope (the 04-15 reference baseline that Whisper handles with WER 0.04–0.08); changing them requires a paired listening test + Whisper sanity check (see "ASR sanity check policy" below).
 
 ## Splits
 
@@ -84,6 +85,23 @@ SFX onset/offset times come **only** from the Stage 3b augmentation log. Speech-
   2. WAV passes `validate_audio()` — 16 kHz, mono, peak ≤ −1.0 dBFS, duration ≥ 3 s
   3. JSON parses as `ClipMetadata` with `is_synthetic=True`
   4. Filename stem is ASCII-only lowercase
+
+## ASR sanity check policy (#87)
+
+The Whisper-large-v3 sanity check (`synthbanshee qa-report --asr`) detects audio that synthesizes fine to a listener but trips Whisper's silence-detection / segmentation heuristic — the failure mode that surfaced in #87 and went undetected on `sp_it_a_0001` for weeks. The canonical fingerprint is **length-ratio collapse** (`hyp_words / ref_words < 0.85`).
+
+**Cost:** ~5–20 s per clip on M-series MPS, ~3 GB Whisper-large-v3 download on first use. Real Azure render to populate the cache is an additional ~$0.05–$0.20 per scene.
+
+**Policy — for the foreseeable future, this check is _local-only_, not in CI:**
+
+1. **Unit tests** for the cap logic (in `tests/unit/test_effective_prosody_cap.py`) run on every PR. They cover ~90 % of regressions with no Azure / Whisper cost.
+2. **`qa-report --asr` (Tier-3)** is run **locally**, **once**, **after all PR reviews and fixes are done**, **and only for PRs that might affect audio rendering** (anything touching `synthbanshee/tts/`, `synthbanshee/script/`, `synthbanshee/augment/`, or the speaker / scene / acoustic / project YAML configs). PRs that only touch labels, packaging, docs, or tests skip it.
+3. **Cost discipline:** use this command **very sparingly** — each invocation incurs Azure spend (~$1–$2 per real-render run). Prefer running against a directory of already-cached clips when possible; only re-render when a code change invalidates the SSML cache.
+4. **Result documentation:** when run, paste the `qa-report --asr` output (table of any clips with `length_ratio < 0.85`, plus the green-tick "no asr warnings" line if all clean) into the PR body's "Test plan" section under a "Tier-3 ASR sanity (local)" sub-heading.
+
+**Future CI consideration:** see GH issue tracking the addition of a scheduled / labeled Whisper-based CI workflow, including repo-secret management for `AZURE_TTS_KEY` and Azure spend caps. Re-evaluate when scene volume increases enough that local manual runs become impractical.
+
+**Install:** `uv pip install --python .venv/bin/python -e ".[eval-asr]"` (heavyweight optional extra).
 
 ## Environment variables
 
@@ -153,3 +171,5 @@ When addressing PR review comments (Copilot, human, or bot):
 - Don't generate clips shorter than 3.0 s
 - Don't add a new typology to `taxonomy.yaml` without adding it to `_TYPOLOGY_INTENSITY_MAP`
 - Don't pin `pr-agent-context` workflow references to a specific patch version — keep `@v4` floating
+- Don't relax the #87 effective-prosody cap (`_EFFECTIVE_PITCH_*`, `_EFFECTIVE_RATE_*` in `synthbanshee/tts/renderer.py`) without a paired listening test + `qa-report --asr` Tier-3 run; the cap defends both naturalness (May-3 listening test) and Whisper transcription
+- Don't merge a PR that touches audio rendering (`synthbanshee/tts/`, `synthbanshee/script/`, `synthbanshee/augment/`, or speaker / scene / acoustic / project YAMLs) without running `qa-report --asr` locally first and pasting the result into the PR's test plan (see "ASR sanity check policy")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,17 @@ google-tts = [
     "google-cloud-texttospeech>=2.16",
 ]
 
+# Whisper-based ASR sanity for `qa-report --asr` (#87 length-ratio detector).
+# Heavyweight: pulls torch + transformers + ~3 GB of Whisper-large-v3 weights
+# on first use.  Not required for normal generation/QA — only install when
+# running the ASR sanity check locally (see CLAUDE.md "ASR sanity check policy").
+eval-asr = [
+    "torch>=2.0",
+    "transformers>=4.40",
+    "accelerate>=0.30",
+    "jiwer>=3.0",
+]
+
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -628,7 +628,7 @@ def _run_generate_pipeline(
     from collections import Counter
 
     from synthbanshee import __version__
-    from synthbanshee.labels.schema import GenerationMetadata
+    from synthbanshee.labels.schema import EffectiveProsodyCapEvent, GenerationMetadata
 
     # Per-speaker TTS backend and voice family.
     _backends_map: dict[str, str] = {sid: spk.tts_provider for sid, spk in speakers.items()}
@@ -655,6 +655,19 @@ def _run_generate_pipeline(
         if turn.speaker_id not in _speaker_states and turn.speaker_state_snapshot:
             _speaker_states[turn.speaker_id] = turn.speaker_state_snapshot
 
+    # #87: roll up per-turn effective-prosody cap activations into clip metadata.
+    _cap_events: list[EffectiveProsodyCapEvent] = [
+        EffectiveProsodyCapEvent(
+            turn_index=i,
+            intensity=turn.intensity,
+            dim=ev["dim"],
+            pre_cap=ev["pre_cap"],
+            post_cap=ev["post_cap"],
+        )
+        for i, turn in enumerate(turns)
+        for ev in turn.effective_prosody_caps
+    ]
+
     gen_meta = GenerationMetadata(
         pipeline_version=__version__,
         tts_backend=_backends_map,
@@ -668,6 +681,7 @@ def _run_generate_pipeline(
         loudness_target_peak_dbfs=preproc_config.target_peak_dbfs,
         breathiness_applied=_breathiness_was_applied,
         speaker_state_serialized=_speaker_states,
+        effective_prosody_caps=_cap_events,
     )
 
     metadata = label_gen.generate_clip_metadata(
@@ -1444,8 +1458,29 @@ def validate(clip: Path) -> None:
     default=False,
     help="Compute and display M10b run-level aggregation metrics.",
 )
+@click.option(
+    "--asr",
+    is_flag=True,
+    default=False,
+    help="Run Whisper-large-v3 on every clip and flag length-ratio collapse "
+    "(the #87 'silence-detector trip' fingerprint). Heavyweight: ~5-20s per "
+    "clip on M-series MPS, ~3GB model download. Requires the 'eval-asr' extra.",
+)
+@click.option(
+    "--asr-min-length-ratio",
+    type=float,
+    default=0.85,
+    show_default=True,
+    help="Length-ratio (hyp_words / ref_words) threshold below which a clip is "
+    "flagged by --asr. The #87 fingerprint sat at ~0.70; baseline is 1.00.",
+)
 def qa_report(
-    data_dir: Path, output: Path | None, max_failure_rate: float, run_summary: bool
+    data_dir: Path,
+    output: Path | None,
+    max_failure_rate: float,
+    run_summary: bool,
+    asr: bool,
+    asr_min_length_ratio: float,
 ) -> None:
     """Run the automated QA suite on a dataset directory.
 
@@ -1455,12 +1490,22 @@ def qa_report(
     from synthbanshee.package.qa import (
         _HIGH_EMOTION_DOWNGRADE_RATE,
         _MIN_VOICE_DIVERSITY,
+        run_asr_check,
         run_qa,
     )
 
     console.print(f"[cyan]Running QA on:[/cyan] {data_dir}")
     report = run_qa(data_dir, max_failure_rate=max_failure_rate, run_summary=run_summary)
     stats = report.stats
+
+    # #87: opt-in Whisper sanity check.  Runs after run_qa so we already
+    # know the clips that validated; ASR results attach to the same report.
+    if asr:
+        console.print(
+            f"[cyan]Running ASR sanity (Whisper-large-v3, "
+            f"length_ratio < {asr_min_length_ratio}):[/cyan] {data_dir}"
+        )
+        report.asr_warnings = run_asr_check(data_dir, min_length_ratio=asr_min_length_ratio)
 
     table = Table(title="Dataset Statistics")
     table.add_column("Metric")
@@ -1476,6 +1521,12 @@ def qa_report(
     )
     table.add_row("Unique speakers", str(stats.speaker_count))
     table.add_row("Quality-flagged", str(stats.quality_flagged_clips))
+    if stats.clips_with_prosody_cap_activations > 0:
+        table.add_row(
+            "Clips with prosody-cap activations (#87)",
+            f"[yellow]{stats.clips_with_prosody_cap_activations}[/yellow]"
+            f" ({stats.prosody_cap_activations_total} total events)",
+        )
     missing_jsonl_label = (
         f"[yellow]{stats.clips_missing_strong_labels}[/yellow]"
         if stats.clips_missing_strong_labels > 0
@@ -1516,6 +1567,44 @@ def qa_report(
             console.print(f"  [red]• {clip_id}[/red]")
         if len(report.failed_clip_ids) > 20:
             console.print(f"  ... and {len(report.failed_clip_ids) - 20} more")
+
+    # #87: prosody-cap activations are surfaced as a top-level table because
+    # they catch a class of regression that the M10a/M10b checks cannot —
+    # specifically, prosody pushed past the listening-test-validated envelope.
+    if report.prosody_cap_activations:
+        t_caps = Table(title="Effective-Prosody Cap Activations (#87)")
+        t_caps.add_column("Clip ID")
+        t_caps.add_column("Cap events", justify="right")
+        for clip_id, count in sorted(
+            report.prosody_cap_activations.items(),
+            key=lambda kv: kv[1],
+            reverse=True,
+        )[:20]:
+            t_caps.add_row(clip_id, str(count))
+        console.print(t_caps)
+        if len(report.prosody_cap_activations) > 20:
+            console.print(f"  ... and {len(report.prosody_cap_activations) - 20} more")
+
+    # #87: ASR sanity surfaces clips whose length-ratio collapsed below the
+    # configured threshold — the Whisper "silence-detector trip" fingerprint.
+    if report.asr_warnings:
+        t_asr = Table(title=f"ASR Sanity Failures (#87, length_ratio < {asr_min_length_ratio})")
+        t_asr.add_column("Clip ID")
+        t_asr.add_column("WER", justify="right")
+        t_asr.add_column("len_ratio", justify="right")
+        t_asr.add_column("hyp / ref", justify="right")
+        for clip_id, m in sorted(report.asr_warnings.items(), key=lambda kv: kv[1]["length_ratio"])[
+            :20
+        ]:
+            t_asr.add_row(
+                clip_id,
+                f"{m['wer']:.3f}",
+                f"[red]{m['length_ratio']:.3f}[/red]",
+                f"{m['hyp_words']} / {m['ref_words']}",
+            )
+        console.print(t_asr)
+        if len(report.asr_warnings) > 20:
+            console.print(f"  ... and {len(report.asr_warnings) - 20} more")
 
     # --- M10b: run-level summary table ---
     if report.run_summary is not None:
@@ -1595,28 +1684,34 @@ def qa_report(
 
     if output is not None:
         output.parent.mkdir(parents=True, exist_ok=True)
-        report_dict = {
+        stats_dict: dict[str, object] = {
+            "total_clips": stats.total_clips,
+            "failed_clips": stats.failed_clips,
+            "total_duration_seconds": stats.total_duration_seconds,
+            "speaker_count": stats.speaker_count,
+            "quality_flagged_clips": stats.quality_flagged_clips,
+            "clips_missing_strong_labels": stats.clips_missing_strong_labels,
+            "clips_by_typology": stats.clips_by_typology,
+            "clips_by_split": stats.clips_by_split,
+            "clips_by_tier": stats.clips_by_tier,
+            "intensity_distribution": {str(k): v for k, v in stats.intensity_distribution.items()},
+            # #87: surface the prosody-cap counts in the JSON report so CI /
+            # post-batch scripts can detect drift without parsing every clip.
+            "clips_with_prosody_cap_activations": stats.clips_with_prosody_cap_activations,
+            "prosody_cap_activations_total": stats.prosody_cap_activations_total,
+        }
+        report_dict: dict[str, object] = {
             "data_dir": report.data_dir,
             "passed": report.passed,
             "failure_rate": report.failure_rate,
-            "stats": {
-                "total_clips": stats.total_clips,
-                "failed_clips": stats.failed_clips,
-                "total_duration_seconds": stats.total_duration_seconds,
-                "speaker_count": stats.speaker_count,
-                "quality_flagged_clips": stats.quality_flagged_clips,
-                "clips_missing_strong_labels": stats.clips_missing_strong_labels,
-                "clips_by_typology": stats.clips_by_typology,
-                "clips_by_split": stats.clips_by_split,
-                "clips_by_tier": stats.clips_by_tier,
-                "intensity_distribution": {
-                    str(k): v for k, v in stats.intensity_distribution.items()
-                },
-            },
+            "stats": stats_dict,
             "failed_clip_ids": report.failed_clip_ids,
             "quality_flagged": report.quality_flagged,
             "acoustic_warnings": report.acoustic_warnings,
             "structural_warnings": report.structural_warnings,
+            # #87: prosody-cap activations + ASR sanity (empty unless --asr).
+            "prosody_cap_activations": report.prosody_cap_activations,
+            "asr_warnings": report.asr_warnings,
         }
         if report.run_summary is not None:
             rs = report.run_summary

--- a/synthbanshee/labels/schema.py
+++ b/synthbanshee/labels/schema.py
@@ -126,6 +126,23 @@ class PreprocessingApplied(BaseModel):
     silence_padded: bool = False
 
 
+class EffectiveProsodyCapEvent(BaseModel):
+    """One activation of the #87 runtime effective-prosody cap.
+
+    Recorded per turn and per dimension when the post-state, post-randomization
+    prosody value would have exceeded the envelope that Whisper-large-v3 can
+    transcribe and the listener finds natural at high intensities.  See
+    ``synthbanshee.tts.renderer._apply_effective_prosody_cap`` for thresholds
+    and rationale.
+    """
+
+    turn_index: int = Field(ge=0)
+    intensity: int = Field(ge=1, le=5)
+    dim: Literal["rate", "pitch", "volume"]
+    pre_cap: float
+    post_cap: float
+
+
 class GenerationMetadata(BaseModel):
     """Pipeline provenance metadata for ablation studies (spec §4.11).
 
@@ -160,6 +177,17 @@ class GenerationMetadata(BaseModel):
 
     breathiness_applied: bool = False
     speaker_state_serialized: dict[str, dict[str, float]] = Field(default_factory=dict)
+
+    effective_prosody_caps: list[EffectiveProsodyCapEvent] = Field(default_factory=list)
+    """Per-turn activations of the #87 effective-prosody cap.
+
+    One entry per ``(turn_index, dim)`` clamp.  An empty list means every turn's
+    effective prosody fell within the envelope (post-state, post-randomization).
+    A non-empty list is a static signal that the renderer pulled the turn's
+    pitch or rate back from the helium / Whisper-trip range — typically a small
+    number of high-intensity turns near the end of an arc with significant M7
+    SpeakerState drift.  Use ``synthbanshee qa-report`` to flag clips with
+    ``len(effective_prosody_caps) > N``."""
 
 
 # ---------------------------------------------------------------------------

--- a/synthbanshee/package/asr_sanity.py
+++ b/synthbanshee/package/asr_sanity.py
@@ -1,0 +1,176 @@
+"""Whisper-based per-clip ASR sanity check (#87).
+
+Detects the Whisper "backdoor" failure mode: clips that synthesize fine to a
+listener but trip Whisper-large-v3's silence-detection / segmentation
+heuristic, causing the encoder to mis-segment audio chunks as silence and
+drop ~20–30% of words from the hypothesis.  This manifests as:
+
+  - High WER (≥ ~0.20) without any obvious audio defect.
+  - **Length ratio** (`hyp_words / ref_words`) collapsing well below 1.0
+    (the #87 cases sat at 0.70–0.76; the 04-15 baseline was 1.00).
+
+The length-ratio collapse is the canonical fingerprint and the metric that
+``run_asr_sanity`` flags on.  WER alone is noisier (it counts substitutions
+and insertions too) and produces false positives on natural pronunciation
+variation.
+
+Heavy dependencies (``transformers``, ``torch``, ``jiwer``) are intentionally
+**lazy-imported** inside the runner so importing this module is cheap and
+does not pull the Whisper weights into memory.  Install with:
+
+    uv pip install --python .venv/bin/python -e ".[eval-asr]"
+
+This module is invoked from ``qa-report --asr``; do not use it as a quality
+gate during generation (per-clip Whisper inference is too expensive).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_log = logging.getLogger(__name__)
+
+# Default Whisper backbone.  Pinned to large-v3 because the #87 evidence base
+# was collected on this exact model; switching alters the silence-detection
+# behaviour and would require re-baselining every flagged clip.
+DEFAULT_MODEL = "openai/whisper-large-v3"
+DEFAULT_LANGUAGE = "he"
+
+
+# Regex factored out from `scripts/m17_phase_a_validation.py` so qa-report
+# and the spike script agree on what counts as a "word" for WER.  Strip
+# punctuation, normalize whitespace, leave Hebrew letters and digits intact.
+_WER_PUNCT_RE = re.compile(r"[^\w\s֐-׿]+", re.UNICODE)
+_WER_WS_RE = re.compile(r"\s+")
+
+
+def normalize_for_wer(text: str) -> str:
+    """Strip punctuation and collapse whitespace for jiwer's word tokenizer."""
+    return _WER_WS_RE.sub(" ", _WER_PUNCT_RE.sub(" ", text)).strip()
+
+
+def _read_reference_text(txt_path: Path) -> str:
+    """Read the bracket-stripped Hebrew transcript from a clip's .txt file."""
+    raw = txt_path.read_text(encoding="utf-8")
+    lines = [ln for ln in raw.splitlines() if ln and not ln.startswith("[")]
+    return "\n".join(lines).strip()
+
+
+@dataclass(frozen=True)
+class AsrMetrics:
+    """Per-clip ASR sanity result."""
+
+    wer: float
+    length_ratio: float  # hyp_words / max(ref_words, 1)
+    hyp_words: int
+    ref_words: int
+    hyp_text: str
+
+    def is_silence_collapse(self, min_length_ratio: float) -> bool:
+        """True when ``length_ratio`` is below the threshold (the #87 fingerprint)."""
+        return self.length_ratio < min_length_ratio
+
+
+class WhisperRunner:
+    """Lazy wrapper around the HuggingFace Whisper ASR pipeline.
+
+    Instantiating this class does NOT load the model — that happens on the
+    first ``transcribe`` call.  Callers that never invoke ``transcribe`` pay
+    nothing.  Re-using one instance across many clips amortizes the
+    ~5–10 s model-load cost.
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        language: str = DEFAULT_LANGUAGE,
+        chunk_length_s: int = 30,
+    ) -> None:
+        self.model = model
+        self.language = language
+        self.chunk_length_s = chunk_length_s
+        # Typed as Any because the ASR pipeline subclass varies across
+        # transformers versions and we lazy-import to avoid the dependency.
+        self._asr: Any = None  # lazy
+
+    def _ensure_loaded(self) -> None:
+        if self._asr is not None:
+            return
+        try:
+            import torch
+            from transformers import pipeline
+        except ImportError as e:  # pragma: no cover - import-time error path
+            raise ImportError(
+                "ASR sanity requires the 'eval-asr' extra. Install with:\n"
+                '  uv pip install -e ".[eval-asr]"\n'
+                f"Underlying error: {e}"
+            ) from e
+
+        device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
+        _log.info("Loading Whisper model %s on %s", self.model, device)
+        self._asr = pipeline(
+            "automatic-speech-recognition",
+            model=self.model,
+            device=device,
+            torch_dtype=torch.float32,
+            chunk_length_s=self.chunk_length_s,
+        )
+
+    def transcribe(self, wav_samples, sample_rate: int) -> str:
+        """Run the model on a numpy float32 mono buffer; return the hypothesis text."""
+        self._ensure_loaded()
+        assert self._asr is not None
+        out = self._asr(
+            {"raw": wav_samples.copy(), "sampling_rate": sample_rate},
+            generate_kwargs={
+                "language": self.language,
+                "task": "transcribe",
+                "num_beams": 1,
+                "do_sample": False,
+            },
+        )
+        return out["text"]
+
+
+def compute_asr_metrics(
+    wav_path: Path,
+    txt_path: Path,
+    runner: WhisperRunner,
+) -> AsrMetrics:
+    """Read a clip's WAV + reference TXT and compute WER + length-ratio.
+
+    Reuses ``runner`` so the Whisper model is loaded at most once across many
+    clips.  ``txt_path`` is parsed with ``_read_reference_text`` (bracket lines
+    stripped); the resulting text is the WER reference.
+    """
+    try:
+        from jiwer import wer
+    except ImportError as e:  # pragma: no cover - import-time error path
+        raise ImportError(
+            "ASR sanity requires 'jiwer'. Install with: uv pip install -e \".[eval-asr]\""
+        ) from e
+    import soundfile as sf
+
+    samples, sr = sf.read(str(wav_path), dtype="float32")
+    if samples.ndim > 1:
+        samples = samples.mean(axis=1)
+
+    ref_text = _read_reference_text(txt_path)
+    hyp_text = runner.transcribe(samples, sr)
+
+    ref_norm = normalize_for_wer(ref_text)
+    hyp_norm = normalize_for_wer(hyp_text)
+    ref_words = max(len(ref_norm.split()), 1)
+    hyp_words = len(hyp_norm.split())
+
+    return AsrMetrics(
+        wer=float(wer(ref_norm, hyp_norm)),
+        length_ratio=hyp_words / ref_words,
+        hyp_words=hyp_words,
+        ref_words=ref_words,
+        hyp_text=hyp_text,
+    )

--- a/synthbanshee/package/qa.py
+++ b/synthbanshee/package/qa.py
@@ -107,6 +107,10 @@ class DatasetStats:
     # M10b structural warning counters (separate from acoustic)
     structural_warnings: dict[str, int] = field(default_factory=dict)
     clips_with_structural_warnings: int = 0
+    # #87: clips whose generation_metadata recorded one or more
+    # effective-prosody cap activations.  Static signal; needs no audio access.
+    clips_with_prosody_cap_activations: int = 0
+    prosody_cap_activations_total: int = 0
 
 
 @dataclass
@@ -150,6 +154,17 @@ class QAReport:
     passed: bool = False
     failure_rate: float = 0.0
     run_summary: RunSummary | None = None
+    # #87: per-clip effective-prosody cap activation counts (clip_id -> count).
+    # Empty when no clip ever tripped the cap during generation.  A non-empty
+    # entry means the renderer pulled this clip's pitch/rate back from the
+    # helium / Whisper-trip range — frequent activations across many clips
+    # warrant a listening-test review of the speaker style_map.
+    prosody_cap_activations: dict[str, int] = field(default_factory=dict)
+    # #87: per-clip ASR sanity results, populated only when ``run_asr_check``
+    # is called.  Maps clip_id -> dict with keys ``wer``, ``length_ratio``,
+    # ``hyp_words``, ``ref_words``.  Clips below the length-ratio threshold
+    # exhibit the Whisper silence-detector failure mode.
+    asr_warnings: dict[str, dict] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -394,6 +409,14 @@ def run_qa(
             stats.quality_flagged_clips += 1
             report.quality_flagged[metadata.clip_id] = list(metadata.quality_flags)
 
+        # #87: count effective-prosody cap activations from generation metadata.
+        if metadata.generation_metadata is not None:
+            cap_count = len(metadata.generation_metadata.effective_prosody_caps)
+            if cap_count > 0:
+                stats.clips_with_prosody_cap_activations += 1
+                stats.prosody_cap_activations_total += cap_count
+                report.prosody_cap_activations[metadata.clip_id] = cap_count
+
         # Count Stage 4b JSONL warnings surfaced by validate_clip()
         if any("Strong labels JSONL missing" in w for w in validation.warnings):
             stats.clips_missing_strong_labels += 1
@@ -512,3 +535,64 @@ def run_qa(
         report.run_summary = summary
 
     return report
+
+
+def run_asr_check(
+    data_dir: Path,
+    *,
+    min_length_ratio: float = 0.85,
+    model: str | None = None,
+) -> dict[str, dict]:
+    """Run Whisper-based per-clip ASR sanity on all valid clips in *data_dir*.
+
+    Detects the #87 Whisper "backdoor": clips that synthesize fine to a
+    listener but cause Whisper-large-v3 to mis-segment audio chunks as
+    silence and drop ~20–30 % of words.  Length ratio
+    (``hyp_words / ref_words``) is the canonical fingerprint — the #87
+    cases sat at 0.70–0.76 vs the 04-15 baseline at 1.00.
+
+    Returns a dict mapping ``clip_id`` → dict of metrics for clips whose
+    length ratio falls below ``min_length_ratio``.  Clips that pass are
+    not reported (the audit is "show me the failures").
+
+    This is heavyweight — Whisper-large-v3 takes ~5–20 s per clip on M-series
+    MPS — so it is opt-in via ``qa-report --asr``.  Whisper weights load
+    lazily on the first clip; reuse one ``WhisperRunner`` across all clips
+    to amortize the load cost (the function does this internally).
+
+    Args:
+        data_dir: Same layout as ``run_qa``: ``{speaker_id}/{clip_id}.wav``.
+        min_length_ratio: Clips with ratio below this are flagged.  Default
+            0.85 leaves comfortable margin above the #87 fingerprint (0.70).
+        model: HuggingFace model id; defaults to ``openai/whisper-large-v3``.
+            Pinned by default because the #87 evidence base used this exact
+            model — switching would require re-baselining flagged clips.
+    """
+    from synthbanshee.package.asr_sanity import (
+        DEFAULT_MODEL,
+        WhisperRunner,
+        compute_asr_metrics,
+    )
+
+    runner = WhisperRunner(model=model or DEFAULT_MODEL)
+    flagged: dict[str, dict] = {}
+    wav_paths = [p for p in sorted(data_dir.rglob("*.wav")) if "_dirty" not in p.stem]
+
+    for wav_path in wav_paths:
+        txt_path = wav_path.with_suffix(".txt")
+        if not txt_path.exists():
+            continue
+        try:
+            metrics = compute_asr_metrics(wav_path, txt_path, runner)
+        except Exception:
+            logger.warning("ASR sanity failed for %s", wav_path.stem, exc_info=True)
+            continue
+        if metrics.is_silence_collapse(min_length_ratio):
+            flagged[wav_path.stem] = {
+                "wer": round(metrics.wer, 4),
+                "length_ratio": round(metrics.length_ratio, 4),
+                "hyp_words": metrics.hyp_words,
+                "ref_words": metrics.ref_words,
+            }
+
+    return flagged

--- a/synthbanshee/script/types.py
+++ b/synthbanshee/script/types.py
@@ -54,6 +54,12 @@ class DialogueTurn:
     # M15: quality gate failures recorded during render_scene().
     # Each entry is "{gate_name}: {detail}".  Empty list means all gates passed.
     quality_gate_failures: list[str] = field(default_factory=list)
+    # #87: per-turn effective-prosody cap activations (post-state, post-randomize).
+    # Each event is a dict with keys ``dim`` ("rate" or "pitch"), ``pre_cap``,
+    # ``post_cap``.  Empty list means the turn's effective prosody fell within
+    # the envelope; non-empty means the renderer clamped one or more dimensions
+    # to defend against the helium / Whisper-trip range.
+    effective_prosody_caps: list[dict] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         # Default text_spoken to the original LLM text when not explicitly set.

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -11,6 +11,7 @@ Spec reference: docs/implementation_plan.md §0.3
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -27,10 +28,77 @@ from synthbanshee.tts.speaker_state import SpeakerState
 from synthbanshee.tts.ssml_builder import SSMLBuilder
 from synthbanshee.tts.ssml_types import PhraseProsody, collect_phrase_prosody, rebase_phrase_prosody
 
+_log = logging.getLogger(__name__)
+
 # Verbose-log callback type.  Strings passed to this callback may contain
 # Rich markup tags (e.g. ``[dim]…[/dim]``).  Callers that do not use Rich
 # (e.g. standard loggers) should strip or ignore the markup.
 _VerboseLog = Callable[[str], None]
+
+
+# ---------------------------------------------------------------------------
+# Effective-prosody cap (#87)
+# ---------------------------------------------------------------------------
+#
+# Bound the post-state, post-randomization prosody before SSML emission.  This
+# defends against two correlated failure modes that surfaced in #87:
+#
+#   1. M7 ``SpeakerState`` drift compounds with #51's M15 style_map values to
+#      push effective pitch past +2.5 st (~+15%) and effective rate past 1.30×
+#      at I4/I5 turns.  Listening test (2026-05-03) flagged that range as
+#      cartoonish ("helium / oompa-loompa").
+#   2. The same effective-prosody range trips Whisper-large-v3's silence-
+#      detection heuristic — pitch/rate combinations outside the natural-speech
+#      training distribution cause the encoder to mis-segment chunks as silence,
+#      producing 6× WER regression with length-ratio collapse to ~0.7
+#      (the #87 fingerprint, also seen on `sp_it_a_0001`).
+#
+# Volume is intentionally NOT capped here — Whisper's log-mel feature extractor
+# internally normalizes loudness (per #82's lever probe, 7 of 8 peak/RMS variants
+# produced byte-identical Whisper hypotheses), so loudness is not a Whisper-trip
+# dimension.  Existing ±50% Azure clamp in ``ssml_builder._volume_to_string``
+# remains the only volume bound.
+#
+# Caps are anchored to the pre-#51 effective prosody envelope, which produced
+# the 04-15 reference clips with WER 0.04–0.08.  Tighter caps would diverge
+# further from M15 listening-test calibration; looser caps would re-trip
+# Whisper.  Revisit with a paired listening test + Whisper sanity check
+# (`qa-report --asr`) before changing.
+_EFFECTIVE_PITCH_MAX_ST = 2.0  # ≈ +12% — pre-#51 AGG never exceeded this with drift
+_EFFECTIVE_PITCH_MIN_ST = -3.0  # pre-#51 VIC went down to -4 baseline + drift
+_EFFECTIVE_RATE_MAX = 1.20
+_EFFECTIVE_RATE_MIN = 0.85
+
+
+def _apply_effective_prosody_cap(
+    rate: float,
+    pitch: float,
+    volume: float,
+    *,
+    out_cap_events: list[dict] | None = None,
+) -> tuple[float, float, float]:
+    """Clamp ``rate`` and ``pitch`` to the #87 effective-prosody envelope.
+
+    Returns the (possibly clamped) ``(rate, pitch, volume)`` tuple.  When
+    ``out_cap_events`` is provided, one event dict is appended per dimension
+    that was actually clamped, with keys ``dim``, ``pre_cap``, ``post_cap``.
+    Volume is returned unchanged (see module-level rationale).
+    """
+    new_pitch = max(_EFFECTIVE_PITCH_MIN_ST, min(_EFFECTIVE_PITCH_MAX_ST, pitch))
+    if new_pitch != pitch:
+        if out_cap_events is not None:
+            out_cap_events.append(
+                {"dim": "pitch", "pre_cap": round(pitch, 4), "post_cap": round(new_pitch, 4)}
+            )
+        _log.warning("Effective pitch %+.2f st clamped to %+.2f st (#87 cap)", pitch, new_pitch)
+    new_rate = max(_EFFECTIVE_RATE_MIN, min(_EFFECTIVE_RATE_MAX, rate))
+    if new_rate != rate:
+        if out_cap_events is not None:
+            out_cap_events.append(
+                {"dim": "rate", "pre_cap": round(rate, 4), "post_cap": round(new_rate, 4)}
+            )
+        _log.warning("Effective rate %.3f clamped to %.3f (#87 cap)", rate, new_rate)
+    return new_rate, new_pitch, volume
 
 
 class TTSRenderer:
@@ -129,6 +197,7 @@ class TTSRenderer:
         rng_seed: int | None = None,
         speaker_state: SpeakerState | None = None,
         phrase_prosody: list[PhraseProsody] | None = None,
+        out_cap_events: list[dict] | None = None,
     ) -> tuple[bytes, str, bool]:
         """Render a single utterance and return (wav_bytes, cache_key, cache_hit).
 
@@ -144,6 +213,10 @@ class TTSRenderer:
                 style values before SSML is built.
             phrase_prosody: Optional resolved per-phrase prosody spans (M2b).
                 Offsets must reference *text* (the final string passed here).
+            out_cap_events: Optional list that the renderer appends to when
+                the #87 effective-prosody cap fires.  One dict per clamped
+                dimension; see ``_apply_effective_prosody_cap``.  Pass an empty
+                list to capture; pass ``None`` to ignore.
 
         Returns:
             Tuple of (raw WAV bytes, cache key string, cache_hit bool).
@@ -176,6 +249,13 @@ class TTSRenderer:
             rate *= rng.uniform(0.97, 1.03)
             pitch += rng.uniform(-0.5, 0.5)
             volume += rng.uniform(-1.0, 1.0)
+
+        # #87: cap effective post-state, post-randomization prosody to keep
+        # the SSML inside the envelope that Whisper can read AND that the
+        # listener finds natural at high intensities.
+        rate, pitch, volume = _apply_effective_prosody_cap(
+            rate, pitch, volume, out_cap_events=out_cap_events
+        )
 
         provider = self._get_provider(speaker)
         ssml = self._ssml_builder.build_from_speaker_config(
@@ -305,6 +385,7 @@ class TTSRenderer:
             # Snapshot pre-render state for reproducibility metadata (prep for M11).
             turn.speaker_state_snapshot = state.to_metadata_dict()
             render_seed = rng.randint(0, 2**31) if randomize else None
+            cap_events: list[dict] = []
             wav_bytes, _, hit = self.render_utterance(
                 text,
                 speaker,
@@ -313,6 +394,7 @@ class TTSRenderer:
                 rng_seed=render_seed,
                 speaker_state=state,
                 phrase_prosody=phrases if phrases else None,
+                out_cap_events=cap_events,
             )
             # M15: run turn-level quality gates with retry on failure.
             if quality_gates:
@@ -324,6 +406,7 @@ class TTSRenderer:
                 while not gate_result.passed and retries_attempted < max_retries:
                     retries_attempted += 1
                     render_seed = rng.randint(0, 2**31)
+                    cap_events = []
                     wav_bytes, _, hit = self.render_utterance(
                         text,
                         speaker,
@@ -332,6 +415,7 @@ class TTSRenderer:
                         rng_seed=render_seed,
                         speaker_state=state,
                         phrase_prosody=phrases if phrases else None,
+                        out_cap_events=cap_events,
                     )
                     gate_result = run_quality_gates(wav_bytes, speaker.gender)
                 if not gate_result.passed:
@@ -344,6 +428,9 @@ class TTSRenderer:
                             f" (after {retries_attempted} retries):"
                             f" {failure_str}[/yellow]"
                         )
+            # #87: persist effective-prosody cap activations on the turn so cli.py
+            # can roll them up into ClipMetadata.generation_metadata.
+            turn.effective_prosody_caps = cap_events
             # Update state after rendering so the first turn always uses neutral
             # state and drift accumulates from the second turn onward.
             state.update(turn.intensity, speaker.role)

--- a/tests/unit/test_asr_sanity.py
+++ b/tests/unit/test_asr_sanity.py
@@ -1,0 +1,92 @@
+"""Tests for ``synthbanshee.package.asr_sanity`` (#87 Whisper sanity check).
+
+The heavyweight Whisper inference itself is exercised by the local Tier-3
+manual run (see CLAUDE.md "ASR sanity check policy") — these tests cover
+the lightweight surface that runs without ``torch``/``transformers``:
+
+  - ``normalize_for_wer`` — punctuation stripping + whitespace collapse so
+    the spike script and ``qa-report --asr`` agree on what counts as a word.
+  - ``AsrMetrics.is_silence_collapse`` — the threshold predicate that decides
+    whether a clip is flagged.
+  - ``_read_reference_text`` — bracket-line stripping (the ``[SPEAKER: …]``
+    headers in the .txt files must not enter the reference passed to jiwer).
+"""
+
+from __future__ import annotations
+
+from synthbanshee.package.asr_sanity import (
+    AsrMetrics,
+    _read_reference_text,
+    normalize_for_wer,
+)
+
+
+class TestNormalizeForWer:
+    def test_strips_ascii_punctuation(self):
+        assert normalize_for_wer("hello, world!") == "hello world"
+
+    def test_collapses_repeated_whitespace(self):
+        assert normalize_for_wer("hello   \n\tworld") == "hello world"
+
+    def test_preserves_hebrew_characters(self):
+        text = "שלום, עולם!"
+        assert "שלום" in normalize_for_wer(text)
+        assert "עולם" in normalize_for_wer(text)
+
+    def test_preserves_digits(self):
+        assert normalize_for_wer("abc 123 def") == "abc 123 def"
+
+    def test_empty_input(self):
+        assert normalize_for_wer("") == ""
+
+    def test_only_punctuation_collapses_to_empty(self):
+        assert normalize_for_wer("...!?,") == ""
+
+
+class TestAsrMetricsThreshold:
+    def test_clip_below_threshold_is_flagged(self):
+        m = AsrMetrics(wer=0.30, length_ratio=0.71, hyp_words=143, ref_words=190, hyp_text="…")
+        assert m.is_silence_collapse(min_length_ratio=0.85) is True
+
+    def test_clip_at_threshold_is_not_flagged(self):
+        m = AsrMetrics(wer=0.10, length_ratio=0.85, hyp_words=170, ref_words=200, hyp_text="…")
+        # is_silence_collapse uses strict less-than: equal-to-threshold passes.
+        assert m.is_silence_collapse(min_length_ratio=0.85) is False
+
+    def test_clip_at_baseline_is_not_flagged(self):
+        m = AsrMetrics(wer=0.05, length_ratio=1.00, hyp_words=234, ref_words=234, hyp_text="…")
+        assert m.is_silence_collapse(min_length_ratio=0.85) is False
+
+
+class TestReadReferenceText:
+    def test_strips_bracket_lines(self, tmp_path):
+        # Mirrors the .txt format produced by cli.py:
+        #   [CLIP_ID: ...]
+        #   [SPEAKER: ... | ROLE: ... | ONSET: ... | OFFSET: ...]
+        #   <hebrew text>
+        #   [ACTION: ... | INTENSITY: ...]
+        path = tmp_path / "clip.txt"
+        path.write_text(
+            "[CLIP_ID: clip_001_00]\n"
+            "[SPEAKER: AGG_M_30-45_001 | ROLE: AGG | ONSET: 0.50 | OFFSET: 4.20]\n"
+            "שלום עולם\n"
+            "[ACTION: NONE_AMBIENT | INTENSITY: 1]\n",
+            encoding="utf-8",
+        )
+        ref = _read_reference_text(path)
+        assert ref == "שלום עולם"
+
+    def test_preserves_multiple_speech_lines(self, tmp_path):
+        path = tmp_path / "clip.txt"
+        path.write_text(
+            "[CLIP_ID: clip_001_00]\n"
+            "[SPEAKER: A | ROLE: AGG | ONSET: 0 | OFFSET: 1]\n"
+            "first\n"
+            "[ACTION: X | INTENSITY: 1]\n"
+            "[SPEAKER: B | ROLE: VIC | ONSET: 1 | OFFSET: 2]\n"
+            "second\n"
+            "[ACTION: Y | INTENSITY: 1]\n",
+            encoding="utf-8",
+        )
+        ref = _read_reference_text(path)
+        assert ref == "first\nsecond"

--- a/tests/unit/test_effective_prosody_cap.py
+++ b/tests/unit/test_effective_prosody_cap.py
@@ -1,0 +1,262 @@
+"""Tests for the #87 effective-prosody runtime cap.
+
+The cap defends against the failure mode where M7 SpeakerState drift
+compounds with #51's M15 style_map values to push effective pitch past
++2.5 st (~+15 %) and rate past 1.30× at high-intensity turns — a range
+that simultaneously sounds cartoonish to listeners (May-3 listening test)
+and trips Whisper-large-v3's silence-detection heuristic, producing the
+length-ratio collapse fingerprint documented on PR #87.
+
+These tests exercise the cap in three places:
+
+  1. ``_apply_effective_prosody_cap`` directly — unit-level; no Azure.
+  2. ``TTSRenderer.render_utterance`` with a mocked Azure provider — verifies
+     the cap fires when state + style would exceed thresholds, and that the
+     resulting ``out_cap_events`` list is populated.
+  3. ``TTSRenderer.render_scene`` end-to-end — verifies cap events propagate
+     to ``DialogueTurn.effective_prosody_caps`` so cli.py can roll them up
+     into ``ClipMetadata.generation_metadata.effective_prosody_caps``.
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import wave
+from unittest.mock import MagicMock
+
+from synthbanshee.config.speaker_config import (
+    DisfluencyProfile,
+    ProsodyBaseline,
+    SpeakerConfig,
+    StyleEntry,
+)
+from synthbanshee.script.types import DialogueTurn
+from synthbanshee.tts.azure_provider import AzureProvider
+from synthbanshee.tts.renderer import (
+    _EFFECTIVE_PITCH_MAX_ST,
+    _EFFECTIVE_PITCH_MIN_ST,
+    _EFFECTIVE_RATE_MAX,
+    _EFFECTIVE_RATE_MIN,
+    TTSRenderer,
+    _apply_effective_prosody_cap,
+)
+from synthbanshee.tts.speaker_state import SpeakerState
+
+
+def _make_wav_bytes() -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "w") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(24000)
+        w.writeframes(struct.pack("<24000h", *([0x2000] * 24000)))
+    return buf.getvalue()
+
+
+def _mock_azure_factory(_key, _region):
+    synth = MagicMock()
+    result = MagicMock()
+    result.audio_data = _make_wav_bytes()
+    del result.reason
+    synth.speak_ssml_async.return_value.get.return_value = result
+    return synth
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEffectiveProsodyCapHelper:
+    def test_in_range_values_pass_through_unchanged(self):
+        events: list[dict] = []
+        rate, pitch, vol = _apply_effective_prosody_cap(1.0, 0.0, 0.0, out_cap_events=events)
+        assert (rate, pitch, vol) == (1.0, 0.0, 0.0)
+        assert events == []
+
+    def test_pitch_above_max_clamps_and_records_event(self):
+        events: list[dict] = []
+        rate, pitch, vol = _apply_effective_prosody_cap(
+            1.0, _EFFECTIVE_PITCH_MAX_ST + 1.5, 0.0, out_cap_events=events
+        )
+        assert pitch == _EFFECTIVE_PITCH_MAX_ST
+        assert len(events) == 1
+        assert events[0]["dim"] == "pitch"
+        assert events[0]["pre_cap"] == round(_EFFECTIVE_PITCH_MAX_ST + 1.5, 4)
+        assert events[0]["post_cap"] == _EFFECTIVE_PITCH_MAX_ST
+
+    def test_pitch_below_min_clamps_and_records_event(self):
+        events: list[dict] = []
+        _, pitch, _ = _apply_effective_prosody_cap(
+            1.0, _EFFECTIVE_PITCH_MIN_ST - 2.0, 0.0, out_cap_events=events
+        )
+        assert pitch == _EFFECTIVE_PITCH_MIN_ST
+        assert len(events) == 1
+        assert events[0]["dim"] == "pitch"
+
+    def test_rate_above_max_clamps_and_records_event(self):
+        events: list[dict] = []
+        rate, _, _ = _apply_effective_prosody_cap(
+            _EFFECTIVE_RATE_MAX + 0.15, 0.0, 0.0, out_cap_events=events
+        )
+        assert rate == _EFFECTIVE_RATE_MAX
+        assert len(events) == 1
+        assert events[0]["dim"] == "rate"
+
+    def test_rate_below_min_clamps_and_records_event(self):
+        events: list[dict] = []
+        rate, _, _ = _apply_effective_prosody_cap(
+            _EFFECTIVE_RATE_MIN - 0.10, 0.0, 0.0, out_cap_events=events
+        )
+        assert rate == _EFFECTIVE_RATE_MIN
+        assert len(events) == 1
+        assert events[0]["dim"] == "rate"
+
+    def test_volume_is_never_capped(self):
+        # Per #82's lever probe, Whisper's log-mel internally normalizes
+        # loudness — so volume is intentionally NOT in the effective cap.
+        events: list[dict] = []
+        _, _, vol = _apply_effective_prosody_cap(1.0, 0.0, 999.0, out_cap_events=events)
+        assert vol == 999.0
+        assert events == []
+
+    def test_multiple_dimensions_record_separate_events(self):
+        events: list[dict] = []
+        rate, pitch, _ = _apply_effective_prosody_cap(
+            _EFFECTIVE_RATE_MAX + 0.1,
+            _EFFECTIVE_PITCH_MAX_ST + 0.5,
+            0.0,
+            out_cap_events=events,
+        )
+        assert rate == _EFFECTIVE_RATE_MAX
+        assert pitch == _EFFECTIVE_PITCH_MAX_ST
+        assert {ev["dim"] for ev in events} == {"rate", "pitch"}
+
+    def test_out_cap_events_none_is_silent(self):
+        # A caller that does not need the event log can pass None and the
+        # cap still fires; nothing is appended (and nothing crashes).
+        rate, pitch, vol = _apply_effective_prosody_cap(
+            _EFFECTIVE_RATE_MAX + 1.0, _EFFECTIVE_PITCH_MAX_ST + 1.0, 0.0, out_cap_events=None
+        )
+        assert rate == _EFFECTIVE_RATE_MAX
+        assert pitch == _EFFECTIVE_PITCH_MAX_ST
+
+
+# ---------------------------------------------------------------------------
+# 2. render_utterance integration (mocked Azure)
+# ---------------------------------------------------------------------------
+
+
+def _make_high_drift_speaker() -> SpeakerConfig:
+    """Speaker with style values that, combined with drifted state, exceed the cap.
+
+    Mirrors the actual sp_it_a_0001 turn 12 (I5 AGG_M) effective prosody we
+    measured on the post-#86 main: rate 1.329, pitch +2.90 st, volume +15.8 dB.
+    """
+    style_map = {i: StyleEntry(style="General", rate_multiplier=1.0) for i in range(1, 6)}
+    style_map[5] = StyleEntry(
+        style="General",
+        rate_multiplier=1.14,
+        pitch_delta_st=2.0,
+        volume_delta_db=13.0,
+    )
+    return SpeakerConfig(
+        speaker_id="TEST_M_30-45_001",
+        role="AGG",
+        gender="male",
+        age_range="30-45",
+        context="she_proves",
+        tts_voice_id="he-IL-AvriNeural",
+        tts_provider="azure",
+        voice_family="he-IL-AvriNeural",
+        prosody_baseline=ProsodyBaseline(rate=1.05, pitch_hz=115, volume_db=0),
+        style_map=style_map,
+        disfluency=DisfluencyProfile(),
+        split="train",
+    )
+
+
+class TestRenderUtteranceCapIntegration:
+    def setup_method(self):
+        self.provider = AzureProvider(sdk_factory=_mock_azure_factory)
+
+    def _make_renderer(self, tmp_path):
+        return TTSRenderer(provider=self.provider, cache_dir=tmp_path / "cache")
+
+    def test_cap_fires_on_drifted_high_intensity_turn(self, tmp_path):
+        # Construct a SpeakerState that looks like late-arc accumulated drift
+        # for an AGG speaker at I5 — pushes the effective pitch past +2.0 st.
+        renderer = self._make_renderer(tmp_path)
+        speaker = _make_high_drift_speaker()
+        state = SpeakerState(
+            rate_offset=1.10,  # → 1.14 * 1.05 * 1.10 = 1.317 → caps to 1.20
+            pitch_offset_st=1.3,  # → 2.0 + 1.3 = 3.3 → caps to 2.0
+            volume_offset_db=4.0,
+        )
+        events: list[dict] = []
+        renderer.render_utterance(
+            "test text",
+            speaker,
+            intensity=5,
+            speaker_state=state,
+            out_cap_events=events,
+        )
+        dims = {ev["dim"] for ev in events}
+        # Both rate and pitch should have been clamped.
+        assert "rate" in dims
+        assert "pitch" in dims
+        # No volume event — by design, volume is not capped at this layer.
+        assert "volume" not in dims
+
+    def test_cap_does_not_fire_on_neutral_low_intensity_turn(self, tmp_path):
+        renderer = self._make_renderer(tmp_path)
+        speaker = _make_high_drift_speaker()
+        events: list[dict] = []
+        renderer.render_utterance(
+            "test text",
+            speaker,
+            intensity=1,  # I1 = base style_map default, no drift
+            speaker_state=SpeakerState(),
+            out_cap_events=events,
+        )
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# 3. render_scene → DialogueTurn propagation
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSceneCapPropagation:
+    def setup_method(self):
+        self.provider = AzureProvider(sdk_factory=_mock_azure_factory)
+
+    def test_cap_events_attached_to_turn_after_render_scene(self, tmp_path):
+        renderer = TTSRenderer(provider=self.provider, cache_dir=tmp_path / "cache")
+        speaker = _make_high_drift_speaker()
+
+        # Build a dialogue arc that drifts SpeakerState through high-intensity
+        # turns so the cap fires by the last turn.  Mirrors sp_it_a_0001's
+        # arc shape ([1,2,3,4,5,...]) on a smaller scale.
+        turns = [
+            DialogueTurn(speaker_id=speaker.speaker_id, text="t", intensity=i)
+            for i in (1, 3, 4, 5, 5)
+        ]
+        renderer.render_scene(
+            turns,
+            speakers={speaker.speaker_id: speaker},
+            randomize=False,
+            quality_gates=False,
+        )
+
+        # At least one of the late-arc I5 turns should record a cap event.
+        late_turn_caps = [ev for t in turns[-2:] for ev in t.effective_prosody_caps]
+        assert late_turn_caps, (
+            "Expected cap activations on late high-intensity turns; got none. "
+            f"All cap events per turn: {[t.effective_prosody_caps for t in turns]}"
+        )
+        # Every recorded event must have the documented schema.
+        for ev in late_turn_caps:
+            assert ev["dim"] in {"rate", "pitch"}
+            assert "pre_cap" in ev and "post_cap" in ev

--- a/tests/unit/test_qa.py
+++ b/tests/unit/test_qa.py
@@ -22,6 +22,59 @@ from synthbanshee.package.qa import (
 )
 
 # ---------------------------------------------------------------------------
+# #87 prosody-cap roll-up tests
+# ---------------------------------------------------------------------------
+
+
+class TestProsodyCapRollup:
+    """qa-report's static surfacing of #87 effective-prosody cap activations."""
+
+    def test_clip_with_no_cap_events_does_not_appear_in_report(self, tmp_path):
+        _write_valid_clip(tmp_path / "agg_m_30-45_001", "clip_001_00")
+        report = run_qa(tmp_path)
+        assert report.prosody_cap_activations == {}
+        assert report.stats.clips_with_prosody_cap_activations == 0
+        assert report.stats.prosody_cap_activations_total == 0
+
+    def test_clip_with_cap_events_recorded(self, tmp_path):
+        events = [
+            {"turn_index": 12, "intensity": 5, "dim": "rate", "pre_cap": 1.33, "post_cap": 1.20},
+            {"turn_index": 12, "intensity": 5, "dim": "pitch", "pre_cap": 2.9, "post_cap": 2.0},
+        ]
+        _write_valid_clip(tmp_path / "agg_m_30-45_001", "clip_001_00", prosody_cap_events=events)
+        report = run_qa(tmp_path)
+        assert report.prosody_cap_activations == {"clip_001_00": 2}
+        assert report.stats.clips_with_prosody_cap_activations == 1
+        assert report.stats.prosody_cap_activations_total == 2
+
+    def test_multiple_clips_aggregated(self, tmp_path):
+        _write_valid_clip(tmp_path / "agg_m_30-45_001", "clip_clean_00")
+        _write_valid_clip(
+            tmp_path / "agg_m_30-45_002",
+            "clip_one_cap_00",
+            prosody_cap_events=[
+                {"turn_index": 0, "intensity": 5, "dim": "rate", "pre_cap": 1.5, "post_cap": 1.2},
+            ],
+        )
+        _write_valid_clip(
+            tmp_path / "agg_m_30-45_003",
+            "clip_three_caps_00",
+            prosody_cap_events=[
+                {"turn_index": 0, "intensity": 5, "dim": "rate", "pre_cap": 1.4, "post_cap": 1.2},
+                {"turn_index": 1, "intensity": 5, "dim": "pitch", "pre_cap": 3.0, "post_cap": 2.0},
+                {"turn_index": 2, "intensity": 4, "dim": "pitch", "pre_cap": 2.5, "post_cap": 2.0},
+            ],
+        )
+        report = run_qa(tmp_path)
+        assert report.stats.clips_with_prosody_cap_activations == 2
+        assert report.stats.prosody_cap_activations_total == 4
+        assert report.prosody_cap_activations == {
+            "clip_one_cap_00": 1,
+            "clip_three_caps_00": 3,
+        }
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -39,6 +92,7 @@ def _write_valid_clip(
     tts_engine: str = "azure_he_IL",
     tts_voice_id: str = "he-IL-AvriNeural",
     gender: str = "male",
+    prosody_cap_events: list[dict] | None = None,
 ) -> Path:
     """Write a minimal valid WAV + TXT + JSON triplet and return the WAV path."""
     parent.mkdir(parents=True, exist_ok=True)
@@ -92,6 +146,11 @@ def _write_valid_clip(
         "annotator_confidence": 1.0,
         "iaa_reviewed": False,
     }
+    if prosody_cap_events is not None:
+        metadata["generation_metadata"] = {
+            "pipeline_version": "0.1.0",
+            "effective_prosody_caps": prosody_cap_events,
+        }
     json_path.write_text(json.dumps(metadata), encoding="utf-8")
     return wav_path
 


### PR DESCRIPTION
## Problem

The bisect on PR #86 (closed #83 for low-intensity scenes) showed that high-intensity scenes still carried a Whisper WER regression: `sp_it_a_0001` measured at 0.322 vs the 04-15 reference's 0.056.  Tracked separately as #87.

Step 1 of the #87 bisect ruled out PR #74 (Lombard spectral tilt — null effect on WER).  Step 2 ruled in PR #51 (M15 prosody tuning): replacing the two scene speakers' YAMLs with their pre-#51 versions dropped WER to 0.047.  But a wholesale revert of #51 throws away the M15 listening-test calibration Shay validated.

The mechanism is **M7 `SpeakerState` drift compounding with #51's M15 style_map values** at high-intensity turns.  Effective prosody on `sp_it_a_0001` reached `pitch +14 % to +17 %` and `rate 1.27-1.33×` — simultaneously the helium range the May-3 listening test flagged ("oompa-loompa"), and the range that trips Whisper-large-v3's silence-detection heuristic to produce length-ratio collapse to ~0.7.

## What this PR ships

A **runtime effective-prosody cap** plus the two detection layers Shay asked for to catch this class of regression in the future.

### The fix — runtime cap in `synthbanshee/tts/renderer._apply_effective_prosody_cap`

Clamps post-state, post-randomization prosody before SSML emission:

  - `pitch ∈ [−3.0, +2.0] st`  (≈ ±12 % Azure)
  - `rate  ∈ [0.85, 1.20]`
  - volume left to the existing ±50 % Azure clamp (Whisper internally normalizes loudness, per #82's lever probe — not a Whisper-trip dimension).

Caps are anchored to the pre-#51 effective envelope, which produced the 04-15 reference clips with WER 0.04-0.08.  Tighter caps would diverge further from M15 listening-test calibration; looser caps would re-trip Whisper.  Each cap activation logs a warning and is recorded per turn.

### Detection layer 1 — static prosody-cap activations in metadata

  - `DialogueTurn.effective_prosody_caps` carries per-turn cap events.
  - `cli.py` rolls them up into `ClipMetadata.generation_metadata.effective_prosody_caps` (new `EffectiveProsodyCapEvent` model in `labels/schema.py`).
  - `qa-report` surfaces a new "Effective-Prosody Cap Activations (#87)" table per clip — runs on every batch, **no Azure / Whisper required**.

### Detection layer 2 — `qa-report --asr` Whisper backdoor check

New `synthbanshee/package/asr_sanity.py` provides a lazy-loaded `WhisperRunner` and `compute_asr_metrics`.  `qa-report --asr` runs Whisper-large-v3 on every clip, flags clips whose length-ratio falls below `--asr-min-length-ratio` (default 0.85 — the #87 fingerprint sat at ~0.71).  Heavy dependencies isolated in the new `eval-asr` optional extra so normal generation/QA stays light.

Per the policy decision documented in `CLAUDE.md` ("ASR sanity check policy"), Tier-3 ASR sanity is **local-only** (not in CI) for now — see #88 for the deferred CI re-evaluation triggers and cost-control plan.

## Tier-3 Whisper validation (local, post-cap)

| variant | dur | WER | length_ratio | hyp_words / ref_words |
|---|---:|---:|---:|---:|
| `sp_it_a_0001` 04-15 reference | 155.9 s | 0.056 | 1.009 | 236 / 234 |
| `sp_it_a_0001` post-#86 main (no cap) | 146.6 s | 0.322 | 0.709 | 166 / 234 |
| **`sp_it_a_0001` this PR (cap active)** | **149.1 s** | **0.129** | **0.906** | **212 / 234** |
| (reference: bisect step 2, full pre-#51 yamls) | 143.8 s | 0.047 | 1.004 | 235 / 234 |

**The cap fixes the canonical Whisper-backdoor fingerprint.**  Length-ratio recovers from 0.709 → 0.906 (above the 0.85 detection threshold).  Whisper now reads 212 of 234 words instead of 166.  The silence-detector trip is gone.

**This is a partial fix; WER is not fully restored to the 04-15 baseline.**  Failure mode shifts from silence-detector trip to substitution noise — distinct mechanism that requires a paired listening test to address without breaking M15 naturalness calibration.  All insights and four proposed approaches are tracked in **#89**.

### Cap activations recorded on the Tier-3 render

Tier-3 render of `sp_it_a_0001` recorded **14 cap activations across 7 high-intensity turns**:

```
turn 08 I4 pitch: 2.367 -> 2.0     turn 13 I4 pitch: 2.286 -> 2.0
turn 08 I4 rate:  1.222 -> 1.2     turn 13 I4 rate:  0.833 -> 0.85
turn 10 I4 pitch: 2.747 -> 2.0     turn 14 I4 pitch: 3.260 -> 2.0
turn 10 I4 rate:  1.265 -> 1.2     turn 14 I4 rate:  1.310 -> 1.2
turn 11 I3 rate:  0.846 -> 0.85    turn 15 I3 rate:  0.819 -> 0.85
turn 12 I5 pitch: 2.899 -> 2.0     turn 16 I3 pitch: 2.182 -> 2.0
turn 12 I5 rate:  1.329 -> 1.2     turn 16 I3 rate:  1.258 -> 1.2
```

Each event is preserved in `clip_meta.json` under `generation_metadata.effective_prosody_caps`.

## Changes per file

| file | change |
|---|---|
| `synthbanshee/tts/renderer.py` | Add `_apply_effective_prosody_cap` (module-level constants + helper); call it after the existing ±12 st clamp + randomization in `render_utterance`; new optional `out_cap_events` parameter; render_scene attaches the resulting list to `DialogueTurn.effective_prosody_caps`.  Module logger added for cap-activation warnings. |
| `synthbanshee/script/types.py` | New `effective_prosody_caps: list[dict]` field on `DialogueTurn`. |
| `synthbanshee/labels/schema.py` | New `EffectiveProsodyCapEvent` Pydantic model + `GenerationMetadata.effective_prosody_caps` field. |
| `synthbanshee/cli.py` | Roll up per-turn cap events into `GenerationMetadata`; add `--asr` and `--asr-min-length-ratio` flags to `qa-report`; render new prosody-cap and ASR sections in console + JSON output; pre-stage `report_dict` to satisfy mypy. |
| `synthbanshee/package/qa.py` | Static prosody-cap roll-up in `run_qa` (new `DatasetStats` + `QAReport` fields); new `run_asr_check` function gated behind the `eval-asr` extra. |
| `synthbanshee/package/asr_sanity.py` | **New module.** `WhisperRunner` lazy-loaded; `compute_asr_metrics` returns `AsrMetrics` (wer, length_ratio, hyp/ref words, hyp text); `normalize_for_wer` factored out for reuse with the M17 spike script. |
| `pyproject.toml` | New `eval-asr` optional extra (torch, transformers, accelerate, jiwer). |
| `CLAUDE.md` | New "ASR sanity check policy" section; updated TTS section with cap thresholds; "What NOT to do" entries pinning the cap and the local-only Tier-3 policy. |
| `tests/unit/test_effective_prosody_cap.py` | **New file** — 11 tests covering `_apply_effective_prosody_cap` directly, `render_utterance` with mocked Azure, and `render_scene` propagation to `DialogueTurn`. |
| `tests/unit/test_qa.py` | New `TestProsodyCapRollup` — 3 tests for cap-event aggregation. |
| `tests/unit/test_asr_sanity.py` | **New file** — 11 tests for `normalize_for_wer`, `AsrMetrics.is_silence_collapse`, `_read_reference_text`. |

## Test plan

- [x] `pytest tests/unit -q` — **1687 passed** (1662 baseline + 25 new) locally
- [x] `ruff check synthbanshee/ tests/` — clean
- [x] `mypy` on touched files — clean
- [x] Reproduce the Whisper-backdoor fingerprint on `sp_it_a_0001` (length-ratio 0.709 confirmed)
- [x] **Tier-3 ASR sanity (local)** — see "Tier-3 Whisper validation" table above; length-ratio recovers above the 0.85 threshold; WER reduces 2.5×
- [x] Render of `sp_it_a_0001` with cap active produces metadata containing 14 cap events; `qa-report` would surface this clip in the new "Effective-Prosody Cap Activations" table
- [x] CI: pending on push (`Lint & type-check`, `Test (Python 3.11)`, `Test (Python 3.12)`, `Combine coverage`, `pre-commit.ci - pr`, `pr-agent-context`)

## References

- **Reduces #87** — fixes the canonical Whisper-backdoor fingerprint and helium-range pitch; does not fully restore WER.  Full restoration tracked in #89.
- **Opens #89** — residual WER gap (0.129 vs 0.056 baseline) with insights, four proposed approaches, and a validation criterion that requires a paired listening test.
- Builds on PR #86 (closed #83 / #81; restored hardenings from #71); orthogonal to #82 loudness contract.
- #88 — deferred CI inclusion of the Whisper sanity check.
- May-3 listening test memo (in agent memory) — the human-naturalness floor that constrains cap tightening.