### PR TITLE
docs(spec): #84 sync §3.1 steps 1–4 with post-M14 preprocessing

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -105,12 +105,12 @@ Project codes: `SP` (She-Proves) · `EL` (Elephant in the Room)
 
 ### 3.1 Preprocessing Pipeline (ordered)
 
-All clips must pass through this pipeline before delivery. The "dirty" pre-pipeline file must be retained in `assets/` for robustness testing.
+All clips must pass through this pipeline before delivery. The "dirty" pre-pipeline file must be retained in `assets/` for robustness testing. Authoritative pipeline order lives in `synthbanshee/augment/preprocessing.py:preprocess()`; if this section disagrees with the code, the code wins.
 
-1. **Resample** — convert to 16,000 Hz (SoX `rate` with VHQ quality, or `torchaudio.functional.resample`)
-2. **Downmix** — stereo → mono (average channels)
-3. **Spectral filter** — low-pass at 7,500 Hz to remove irrelevant high-frequency noise from budget sensors (Butterworth order 4)
-4. **Denoising** — spectral subtraction (Wiener filtering) to remove electrical hum; parameterize noise profile from silent leading segment
+1. **Resample** — convert to 16 kHz with `scipy.signal.resample_poly` (polyphase filter; `torchaudio` is forbidden in this repo, see AGENTS.md).
+2. **Downmix** — stereo → mono via channel averaging.
+3. **High-pass filter at 80 Hz** (Butterworth order 2, sos form) to remove DC and sub-bass rumble that small phone microphones cannot capture. Note: M14 (PR #48, 2026-05-01) removed the legacy 7,500 Hz low-pass filter — at 16 kHz Nyquist (8 kHz) it was destroying sibilants and breathiness cues.
+4. **Denoising** — *optional*, controlled by `PreprocessingConfig.wiener_denoise` (default `False`). M14 changed the default because Wiener filtering on clean TTS output over-smooths high-frequency transients (muddy/muffled sound). Enable only for clips with real added noise (Tier B/C after acoustic augmentation).
 5. **Loudness normalization** (#78) — two stages:
    - **5a. Peak-normalize to target.** Apply a single global gain so the absolute peak lands at `PreprocessingConfig.target_peak_dbfs` (default −2.0 dBFS). A *single* gain preserves per-turn RMS *ratios* exactly, so the within-scene loudness trajectory established by per-turn RMS gain (M3a) survives — only the absolute level shifts. This step replaces the M3b "limiter only, never scale up" behaviour: pre-#78 the spec had only an upper bound on peak, leaving the absolute level unspecified; two clips could legitimately sit 6 dB apart and both be in-spec.
    - **5b. Safety limiter.** Attenuate any sample exceeding −1.0 dBFS. For in-spec target values (`target_peak_dbfs ∈ [−12.0, −1.5]`) this is a guaranteed no-op (0.5 dB margin); it remains as defence-in-depth against upstream over-range samples.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -105,12 +105,12 @@ Project codes: `SP` (She-Proves) · `EL` (Elephant in the Room)
 
 ### 3.1 Preprocessing Pipeline (ordered)
 
-All clips must pass through this pipeline before delivery. The "dirty" pre-pipeline file must be retained in `assets/` for robustness testing. Authoritative pipeline order lives in `synthbanshee/augment/preprocessing.py:preprocess()`; if this section disagrees with the code, the code wins.
+All clips must pass through this pipeline before delivery. The "dirty" pre-pipeline file must be retained in `assets/` for robustness testing. Implementation: `synthbanshee/augment/preprocessing.py:preprocess()`. PRs that change either MUST update the other in the same change.
 
-1. **Resample** — convert to 16 kHz with `scipy.signal.resample_poly` (polyphase filter; `torchaudio` is forbidden in this repo, see AGENTS.md).
+1. **Resample** — convert to 16,000 Hz using a polyphase filter. Skipped when the input is already at 16,000 Hz.
 2. **Downmix** — stereo → mono via channel averaging.
-3. **High-pass filter at 80 Hz** (Butterworth order 2, sos form) to remove DC and sub-bass rumble that small phone microphones cannot capture. Note: M14 (PR #48, 2026-05-01) removed the legacy 7,500 Hz low-pass filter — at 16 kHz Nyquist (8 kHz) it was destroying sibilants and breathiness cues.
-4. **Denoising** — *optional*, controlled by `PreprocessingConfig.wiener_denoise` (default `False`). M14 changed the default because Wiener filtering on clean TTS output over-smooths high-frequency transients (muddy/muffled sound). Enable only for clips with real added noise (Tier B/C after acoustic augmentation).
+3. **High-pass filter at 80 Hz** (Butterworth order 2, sos form) to remove DC and sub-bass rumble.
+4. **Conditional Wiener denoising** — applied only when explicitly enabled (off by default). Used for Tier B/C clips with real added noise after acoustic augmentation. Configuration: `PreprocessingConfig`.
 5. **Loudness normalization** (#78) — two stages:
    - **5a. Peak-normalize to target.** Apply a single global gain so the absolute peak lands at `PreprocessingConfig.target_peak_dbfs` (default −2.0 dBFS). A *single* gain preserves per-turn RMS *ratios* exactly, so the within-scene loudness trajectory established by per-turn RMS gain (M3a) survives — only the absolute level shifts. This step replaces the M3b "limiter only, never scale up" behaviour: pre-#78 the spec had only an upper bound on peak, leaving the absolute level unspecified; two clips could legitimately sit 6 dB apart and both be in-spec.
    - **5b. Safety limiter.** Attenuate any sample exceeding −1.0 dBFS. For in-spec target values (`target_peak_dbfs ∈ [−12.0, −1.5]`) this is a guaranteed no-op (0.5 dB margin); it remains as defence-in-depth against upstream over-range samples.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -105,12 +105,14 @@ Project codes: `SP` (She-Proves) · `EL` (Elephant in the Room)
 
 ### 3.1 Preprocessing Pipeline (ordered)
 
-All clips must pass through this pipeline before delivery. The "dirty" pre-pipeline file must be retained in `assets/` for robustness testing. Implementation: `synthbanshee/augment/preprocessing.py:preprocess()`. PRs that change either MUST update the other in the same change.
+All clips must pass through this pipeline before delivery. The "dirty" pre-pipeline file must be retained in `assets/` for robustness testing.
+
+**Implementation:** `synthbanshee/augment/preprocessing.py:preprocess()`. PRs that change either the implementation or this section MUST update the other in the same change.
 
 1. **Resample** — convert to 16,000 Hz using a polyphase filter. Skipped when the input is already at 16,000 Hz.
 2. **Downmix** — stereo → mono via channel averaging.
-3. **High-pass filter at 80 Hz** (Butterworth order 2, sos form) to remove DC and sub-bass rumble.
-4. **Conditional Wiener denoising** — applied only when explicitly enabled (off by default). Used for Tier B/C clips with real added noise after acoustic augmentation. Configuration: `PreprocessingConfig`.
+3. **High-pass filter at 80 Hz** (Butterworth order 2, in second-order-sections (SOS) form) to remove DC and sub-bass rumble.
+4. **Conditional Wiener denoising** — off by default; toggle via a boolean flag on `PreprocessingConfig`. Used for Tier B/C clips with real added noise after acoustic augmentation.
 5. **Loudness normalization** (#78) — two stages:
    - **5a. Peak-normalize to target.** Apply a single global gain so the absolute peak lands at `PreprocessingConfig.target_peak_dbfs` (default −2.0 dBFS). A *single* gain preserves per-turn RMS *ratios* exactly, so the within-scene loudness trajectory established by per-turn RMS gain (M3a) survives — only the absolute level shifts. This step replaces the M3b "limiter only, never scale up" behaviour: pre-#78 the spec had only an upper bound on peak, leaving the absolute level unspecified; two clips could legitimately sit 6 dB apart and both be in-spec.
    - **5b. Safety limiter.** Attenuate any sample exceeding −1.0 dBFS. For in-spec target values (`target_peak_dbfs ∈ [−12.0, −1.5]`) this is a guaranteed no-op (0.5 dB margin); it remains as defence-in-depth against upstream over-range samples.


### PR DESCRIPTION
## Summary

Closes #84.

`docs/spec.md` §3.1 still described the pre-M14 preprocessing pipeline (SoX/torchaudio resample, 7.5 kHz low-pass, on-by-default Wiener). Anyone reading spec.md to understand the pipeline got pre-M14 information — exactly the paper-vs-reality drift that lets future audits over-trust either source.

PR #48 (M14, 2026-05-01) replaced step 3 with an 80 Hz high-pass and made step 4 (Wiener) opt-in. Step 5 (loudness) was already synced in #78/#82. Steps 1–4 had remained stale.

## Changes

`docs/spec.md` only — rewrote §3.1 steps 1–4 to match the current `synthbanshee/augment/preprocessing.py:preprocess()` contract, and added a one-line implementation pointer + a constraint that PRs touching either side must update the other.

## Spec ↔ code mapping (mechanical verification)

Reviewer can confirm correctness by following each row:

| Spec clause (after this PR) | Code source of truth |
|---|---|
| Implementation: `synthbanshee/augment/preprocessing.py:preprocess()` | `synthbanshee/augment/preprocessing.py` line 1 (module docstring) and line 178 (`def preprocess(...)`) |
| Step 1 — "convert to 16,000 Hz using a polyphase filter" | `from scipy.signal import ... resample_poly` (line 30); `_TARGET_SR = 16_000` (line 34); `_resample(...)` helper (line 140, "Resample using polyphase filtering") |
| Step 1 — "Skipped when the input is already at 16,000 Hz" | `if src_sr != _TARGET_SR:` (line 221) |
| Step 2 — "stereo → mono via channel averaging" | `_TARGET_CHANNELS = 1` (line 35); downmix happens in `preprocess()` body (mean across channels) |
| Step 3 — "High-pass filter at 80 Hz (Butterworth order 2, sos form)" | `_HP_CUTOFF_HZ = 80` (line 37); `_HP_ORDER = 2` (line 38); `from scipy.signal import butter, ..., sosfilt` (line 30) |
| Step 4 — "applied only when explicitly enabled (off by default)" | `synthbanshee/config/preprocessing_config.py:27` — `wiener_denoise: bool = False` |
| Step 4 — "Configuration: `PreprocessingConfig`" | `from synthbanshee.config.preprocessing_config import PreprocessingConfig` (line 32) |

Steps 5–7 left untouched; already in sync via #78/#82.

## Design notes

This PR went through one round of self-review (commit `e54b186`) which removed three structural problems from the first attempt:

1. **No "code wins" disclaimer.** A spec that says "if I disagree with the code, ignore me" formalises drift instead of forbidding it. Replaced with `PRs that change either MUST update the other in the same change`.
2. **No M14 changelog narrative.** Specs describe the current contract; rationale lives in `wiki/topics/research-synthesis.md` (already cited from `preprocessing.py:1-18`) and in the M14 PR description. Duplicating it in §3.1 would rot on the next pipeline change.
3. **No library or field-name hardcoding.** "polyphase filter" instead of `scipy.signal.resample_poly`; "Configuration: `PreprocessingConfig`" instead of `PreprocessingConfig.wiener_denoise`. The spec describes the audio contract, not the implementation surface.

## Test plan

- [x] `pre-commit run --files docs/spec.md` — all hooks pass (no Python files touched, ruff/mypy skipped).
- [x] Each row of the spec ↔ code mapping table above is independently verifiable by `grep` / file read.
- [x] §3.1 steps 5–7 unchanged (already in sync via #78/#82); diff is bounded to the §3.1 header sentence and steps 1–4.

No code changes; nothing to test functionally beyond the spec ↔ code sanity diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)