### PR TITLE
spike(tts): #97 — Azure express-as fearful style A/B at I4–I5 on sp_it_a_0001

### DIFF
--- a/synthbanshee/tts/azure_provider.py
+++ b/synthbanshee/tts/azure_provider.py
@@ -23,15 +23,13 @@ class SpeechSDKProtocol(Protocol):
 
 _AZURE_CAPABILITIES = ProviderCapabilities(
     supports_ssml=True,
-    # #97: re-enabled.  M14's False default was speculative ("express-as styles
-    # are unavailable / blended for he-IL") — never validated by listening test.
-    # The PR #95 listening test (2026-05-07) found rate/pitch alone don't carry
-    # distress at I4–I5; this flip is the prerequisite for the spike's per-call
-    # style override on VIC@I4–I5 in renderer.py.  All production speakers in
-    # configs/speakers/ currently use style="General", so the flip is a no-op
-    # for existing renders — non-General styles only emit when the spike's
-    # override fires (gated by SYNTHBANSHEE_SPIKE_97_VIC_STYLE).
-    supports_style_tags=True,
+    supports_style_tags=False,  # M14: disabled for he-IL voices — express-as styles
+    # are not supported for Hebrew and cause voice identity shifts.
+    # Use <prosody> tags for emotional control instead.  #97 confirmed this
+    # empirically: the renderer's per-call override (renderer.py) was used to
+    # A/B-test express-as on a single VIC@I4 turn; Azure returned byte-identical
+    # audio for General and fearful SSML, falsifying any benefit to flipping
+    # this default.  See tests/fixtures/issue_97_fearful_ssml.json for evidence.
     supports_phoneme_tags=True,
     supports_api_emotion_sliders=False,
     max_volume_delta_db=None,

--- a/synthbanshee/tts/azure_provider.py
+++ b/synthbanshee/tts/azure_provider.py
@@ -23,9 +23,15 @@ class SpeechSDKProtocol(Protocol):
 
 _AZURE_CAPABILITIES = ProviderCapabilities(
     supports_ssml=True,
-    supports_style_tags=False,  # M14: disabled for he-IL voices — express-as styles
-    # are not supported for Hebrew and cause voice identity shifts.
-    # Use <prosody> tags for emotional control instead.
+    # #97: re-enabled.  M14's False default was speculative ("express-as styles
+    # are unavailable / blended for he-IL") — never validated by listening test.
+    # The PR #95 listening test (2026-05-07) found rate/pitch alone don't carry
+    # distress at I4–I5; this flip is the prerequisite for the spike's per-call
+    # style override on VIC@I4–I5 in renderer.py.  All production speakers in
+    # configs/speakers/ currently use style="General", so the flip is a no-op
+    # for existing renders — non-General styles only emit when the spike's
+    # override fires (gated by SYNTHBANSHEE_SPIKE_97_VIC_STYLE).
+    supports_style_tags=True,
     supports_phoneme_tags=True,
     supports_api_emotion_sliders=False,
     max_volume_delta_db=None,

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -78,30 +78,28 @@ _EFFECTIVE_RATE_MIN = 0.95
 
 
 # ---------------------------------------------------------------------------
-# #97 spike: VIC high-intensity express-as override
+# VIC high-intensity express-as override (originally #97 spike, kept generic)
 # ---------------------------------------------------------------------------
 #
-# The 2026-05-07 listening test on PR #95's candidate render said VIC at I3–I5
-# sounds "like a robot whose pitch is a bit higher" — rate/pitch alone don't
-# carry distress on Hebrew Azure voices.  This env var is the spike's single
-# knob for A/B-testing Azure ``<mstts:express-as>`` styles on VIC at I4–I5
-# without changing any speaker YAML or production default.  Set it to one of
-# the he-IL-supported Azure styles (e.g. ``fearful``, ``terrified``,
-# ``whispering``, ``sad``); leave unset for the byte-identical baseline.
+# Per-call A/B knob for Azure ``<mstts:express-as>`` styles on VIC at high
+# intensity, without touching any speaker YAML or the provider's global
+# ``supports_style_tags`` capability.  When the env var is set:
+#   - VIC role at intensity ≥ 4
+#   - The renderer overrides ``style_entry.style`` with the env value AND
+#     forces ``supports_style_tags=True`` for this single SSML build (so the
+#     Azure default ``False`` is preserved for every other turn).
 #
-# Scope is intentionally narrow:
-#   - Only VIC role (matches the issue's pass criterion).
-#   - Only intensity ≥ 4 (where the listening test heard the gap).
-#   - Provider must already advertise supports_style_tags (Azure now does;
-#     Google still does not — the env var is a no-op there).
-#
-# When the spike concludes, replace this with whatever the listening test
-# decided: a permanent edit to VIC speaker YAMLs, a different lever from #97's
-# enumerated list, or a revert of the azure_provider.py flip if Azure's he-IL
-# express-as turns out to be perceptually flat.
-_SPIKE_97_ENV_VAR = "SYNTHBANSHEE_SPIKE_97_VIC_STYLE"
-_SPIKE_97_MIN_INTENSITY = 4
-_SPIKE_97_ROLE = "VIC"
+# Origin: the 2026-05-07 listening test on PR #95 said VIC at I3–I5 sounds
+# robotic; rate/pitch alone don't carry distress on Hebrew Azure voices.
+# #97 used this knob to A/B-test ``fearful`` and found Azure he-IL returns
+# byte-identical audio regardless of the express-as wrapper — see
+# ``tests/fixtures/issue_97_fearful_ssml.json``.  The mechanism is left in
+# place so the next style spike (e.g. ``terrified``) can run with no code
+# changes; if all styles are confirmed no-op, delete this block and the
+# unit test in ``tests/unit/test_vic_style_override.py``.
+_VIC_STYLE_OVERRIDE_ENV_VAR = "SYNTHBANSHEE_VIC_STYLE_OVERRIDE"
+_VIC_STYLE_OVERRIDE_MIN_INTENSITY = 4
+_VIC_STYLE_OVERRIDE_ROLE = "VIC"
 
 
 def _apply_effective_prosody_cap(
@@ -293,16 +291,19 @@ class TTSRenderer:
 
         provider = self._get_provider(speaker)
 
-        # #97 spike: optional VIC@I4–I5 express-as style override (see module docstring).
+        # Optional VIC@I≥4 express-as style override (see module docstring).
+        # Forces supports_style_tags=True for this single call so the override
+        # actually takes effect — without flipping the provider's global flag.
         style_for_ssml = style_entry.style
-        spike_style = os.environ.get(_SPIKE_97_ENV_VAR)
+        supports_style_tags = provider.capabilities.supports_style_tags
+        override_style = os.environ.get(_VIC_STYLE_OVERRIDE_ENV_VAR)
         if (
-            spike_style
-            and speaker.role == _SPIKE_97_ROLE
-            and intensity >= _SPIKE_97_MIN_INTENSITY
-            and provider.capabilities.supports_style_tags
+            override_style
+            and speaker.role == _VIC_STYLE_OVERRIDE_ROLE
+            and intensity >= _VIC_STYLE_OVERRIDE_MIN_INTENSITY
         ):
-            style_for_ssml = spike_style
+            style_for_ssml = override_style
+            supports_style_tags = True
 
         ssml = self._ssml_builder.build_from_speaker_config(
             text=text,
@@ -312,7 +313,7 @@ class TTSRenderer:
             pitch_delta_st=pitch,
             volume_delta_db=volume,
             phrase_prosody=phrase_prosody,
-            supports_style_tags=provider.capabilities.supports_style_tags,
+            supports_style_tags=supports_style_tags,
         )
 
         cache_key = self._cache_key(ssml)

--- a/synthbanshee/tts/renderer.py
+++ b/synthbanshee/tts/renderer.py
@@ -77,6 +77,33 @@ _EFFECTIVE_RATE_MAX = 1.20
 _EFFECTIVE_RATE_MIN = 0.95
 
 
+# ---------------------------------------------------------------------------
+# #97 spike: VIC high-intensity express-as override
+# ---------------------------------------------------------------------------
+#
+# The 2026-05-07 listening test on PR #95's candidate render said VIC at I3–I5
+# sounds "like a robot whose pitch is a bit higher" — rate/pitch alone don't
+# carry distress on Hebrew Azure voices.  This env var is the spike's single
+# knob for A/B-testing Azure ``<mstts:express-as>`` styles on VIC at I4–I5
+# without changing any speaker YAML or production default.  Set it to one of
+# the he-IL-supported Azure styles (e.g. ``fearful``, ``terrified``,
+# ``whispering``, ``sad``); leave unset for the byte-identical baseline.
+#
+# Scope is intentionally narrow:
+#   - Only VIC role (matches the issue's pass criterion).
+#   - Only intensity ≥ 4 (where the listening test heard the gap).
+#   - Provider must already advertise supports_style_tags (Azure now does;
+#     Google still does not — the env var is a no-op there).
+#
+# When the spike concludes, replace this with whatever the listening test
+# decided: a permanent edit to VIC speaker YAMLs, a different lever from #97's
+# enumerated list, or a revert of the azure_provider.py flip if Azure's he-IL
+# express-as turns out to be perceptually flat.
+_SPIKE_97_ENV_VAR = "SYNTHBANSHEE_SPIKE_97_VIC_STYLE"
+_SPIKE_97_MIN_INTENSITY = 4
+_SPIKE_97_ROLE = "VIC"
+
+
 def _apply_effective_prosody_cap(
     rate: float,
     pitch: float,
@@ -265,10 +292,22 @@ class TTSRenderer:
         )
 
         provider = self._get_provider(speaker)
+
+        # #97 spike: optional VIC@I4–I5 express-as style override (see module docstring).
+        style_for_ssml = style_entry.style
+        spike_style = os.environ.get(_SPIKE_97_ENV_VAR)
+        if (
+            spike_style
+            and speaker.role == _SPIKE_97_ROLE
+            and intensity >= _SPIKE_97_MIN_INTENSITY
+            and provider.capabilities.supports_style_tags
+        ):
+            style_for_ssml = spike_style
+
         ssml = self._ssml_builder.build_from_speaker_config(
             text=text,
             voice_id=speaker.tts_voice_id,
-            style=style_entry.style,
+            style=style_for_ssml,
             rate_multiplier=rate,
             pitch_delta_st=pitch,
             volume_delta_db=volume,

--- a/tests/fixtures/issue_97_fearful_ssml.json
+++ b/tests/fixtures/issue_97_fearful_ssml.json
@@ -1,0 +1,43 @@
+{
+  "issue": 97,
+  "scene": "sp_it_a_0001",
+  "captured_index": 13,
+  "speaker_role": "VIC",
+  "intensity": 4,
+  "voice_id": "he-IL-HilaNeural",
+  "prosody": {
+    "rate_multiplier": 0.95,
+    "pitch_delta_st": 2.0,
+    "volume_delta_db": 1.56912
+  },
+  "general": {
+    "style": "General",
+    "supports_style_tags_used": false,
+    "ssml_sha256": "9880c52f17531c8b4bc6ea3c95886cffdc9a048dfb37faec6bd8bc1d06742703",
+    "cache_file": "9880c52f17531c8b4bc6ea3c95886cffdc9a048dfb37faec6bd8bc1d06742703.wav",
+    "audio_bytes": 309934,
+    "audio_sha256": "f495bf6a20983d112f8be3da61ae65a444f516766745b4aa41ee7b021228c239",
+    "ssml_fingerprint": {
+      "has_xmlns_mstts": false,
+      "has_express_as_wrapper": false,
+      "ssml_byte_length": 287,
+      "note": "SSML body redacted \u2014 contained the rendered Hebrew utterance text. The ssml_sha256 below is authoritative; anyone with the codebase can regenerate the literal SSML by re-running the spike (see PR #98 reproducer)."
+    }
+  },
+  "fearful": {
+    "style": "fearful",
+    "supports_style_tags_used": true,
+    "ssml_sha256": "18aa1ae1005694f40ea8c9238365d93f664055a5ee7af0057588e9717a80b26c",
+    "cache_file": "18aa1ae1005694f40ea8c9238365d93f664055a5ee7af0057588e9717a80b26c.wav",
+    "audio_bytes": 309934,
+    "audio_sha256": "f495bf6a20983d112f8be3da61ae65a444f516766745b4aa41ee7b021228c239",
+    "ssml_fingerprint": {
+      "has_xmlns_mstts": true,
+      "has_express_as_wrapper": true,
+      "ssml_byte_length": 383,
+      "note": "SSML body redacted \u2014 contained the rendered Hebrew utterance text. The ssml_sha256 below is authoritative; anyone with the codebase can regenerate the literal SSML by re-running the spike (see PR #98 reproducer)."
+    }
+  },
+  "byte_identical": true,
+  "evidence": "Two distinct SSML strings (one wraps prosody with <mstts:express-as style=\"fearful\">, one does not; different SHA-256) hash to two distinct cache keys, both populated by real Azure he-IL-HilaNeural synthesis.  Their cached audio bytes are byte-identical \u2192 Azure's he-IL voice silently ignores the express-as wrapper for this voice and prosody combination."
+}

--- a/tests/unit/test_google_provider.py
+++ b/tests/unit/test_google_provider.py
@@ -87,7 +87,10 @@ class TestProviderCapabilities:
         p = AzureProvider(sdk_factory=lambda k, r: MagicMock())
         caps = p.capabilities
         assert caps.supports_ssml is True
-        assert caps.supports_style_tags is False  # M14: disabled for he-IL voices
+        # #97: M14's False default was speculative; flipped pending the spike's
+        # listening-test verdict.  Production speakers all use style="General"
+        # so this is a no-op for default renders.
+        assert caps.supports_style_tags is True
         assert caps.supports_phoneme_tags is True
         assert caps.supports_api_emotion_sliders is False
 

--- a/tests/unit/test_google_provider.py
+++ b/tests/unit/test_google_provider.py
@@ -87,10 +87,7 @@ class TestProviderCapabilities:
         p = AzureProvider(sdk_factory=lambda k, r: MagicMock())
         caps = p.capabilities
         assert caps.supports_ssml is True
-        # #97: M14's False default was speculative; flipped pending the spike's
-        # listening-test verdict.  Production speakers all use style="General"
-        # so this is a no-op for default renders.
-        assert caps.supports_style_tags is True
+        assert caps.supports_style_tags is False  # M14: disabled for he-IL voices
         assert caps.supports_phoneme_tags is True
         assert caps.supports_api_emotion_sliders is False
 

--- a/tests/unit/test_vic_style_override.py
+++ b/tests/unit/test_vic_style_override.py
@@ -1,0 +1,126 @@
+"""Tests for the VIC high-intensity express-as override in ``TTSRenderer``.
+
+Covers the four-condition gate (env-set + role + intensity + provider-default)
+and the per-call ``supports_style_tags=True`` forcing.  Originally added for the
+#97 spike (see ``tests/fixtures/issue_97_fearful_ssml.json``); kept generic so
+follow-up style spikes (terrified, whispering, …) need no test changes.
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import wave
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from synthbanshee.config.speaker_config import SpeakerConfig
+from synthbanshee.tts.azure_provider import AzureProvider
+from synthbanshee.tts.renderer import TTSRenderer
+
+EXAMPLES_DIR = Path(__file__).parent.parent.parent / "configs" / "examples"
+SPEAKERS_DIR = Path(__file__).parent.parent.parent / "configs" / "speakers"
+ENV_VAR = "SYNTHBANSHEE_VIC_STYLE_OVERRIDE"
+
+
+def _make_wav_bytes() -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "w") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(24000)
+        w.writeframes(struct.pack("<24000h", *([1000] * 24000)))
+    return buf.getvalue()
+
+
+def _capturing_azure_factory(captured: list[str]):
+    """Return an Azure SDK factory that appends every SSML it sees to *captured*."""
+
+    def factory(key, region):
+        def speak_ssml_async(ssml: str):
+            captured.append(ssml)
+            mock_result = MagicMock()
+            mock_result.audio_data = _make_wav_bytes()
+            del mock_result.reason
+            future = MagicMock()
+            future.get.return_value = mock_result
+            return future
+
+        synth = MagicMock()
+        synth.speak_ssml_async.side_effect = speak_ssml_async
+        return synth
+
+    return factory
+
+
+def _renderer(tmp_path: Path, captured: list[str]) -> tuple[TTSRenderer, AzureProvider]:
+    azure = AzureProvider(sdk_factory=_capturing_azure_factory(captured))
+    return TTSRenderer(providers={"azure": azure}, cache_dir=tmp_path / "cache"), azure
+
+
+class TestVICStyleOverride:
+    """The override fires only on (env-set + VIC + I≥4); provider default stays False."""
+
+    def test_env_unset_emits_no_express_as_at_vic_i4(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        captured: list[str] = []
+        renderer, _ = _renderer(tmp_path, captured)
+        speaker = SpeakerConfig.from_yaml(SPEAKERS_DIR / "speaker_VIC_F_25-40_004.yaml")
+        renderer.render_utterance("שלום", speaker, intensity=4)
+        assert captured, "Azure must have been called"
+        assert "express-as" not in captured[0]
+        assert "xmlns:mstts" not in captured[0]
+
+    def test_env_set_emits_express_as_at_vic_i4(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "fearful")
+        captured: list[str] = []
+        renderer, _ = _renderer(tmp_path, captured)
+        speaker = SpeakerConfig.from_yaml(SPEAKERS_DIR / "speaker_VIC_F_25-40_004.yaml")
+        renderer.render_utterance("שלום", speaker, intensity=4)
+        assert captured
+        assert 'mstts:express-as style="fearful"' in captured[0]
+        assert "xmlns:mstts" in captured[0]
+
+    def test_env_set_emits_express_as_at_vic_i5(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "terrified")
+        captured: list[str] = []
+        renderer, _ = _renderer(tmp_path, captured)
+        speaker = SpeakerConfig.from_yaml(SPEAKERS_DIR / "speaker_VIC_F_25-40_004.yaml")
+        renderer.render_utterance("שלום", speaker, intensity=5)
+        assert 'mstts:express-as style="terrified"' in captured[0]
+
+    def test_env_set_does_not_fire_below_min_intensity(self, tmp_path, monkeypatch):
+        """I=3 is below the gate; baseline path is preserved."""
+        monkeypatch.setenv(ENV_VAR, "fearful")
+        captured: list[str] = []
+        renderer, _ = _renderer(tmp_path, captured)
+        speaker = SpeakerConfig.from_yaml(SPEAKERS_DIR / "speaker_VIC_F_25-40_004.yaml")
+        renderer.render_utterance("שלום", speaker, intensity=3)
+        assert "express-as" not in captured[0]
+        assert "xmlns:mstts" not in captured[0]
+
+    def test_env_set_does_not_fire_for_non_vic_role(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "fearful")
+        captured: list[str] = []
+        renderer, _ = _renderer(tmp_path, captured)
+        speaker = SpeakerConfig.from_yaml(SPEAKERS_DIR / "speaker_AGG_M_30-45_003.yaml")
+        renderer.render_utterance("שלום", speaker, intensity=5)
+        assert "express-as" not in captured[0]
+        assert "xmlns:mstts" not in captured[0]
+
+    def test_provider_global_capability_unchanged(self):
+        """The override must not flip the provider's default — only force per-call."""
+        provider = AzureProvider(sdk_factory=lambda k, r: MagicMock())
+        assert provider.capabilities.supports_style_tags is False
+
+    @pytest.mark.parametrize("style", ["fearful", "terrified", "whispering", "sad"])
+    def test_arbitrary_styles_route_through(self, tmp_path, monkeypatch, style):
+        """Future style spikes need no code changes — the env var routes any value."""
+        monkeypatch.setenv(ENV_VAR, style)
+        captured: list[str] = []
+        renderer, _ = _renderer(tmp_path, captured)
+        speaker = SpeakerConfig.from_yaml(SPEAKERS_DIR / "speaker_VIC_F_25-40_004.yaml")
+        renderer.render_utterance("שלום", speaker, intensity=4)
+        assert f'mstts:express-as style="{style}"' in captured[0]


### PR DESCRIPTION
## TL;DR — negative result, do not merge

A/B-tested Azure `<mstts:express-as style="fearful">` on a VIC@I=4 turn in `sp_it_a_0001`. The two cached audio bytes are **byte-identical** (`f495bf6a…`) despite distinct SSML inputs — Azure's `he-IL-HilaNeural` voice silently ignores the express-as wrapper for this voice + prosody combination. M14's defensive `supports_style_tags=False` default was empirically correct.

**Recommendation**: close this PR without merging. Pursue [candidate #2 in #97](https://github.com/DataHackIL/SynthBanshee/issues/97) (disfluency density at high intensity) under the same one-knob discipline.

## What changed

| File | Change |
|---|---|
| `synthbanshee/tts/renderer.py` | Added env var `SYNTHBANSHEE_VIC_STYLE_OVERRIDE` that, when set AND the turn is VIC at intensity ≥ 4, overrides `style_entry.style` AND forces `supports_style_tags=True` *per call*. The provider's global capability is left at M14's `False` default. Cache key changes only for the affected turn. |
| `tests/unit/test_vic_style_override.py` | New file. Parameterized coverage of the four-condition gate (env-set + role + intensity + provider-default-unchanged) plus multiple style values, so the next style spike needs no code changes. |
| `tests/fixtures/issue_97_fearful_ssml.json` | Direct byte-identity evidence: SSML SHAs + cache file pointers + audio SHAs for the General and fearful renders of VIC@I=4 turn 14. Hebrew utterance text redacted per CLAUDE.md. |

Out of scope, intentionally:
- No prosody / cap / RMS-gain changes.
- No speaker-YAML edits.
- No SSML-builder changes.
- `supports_style_tags` global default unchanged (override forces `True` per call).

## Scope-narrowing rationale

Issue says "VIC at I3–I5 does not sound distressed." Override gate is `I ≥ 4`. Reasoning: the negative result generalises downward — if Azure ignores the express-as wrapper at I=4, it ignores it at I=3 too. Lowering the gate would burn 4× more Azure calls re-rendering I=3 turns for the same finding.

## Test plan

- [x] `pytest tests/unit/` — 1698 passed (was 1688; +10 new gate tests).
- [x] Ruff + mypy clean on touched files.
- [x] Baseline render of `sp_it_a_0001` (env unset): all 17 turns hit cache → $0 Azure.
- [x] Fearful render (`SYNTHBANSHEE_VIC_STYLE_OVERRIDE=fearful`): only VIC@I=4 turn re-rendered → ~1¢ Azure.
- [x] Verified at the SSML layer that the override fired and the cache key changed.
- [x] Tier-3 ASR sanity (local) — see below.

### Tier-3 ASR sanity (local)

```
$ synthbanshee qa-report data/spikes/97_express_as_fearful/fearful --asr
QA PASSED — failure rate 0.0% ≤ 2.0%
asr_warnings: {}     # 0 clips with length_ratio < 0.85
```

ASR re-run is mechanically a no-op given byte-identity (the audio is the same as the General-style baseline, which has known WER ≈ 0.052 from PR #95). Included only because CLAUDE.md mandates it for any `synthbanshee/tts/` touch.

## Direct byte-identity evidence

`tests/fixtures/issue_97_fearful_ssml.json` records, for the same VIC@I=4 turn (same Hebrew text, same prosody, same voice):

| | General | Fearful |
|---|---|---|
| `xmlns:mstts` declared | no | yes |
| `<mstts:express-as>` wrapper | no | yes |
| SSML SHA-256 | `9880c52f…` | `18aa1ae1…` |
| Cache file (real Azure render) | `9880c52f….wav` | `18aa1ae1….wav` |
| Audio bytes | 309 934 | 309 934 |
| Audio SHA-256 | `f495bf6a…` | `f495bf6a…` |

Two distinct SSML strings → two distinct cache keys → two real Azure synthesis events → byte-identical audio output. No listening-test interpretation needed.

## What this falsifies — and what it doesn't

- **Falsified**: candidate #1 with `style="fearful"` on `he-IL-HilaNeural` for this prosody combination.
- **Not yet falsified**: the other styles in the family (`terrified`, `whispering`, `shouting`, `sad`). Strong prior they're also no-ops (same voice model), but unverified. One more spike (~1¢ + listening test) would close the family.

## Recommendation

- **Close this PR without merging.** The override mechanism is clean enough to keep on a branch as a reproducer, but landing it as production code is unjustified for a knob we know is decorative on he-IL.
- **Next spike**: candidate #2 — disfluency density at high intensity. `DisfluencyProfile` plumbing already exists; same one-knob discipline.
- A parallel write-up is on [#97](https://github.com/DataHackIL/SynthBanshee/issues/97#issuecomment-4406738266) so the finding survives this PR's disposition.

## Reproducer

```bash
git fetch && git checkout spike/97-express-as-fearful-i4-i5
synthbanshee generate -c configs/scenes/she_proves/sp_it_a_0001.yaml -o /tmp/baseline -v
SYNTHBANSHEE_VIC_STYLE_OVERRIDE=fearful synthbanshee generate -c configs/scenes/she_proves/sp_it_a_0001.yaml -o /tmp/fearful -v
cmp /tmp/baseline/agg_m_30-45_001/sp_it_a_0001_00.wav /tmp/fearful/agg_m_30-45_001/sp_it_a_0001_00.wav   # exit 0
```

## Refs

- Refs #87 (already closed in spirit by PR #95; closure comment left).
- Refs #97 (falsifies candidate #1; issue stays open pending candidate #2).