### PR TITLE
fix(spec,cli): corpus pre-handoff schema fixes

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -24,8 +24,8 @@ All requirements in §2–§7 are binding on both the generator (the synthetic f
 ```
 data/
   {language_code}/
-    {speaker_id}/
-      {clip_id}.wav
+    {speaker_id_lower}/                    ← speaker_id.lower() of the scene's primary
+      {clip_id}.wav                          (AGG-role) speaker — see §2.3
       {clip_id}.txt         ← transcript (UTF-8, Hebrew in he-IL clips)
       {clip_id}.json        ← per-clip metadata (see §5)
       {clip_id}.jsonl       ← per-clip strong labels, one event per line (see §5.2)
@@ -67,16 +67,18 @@ Examples:
 
 Role codes: `AGG` (aggressor) · `VIC` (victim) · `BYS` (bystander) · `NEU` (neutral/non-violent speaker)
 
+`speaker_id` is **uppercase** wherever it appears as a value — in YAML configs, in JSON / JSONL / TXT outputs, in the manifest's `speaker_ids` column, and as a Python identifier at runtime. The **directory name** under `data/{language}/` is the lowercase form of this same id (per §2.5 every filesystem path component is ASCII lowercase). Concretely: a scene whose primary speaker is `AGG_M_30-45_001` writes to `data/he/agg_m_30-45_001/`, but every metadata value still reads `AGG_M_30-45_001`. Consumers reconstructing paths from metadata must apply `.lower()` to `speakers[0].speaker_id` (or read `wav_path` from the manifest, which is already correct).
+
 ### 2.4 Clip ID Format
 
 ```
 {project_code}_{violence_type_code}_{tier}_{scene_id:04d}_{segment:02d}
 ```
 
-Examples:
-- `SP_IT_B_0023_00` — She-Proves, Intimate Terrorism, Tier B, scene 23, full scene
-- `EL_SV_A_0105_03` — Elephant in the Room, Situational Violence, Tier A, scene 105, segment 3
-- `SP_NEG_C_0412_00` — She-Proves, Negative/Confusor, Tier C, scene 412
+Examples (on-disk form — §2.5 mandates lowercase filenames; the same id is uppercase in YAML scene configs, written by the CLI as `scene_id.lower().replace("-", "_")` at clip-write time):
+- `sp_it_b_0023_00` — She-Proves, Intimate Terrorism, Tier B, scene 23, full scene
+- `el_sv_a_0105_03` — Elephant in the Room, Situational Violence, Tier A, scene 105, segment 3
+- `sp_neg_c_0412_00` — She-Proves, Negative/Confusor, Tier C, scene 412
 
 Project codes: `SP` (She-Proves) · `EL` (Elephant in the Room)
 
@@ -247,7 +249,7 @@ Every clip has a companion `{clip_id}.json` file with this schema:
 
 ```json
 {
-  "clip_id": "SP_IT_B_0023_00",
+  "clip_id": "sp_it_b_0023_00",
   "project": "she_proves",
   "language": "he",
   "violence_typology": "IT",
@@ -256,10 +258,10 @@ Every clip has a companion `{clip_id}.json` file with this schema:
   "sample_rate": 16000,
   "channels": 1,
   "snr_db_estimated": 19.4,
-  "scene_config": "configs/scenes/SP_IT_B_0023.yaml",
+  "scene_config": "configs/scenes/she_proves/sp_it_b_0023.yaml",
   "random_seed": 42,
   "generation_date": "2026-04-10",
-  "generator_version": "avdp-synth-0.1.0",
+  "generator_version": "0.1.0",
   "is_synthetic": true,
   "tts_engine": "azure_he_IL",
   "acoustic_scene": {
@@ -276,14 +278,16 @@ Every clip has a companion `{clip_id}.json` file with this schema:
       "role": "AGG",
       "gender": "male",
       "age_range": "30-45",
-      "tts_voice_id": "he-IL-AvriNeural"
+      "tts_voice_id": "he-IL-AvriNeural",
+      "voice_family": "he-IL-AvriNeural"
     },
     {
       "speaker_id": "VIC_F_25-40_002",
       "role": "VIC",
       "gender": "female",
       "age_range": "25-40",
-      "tts_voice_id": "he-IL-HilaNeural"
+      "tts_voice_id": "he-IL-HilaNeural",
+      "voice_family": "he-IL-HilaNeural"
     }
   ],
   "weak_label": {
@@ -297,16 +301,40 @@ Every clip has a companion `{clip_id}.json` file with this schema:
     "downmixed_to_mono": true,
     "spectral_filtered": true,
     "denoised": true,
-    "normalized_dbfs": -1.0,
+    "normalized_dbfs": -2.0,
     "silence_padded": true
   },
-  "dirty_file_path": "assets/speech/he/AGG_M_30-45_001/SP_IT_B_0023_00_dirty.wav",
-  "transcript_path": "data/he/AGG_M_30-45_001/SP_IT_B_0023_00.txt",
+  "generation_metadata": {
+    "pipeline_version": "0.1.0",
+    "tts_backend": {"AGG_M_30-45_001": "azure", "VIC_F_25-40_002": "azure"},
+    "voice_family": {"AGG_M_30-45_001": "he-IL-AvriNeural", "VIC_F_25-40_002": "he-IL-HilaNeural"},
+    "mix_mode_used": "sequential",
+    "normalization_strategy": "per_turn_rms_v2_target_peak",
+    "loudness_target_peak_dbfs": -2.0,
+    "breathiness_applied": false,
+    "effective_prosody_caps": []
+  },
+  "dirty_file_path": "assets/speech/dirty/sp_it_b_0023_00_dirty.wav",
+  "transcript_path": "data/he/agg_m_30-45_001/sp_it_b_0023_00.txt",
   "quality_flags": [],
   "annotator_confidence": 1.0,
   "iaa_reviewed": false
 }
 ```
+
+`preprocessing_applied.normalized_dbfs` is the **measured** post-preprocess peak written by `synthbanshee.augment.preprocessing.preprocess()`. Pre-#78 this always landed at −1.0 dBFS (the limiter ceiling). Post-#78 it tracks `PreprocessingConfig.target_peak_dbfs` (default −2.0 dBFS, valid range `[−12.0, −1.5]`) — see §3 step 5. The same configured target also surfaces structurally in `generation_metadata.loudness_target_peak_dbfs`; pairing the two diagnoses loudness regressions from metadata alone.
+
+`generation_metadata` is present from `generator_version: 0.1.0` onward (added in M11 with the V3 pipeline) and is `null` on pre-M11 clips. Downstream tooling that reads its fields (`loudness_target_peak_dbfs`, `effective_prosody_caps`, `breathiness_applied`, `mix_mode_used`) must treat absence as "unknown", not as a failure.
+
+#### `weak_label.has_violence` — derivation rule
+
+Authoritative source: `LabelGenerator.build_clip_metadata` in `synthbanshee/labels/generator.py`. The flag is derived from the strong-label events, not from `violence_typology` or `max_intensity`:
+
+```python
+has_violence = any(e.tier1_category != "NONE" for e in events)
+```
+
+This means `NEG` (Negative / Confusor) clips are correctly `has_violence: false` even when `max_intensity ≥ 3` — by taxonomy definition (§4.1) NEG is "acoustically intense but non-violent", so every event ends up labelled `tier1_category: NONE` and the convenience flag stays false. Downstream consumers and external documentation **must mirror this rule**; do not re-derive `has_violence` from typology alone or you will disagree with the data on every NEG row.
 
 **`quality_flags`** valid values: `low_snr` · `clipping` · `short_silence_pad` · `label_uncertainty` · `iaa_disagreement` · `synthetic_artifact`
 
@@ -316,8 +344,8 @@ One record per labeled event, stored **per-clip** as `{clip_id}.jsonl` in the sa
 
 ```json
 {
-  "event_id": "SP_IT_B_0023_00_EVT_007",
-  "clip_id": "SP_IT_B_0023_00",
+  "event_id": "sp_it_b_0023_00_EVT_007",
+  "clip_id": "sp_it_b_0023_00",
   "onset": 143.82,
   "offset": 146.05,
   "tier1_category": "PHYS",

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -619,7 +619,9 @@ def _run_generate_pipeline(
         downmixed_to_mono=True,
         spectral_filtered=True,
         denoised=True,
-        normalized_dbfs=-1.0,
+        # Reflect the actual measured peak (#78 made the target configurable,
+        # so a hardcoded −1.0 here silently lied about loudness post-#78).
+        normalized_dbfs=result.peak_dbfs,
         silence_padded=True,
     )
     quality_flags = ["emotion_downgrade"] if emotion_downgrade_turns else []

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 import soundfile as sf
 from click.testing import CliRunner
 
@@ -192,6 +193,61 @@ class TestGenerateCommand:
         # At least one WAV file was written
         wav_files = list((tmp_path / "out").rglob("*.wav"))
         assert len(wav_files) >= 1
+
+    def test_normalized_dbfs_reflects_actual_peak(self, tmp_path):
+        """`preprocessing_applied.normalized_dbfs` must echo the measured WAV peak,
+        not a stale hardcoded constant.  Pre-#100 the CLI wrote `-1.0` regardless
+        of `PreprocessingConfig.target_peak_dbfs` (default `-2.0` post-#78), so
+        every clip's JSON silently lied about its loudness."""
+        turns = _make_dialogue_turns(n=1)
+        mixed = _make_mixed_scene(n_turns=1)
+
+        runner = CliRunner()
+        with (
+            patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
+            patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
+        ):
+            MockGen.return_value.generate.return_value = turns
+            MockRenderer.return_value.render_scene.return_value = mixed
+            result = runner.invoke(
+                cli,
+                [
+                    "generate",
+                    "--config",
+                    str(SCENES_DIR / "test_scene_001.yaml"),
+                    "--output-dir",
+                    str(tmp_path / "out"),
+                    "--cache-dir",
+                    str(tmp_path / "cache"),
+                    "--dirty-dir",
+                    str(tmp_path / "dirty"),
+                    "--script-cache-dir",
+                    str(tmp_path / "scripts"),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        json_files = list((tmp_path / "out").rglob("*.json"))
+        assert len(json_files) >= 1
+        meta = json.loads(json_files[0].read_text())
+        normalized = meta["preprocessing_applied"]["normalized_dbfs"]
+        # Read the actual peak straight from the WAV
+        wav_path = next((tmp_path / "out").rglob("*.wav"))
+        data, _ = sf.read(str(wav_path))
+        actual_peak_dbfs = 20.0 * np.log10(float(np.max(np.abs(data))))
+        assert normalized == pytest.approx(actual_peak_dbfs, abs=0.05), (
+            f"normalized_dbfs={normalized} did not match measured WAV peak "
+            f"{actual_peak_dbfs:.3f} (regression of pre-#100 hardcoded -1.0)"
+        )
+        # Cross-check against the post-#78 default target (-2.0 dBFS).
+        # PreprocessingConfig clamps peak via a single global gain, so the
+        # measured peak should sit within 0.5 dB of the configured target.
+        target = -2.0
+        assert abs(normalized - target) < 0.6, (
+            f"normalized_dbfs={normalized} is more than 0.6 dB from the "
+            f"default target {target}; either target_peak_dbfs changed "
+            f"or the loudness step regressed"
+        )
 
     def test_full_generate_verbose(self, tmp_path):
         """--verbose flag exercises the vlog code path in _run_generate_pipeline."""


### PR DESCRIPTION
## Problem

Reviewed `DataHackIL/avdp-synth-corpus` (PR #2, the active 8-clip M2a wet-test) for first handoff to the consumer teams. Putting audio quality aside (already tracked in `deliveries/002-m2a-wettest/`), three pieces of schema drift between this repo's spec, the generator code, and the data on disk would force consumer teams to either special-case or guess. A regen of the corpus on top of this PR will produce clips that match `docs/spec.md` exactly — no per-team divergence.

## Findings (from the corpus review)

| Surface | Drift |
| --- | --- |
| `cli.py:622` (now `:624`) | `preprocessing_applied.normalized_dbfs` hardcoded `-1.0` regardless of `PreprocessingConfig.target_peak_dbfs` (default `-2.0` post-#78). Every freshly generated clip's JSON silently lied about its loudness. |
| `docs/spec.md` §5.1 example JSON | Showed pre-#78 `-1.0`, lacked the M11 `generation_metadata` block, lacked `speakers[].voice_family`, and used uppercase paths contradicting §2.5 ("all filenames are lowercase"). |
| `docs/spec.md` §5.1 (rule) | Never pinned the `has_violence` derivation rule, so the corpus README invented one (`typology in {SV,IT,NEG} and max_intensity >= 3`) that disagrees with the actual code (`any(e.tier1_category != "NONE" for e in events)`) on every NEG row. |
| `docs/spec.md` §2.1 / §2.4 | Directory and clip-id examples used uppercase, contradicting §2.5 and cli.py:365–367 (`scene_id.lower()`, `speaker_id.lower()`). |

## Solution summary

- **Code**: `_run_generate_pipeline` now records `result.peak_dbfs` (the measured post-preprocess peak) into `PreprocessingApplied.normalized_dbfs`. Single-line change; behaviour previously buggy.
- **Spec**: §5.1 example JSON is now self-consistent (lowercase paths, `-2.0` target, `generation_metadata` populated, `voice_family` echoed). Two short prose blocks added — one for the `normalized_dbfs` ⇄ `loudness_target_peak_dbfs` pairing, one pinning the authoritative `has_violence` rule with file/line reference. §2.1 / §2.3 / §2.4 reconciled with the lowercase filesystem rule.
- **Test**: new regression test in `tests/unit/test_cli.py` reads the on-disk WAV peak and asserts the JSON `normalized_dbfs` matches it within 0.05 dB. With the hardcoded `-1.0` this test fails by ~1 dB.

## Files changed

| File | Change |
| --- | --- |
| `synthbanshee/cli.py` | `normalized_dbfs=-1.0` → `normalized_dbfs=result.peak_dbfs` |
| `docs/spec.md` | §2.1, §2.3, §2.4, §5.1, §5.2 — drift fixes + `has_violence` rule documented |
| `tests/unit/test_cli.py` | new `test_normalized_dbfs_reflects_actual_peak` regression test |

## Test plan

- [x] `pytest tests/unit/` — **1689 passed**, 2 expected warnings, no regressions
- [x] `pytest tests/integration/` — **54 passed**, 1 skipped
- [x] `ruff check synthbanshee/ tests/ docs/` — clean
- [x] `pytest tests/unit/test_cli.py::TestGenerateCommand::test_normalized_dbfs_reflects_actual_peak` — new regression test green
- [x] Audited what does *not* need a code change: the 7/8 missing dirty files in PR #2 of the corpus are a stale-snapshot artefact (the current `preprocess()` writes a dirty file whenever `dirty_dir` is provided, and `_run_generate_pipeline` always provides one). A clean corpus regen fixes them — no code regression to gate.

### Tier-3 ASR sanity (local)

Not applicable for this PR: changes touch `cli.py` metadata wiring only (no `tts/`, `script/`, `augment/` or speaker / scene / acoustic YAML changes). Per the policy in `CLAUDE.md`, only PRs that might affect audio rendering require a local `qa-report --asr` run.

## Follow-up (not in this PR)

A second PR will land on `DataHackIL/avdp-synth-corpus` that:
1. Regenerates the 8 wet-test clips on top of this branch (fixes `dirty_file_path`, `generation_metadata`, `voice_family`, and the `manifest.csv` column count in one shot).
2. Updates the corpus `README.md` and `CLAUDE.md` to point at the spec sections this PR adds (canonical `has_violence` rule, peak target language, directory naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)