### PR TITLE
fix(tts): #91 — rate-floor lift R experiment (sp_it_a_0001)

### DIFF
--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -67,7 +67,14 @@ _VerboseLog = Callable[[str], None]
 _EFFECTIVE_PITCH_MAX_ST = 2.0  # ≈ +12% — pre-#51 AGG never exceeded this with drift
 _EFFECTIVE_PITCH_MIN_ST = -3.0  # pre-#51 VIC went down to -4 baseline + drift
 _EFFECTIVE_RATE_MAX = 1.20
-_EFFECTIVE_RATE_MIN = 0.85
+# #91 R experiment: rate floor lifted 0.85 → 0.95.  PR #90's symmetric pitch cap
+# closed most of the #87 WER gap on `sp_it_a_0001` (0.322 → 0.129) but left a
+# residual to the 04-15 baseline (0.056).  #89 falsified pitch as the residual
+# driver; rate is the next single-knob lever.  Hypothesis: VIC's I4/I5 slowdown
+# (style_map 0.90 × baseline 1.0 × drift → floors at 0.85) is what trips Whisper's
+# silence-detection heuristic.  Lifting the floor risks flattening VIC's
+# deliberate distress cue — listening test is the merge gate.
+_EFFECTIVE_RATE_MIN = 0.95
 
 
 def _apply_effective_prosody_cap(

--- a/tests/unit/test_effective_prosody_cap.py
+++ b/tests/unit/test_effective_prosody_cap.py
@@ -142,6 +142,14 @@ class TestApplyEffectiveProsodyCapHelper:
         assert rate == _EFFECTIVE_RATE_MAX
         assert pitch == _EFFECTIVE_PITCH_MAX_ST
 
+    def test_rate_floor_anchored_to_0_95_for_issue_91(self):
+        # #91 R experiment lifts the rate floor 0.85 → 0.95 to test whether
+        # VIC's I4/I5 slowdown is what drives the residual Whisper WER gap on
+        # sp_it_a_0001 after PR #90.  Anchored as a literal so a silent revert
+        # back to 0.85 is caught here (paired listening test is the merge gate
+        # for any further movement on this constant).
+        assert _EFFECTIVE_RATE_MIN == 0.95
+
 
 # ---------------------------------------------------------------------------
 # 2. render_utterance integration (mocked Azure)


### PR DESCRIPTION
## Hypothesis (#91 R)

PR #90's symmetric pitch cap recovered `sp_it_a_0001` WER from 0.322 → 0.129, but left a residual gap to the 04-15 baseline (0.056). #89 falsified pitch as the residual driver. **R** is the next single-knob lever: lift `_EFFECTIVE_RATE_MIN` from `0.85` → `0.95`, on the hypothesis that VIC's I4/I5 slowdown — currently flooring at 0.85 — is what still trips Whisper's silence-detection heuristic.

The risk this PR explicitly traded against: VIC slowdown at high intensity is a deliberate distress cue. Flooring rate at 0.95 may flatten it. **The native-speaker listening test was the merge gate** — Tier-3 ASR alone is not sufficient.

## What this PR ships

A single-constant change plus an anchor test:

| file | change |
|---|---|
| `synthbanshee/tts/renderer.py` | `_EFFECTIVE_RATE_MIN = 0.85` → `0.95`. Comment updated to anchor the new value to #91's R rationale. Pitch cap (`_EFFECTIVE_PITCH_*`) and rate ceiling (`_EFFECTIVE_RATE_MAX`) untouched. |
| `tests/unit/test_effective_prosody_cap.py` | Add `test_rate_floor_anchored_to_0_95_for_issue_91` — a literal-value anchor so an inadvertent revert is caught loudly. Existing rate-floor assertions reference the imported `_EFFECTIVE_RATE_MIN` symbol and auto-track the new value. |

Diff: 2 files, +16 / -1.

## Tier-3 ASR sanity (local)

`sp_it_a_0001` re-rendered at seed 1101 into `data/m17_pr89_R_rate_floor/` (5 VIC turns re-rendered against Azure due to new floor; AGG and pitch SSML unchanged → cache hits). Whisper-large-v3 + jiwer over four variants:

| variant                                  |    dur |   WER | length_ratio | hyp / ref |
|------------------------------------------|-------:|------:|-------------:|----------:|
| 04-15 baseline (target)                  | 155.9s | 0.056 |        1.013 |  236 / 233 |
| PR #90 reference (cap on)                | 149.1s | 0.129 |        0.910 |  212 / 233 |
| B falsification (per-role pitch cap)     | 149.1s | 0.129 |        0.910 |  212 / 233 |
| **R (rate floor 0.95) — this PR**        | **143.8s** | **0.052** | **1.009** | **235 / 233** |

**WER pass criterion (≤ 0.10) cleared with margin; R reaches WER 0.052, equivalent to the 04-15 baseline.** Length-ratio fully recovered to 1.009 (vs PR #90's 0.910).

## Cap-clamp breakdown (this render)

19 cap activations across the scene. Rate-floor clamps are the new behaviour from this PR:

| turn | role | I | dim | pre | post |
|-----:|-----|--:|-----|----:|----:|
| 04 | VIC | 2 | rate floor | 0.912 | 0.950 |
| 06 | VIC | 2 | rate floor | 0.901 | 0.950 |
| 08 | VIC | 3 | rate floor | 0.878 | 0.950 |
| 10 | VIC | 3 | rate floor | 0.846 | 0.950 |
| 12 | VIC | 3 | rate floor | 0.819 | 0.950 |
| 14 | VIC | 4 | rate floor | 0.833 | 0.950 |
| 14 | VIC | 4 | pitch ceil | +2.29 | +2.00 |
| 16 | VIC | 3 | rate floor | 0.819 | 0.950 |

Plus the unchanged PR #90 ceiling clamps on AGG turns (rate 1.20, pitch +2.00) — 11 events on AGG at I3-I5.

## Listening test — completed (2026-05-07)

Native-speaker A/B by @shaypal5 between PR #90 reference and R candidate, focused on VIC at I3–I4.

**Verdict: parity, not flattening.** Both renders sound the same. In both, VIC at I3–I5 does **not** sound distressed — only the +2.0 st pitch ceiling is audible as an intensity cue, while the rate movement (whether floored at 0.85 or 0.95) is below perceptual threshold.

Verbatim: *"both sound the same, which in both cases doesn't sound very distressed, just a robot whose pitch is a bit higher."*

### What that means for R

R does not regress vs the May-3-calibrated PR #90 cap — naturalness parity holds. The "VIC sounds distressed" bar wasn't being met by main either; that's a deeper TTS issue (rate + pitch knobs are not the right levers for distress in Azure he-IL voices) which is now tracked separately as #97.

**Reframed merge rationale:** R is a strict WER win at zero perceptual cost. Decoupling the WER fix (this PR) from the distress investigation (#97) is the right call — the two need different levers and shouldn't be gated on each other.

### What R does NOT fix

- VIC distress cue at I3–I5 — see **#97** (TTS distress cue absent: rate + pitch are not sufficient signal). Out of scope here.
- AGG aggression at I3–I5 — not exercised by this listening test; may or may not have the same gap.

## Test plan

- [x] `pytest tests/unit -q` — **1688 passed** locally (1687 pre-PR + 1 new anchor test).
- [x] `ruff check synthbanshee/tts/renderer.py tests/unit/test_effective_prosody_cap.py` — clean.
- [x] `mypy synthbanshee/tts/renderer.py tests/unit/test_effective_prosody_cap.py` — clean.
- [x] **Tier-3 ASR sanity (local)** — see four-way table above; R clears the 0.10 WER bar and matches the 04-15 baseline. Length-ratio 1.009, no silence-detector trip.
- [x] **Native-speaker listening test (paired A/B)** — completed 2026-05-07. Verdict: parity vs PR #90 reference; no naturalness regression. Distress-cue absence is a pre-existing problem tracked in #97.

## References

- **Closes #91**.
- **Surfaces #97** — distress cue at I3–I5 is not addressable through the cap layer's prosody knobs; a different lever (style, breathiness, disfluency, alt voice model) is needed. PR #95 banks the WER win without blocking on that work.
- Builds on #90 (effective-prosody cap; pitch ceiling + rate ceiling retained from there).
- #89 (B falsification) — closed on the basis that pitch is not the residual driver; this PR confirms rate is.
- #87 — original Whisper WER regression. **PR #95 fully closes the WER gap on `sp_it_a_0001`** (0.052 ≈ baseline 0.056).
- CLAUDE.md "ASR sanity check policy" — local-only Tier-3 run completed; paired listening test completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)