### PR TITLE
fix(cli): #101 — normalized_dbfs records the *measured* peak (helper + parametrized test)

### DIFF
--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -18,15 +18,18 @@ from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
-if TYPE_CHECKING:
-    from synthbanshee.config.project_profile import ProjectProfile
-    from synthbanshee.config.scene_config import SceneConfig
-
 import click
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from rich.table import Table
+
+from synthbanshee.labels.schema import PreprocessingApplied
+
+if TYPE_CHECKING:
+    from synthbanshee.augment.preprocessing import PreprocessingResult
+    from synthbanshee.config.project_profile import ProjectProfile
+    from synthbanshee.config.scene_config import SceneConfig
 
 console = Console()
 
@@ -191,6 +194,24 @@ def _normalize_emotion(state: str) -> tuple[str, bool]:
     )
 
 
+def _build_preprocessing_metadata(result: PreprocessingResult) -> PreprocessingApplied:
+    """Construct the ``preprocessing_applied`` block from a finished preprocess run.
+
+    ``normalized_dbfs`` is the *measured* post-preprocess peak — see
+    ``PreprocessingApplied.normalized_dbfs`` and the docstring on
+    ``GenerationMetadata.loudness_target_peak_dbfs`` (which records the
+    *target* and is deliberately the separate field for that).
+    """
+    return PreprocessingApplied(
+        resampled_to_16k=True,
+        downmixed_to_mono=True,
+        spectral_filtered=True,
+        denoised=True,
+        normalized_dbfs=result.peak_dbfs,
+        silence_padded=True,
+    )
+
+
 def _run_generate_pipeline(
     config: Path,
     output_dir: Path,
@@ -223,7 +244,7 @@ def _run_generate_pipeline(
         LabelGenerator,
         ScriptEvent,
     )
-    from synthbanshee.labels.schema import PreprocessingApplied, SpeakerInfo
+    from synthbanshee.labels.schema import SpeakerInfo
     from synthbanshee.package.validator import validate_clip
     from synthbanshee.script.generator import ScriptGenerator
     from synthbanshee.tts.renderer import TTSRenderer
@@ -614,14 +635,7 @@ def _run_generate_pipeline(
         )
         for spk in speakers.values()
     ]
-    preprocessing_meta = PreprocessingApplied(
-        resampled_to_16k=True,
-        downmixed_to_mono=True,
-        spectral_filtered=True,
-        denoised=True,
-        normalized_dbfs=preproc_config.target_peak_dbfs,
-        silence_padded=True,
-    )
+    preprocessing_meta = _build_preprocessing_metadata(result)
     quality_flags = ["emotion_downgrade"] if emotion_downgrade_turns else []
 
     # M11: Build GenerationMetadata for pipeline provenance.

--- a/synthbanshee/cli.py
+++ b/synthbanshee/cli.py
@@ -619,7 +619,7 @@ def _run_generate_pipeline(
         downmixed_to_mono=True,
         spectral_filtered=True,
         denoised=True,
-        normalized_dbfs=-1.0,
+        normalized_dbfs=preproc_config.target_peak_dbfs,
         silence_padded=True,
     )
     quality_flags = ["emotion_downgrade"] if emotion_downgrade_turns else []

--- a/tests/integration/test_happy_path.py
+++ b/tests/integration/test_happy_path.py
@@ -131,7 +131,7 @@ class TestHappyPath:
             downmixed_to_mono=True,
             spectral_filtered=True,
             denoised=True,
-            normalized_dbfs=-1.0,
+            normalized_dbfs=result.peak_dbfs,
             silence_padded=True,
         )
         metadata = self.label_gen.generate_clip_metadata(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -732,6 +732,36 @@ class TestRunGeneratePipeline:
         assert wav is None
         assert "bad sample rate" in errors
 
+    def test_normalized_dbfs_records_configured_target(self, tmp_path):
+        """`PreprocessingApplied.normalized_dbfs` echoes the live
+        `PreprocessingConfig.target_peak_dbfs`.  Pre-#101 the CLI wrote
+        `-1.0` regardless of the configured target, so the field silently
+        drifted from the actual normalization contract."""
+        from synthbanshee.config.preprocessing_config import PreprocessingConfig
+
+        turns = _make_dialogue_turns(n=1)
+        mixed = _make_mixed_scene(n_turns=1)
+
+        with (
+            patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
+            patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
+        ):
+            MockGen.return_value.generate.return_value = turns
+            MockRenderer.return_value.render_scene.return_value = mixed
+            wav, _ = _run_generate_pipeline(
+                SCENES_DIR / "test_scene_001.yaml",
+                tmp_path / "out",
+                tmp_path / "cache",
+                tmp_path / "dirty",
+                tmp_path / "scripts",
+            )
+
+        assert wav is not None
+        meta = json.loads(wav.with_suffix(".json").read_text())
+        assert meta["preprocessing_applied"]["normalized_dbfs"] == (
+            PreprocessingConfig().target_peak_dbfs
+        )
+
     def test_success_with_warnings_returns_wav_and_warnings(self, tmp_path):
         """Successful pipeline with validation warnings returns (wav_path, warnings)."""
         turns = _make_dialogue_turns(n=1)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,11 +11,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 import soundfile as sf
 from click.testing import CliRunner
 
 from synthbanshee.cli import (
     DiscoveredScene,
+    _build_preprocessing_metadata,
     _derive_event_type,
     _discover_scene_configs,
     _distribute_speakers,
@@ -731,36 +733,6 @@ class TestRunGeneratePipeline:
             )
         assert wav is None
         assert "bad sample rate" in errors
-
-    def test_normalized_dbfs_records_configured_target(self, tmp_path):
-        """`PreprocessingApplied.normalized_dbfs` echoes the live
-        `PreprocessingConfig.target_peak_dbfs`.  Pre-#101 the CLI wrote
-        `-1.0` regardless of the configured target, so the field silently
-        drifted from the actual normalization contract."""
-        from synthbanshee.config.preprocessing_config import PreprocessingConfig
-
-        turns = _make_dialogue_turns(n=1)
-        mixed = _make_mixed_scene(n_turns=1)
-
-        with (
-            patch("synthbanshee.script.generator.ScriptGenerator") as MockGen,
-            patch("synthbanshee.tts.renderer.TTSRenderer") as MockRenderer,
-        ):
-            MockGen.return_value.generate.return_value = turns
-            MockRenderer.return_value.render_scene.return_value = mixed
-            wav, _ = _run_generate_pipeline(
-                SCENES_DIR / "test_scene_001.yaml",
-                tmp_path / "out",
-                tmp_path / "cache",
-                tmp_path / "dirty",
-                tmp_path / "scripts",
-            )
-
-        assert wav is not None
-        meta = json.loads(wav.with_suffix(".json").read_text())
-        assert meta["preprocessing_applied"]["normalized_dbfs"] == (
-            PreprocessingConfig().target_peak_dbfs
-        )
 
     def test_success_with_warnings_returns_wav_and_warnings(self, tmp_path):
         """Successful pipeline with validation warnings returns (wav_path, warnings)."""
@@ -1737,6 +1709,49 @@ class TestDeriveEventType:
     def test_unknown_typology_defaults_to_ambient(self):
         t1, t2 = _derive_event_type("UNKNOWN", 3)
         assert t1 == "NONE" and t2 == "NONE_AMBIENT"
+
+
+# ---------------------------------------------------------------------------
+# _build_preprocessing_metadata — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _fake_preprocessing_result(peak_dbfs: float):
+    """Minimal PreprocessingResult for helper tests; only peak_dbfs is read."""
+    from synthbanshee.augment.preprocessing import PreprocessingResult
+
+    return PreprocessingResult(
+        output_path=Path("/tmp/unused.wav"),
+        dirty_path=None,
+        sample_rate=16000,
+        channels=1,
+        duration_seconds=4.0,
+        peak_dbfs=peak_dbfs,
+    )
+
+
+class TestBuildPreprocessingMetadata:
+    """`_build_preprocessing_metadata` must pass the *measured* peak from
+    `PreprocessingResult.peak_dbfs` into `PreprocessingApplied.normalized_dbfs`
+    — see the docstring on `GenerationMetadata.loudness_target_peak_dbfs` in
+    `synthbanshee/labels/schema.py` for why the field is measured (not target).
+    """
+
+    @pytest.mark.parametrize("peak_dbfs", [-1.0, -2.0, -2.013, -3.5, -11.97])
+    def test_passes_measured_peak_through(self, peak_dbfs):
+        """A non-default peak must flow into the JSON-bound model unchanged."""
+        meta = _build_preprocessing_metadata(_fake_preprocessing_result(peak_dbfs))
+        assert meta.normalized_dbfs == peak_dbfs
+
+    def test_preprocessing_step_flags_are_all_true(self):
+        """The block reports a fully-applied pipeline; flags must not drift to
+        False without a deliberate schema/spec change."""
+        meta = _build_preprocessing_metadata(_fake_preprocessing_result(-2.0))
+        assert meta.resampled_to_16k is True
+        assert meta.downmixed_to_mono is True
+        assert meta.spectral_filtered is True
+        assert meta.denoised is True
+        assert meta.silence_padded is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`synthbanshee/cli.py:622` hardcoded `PreprocessingApplied.normalized_dbfs = -1.0`. The existing schema docstring in `synthbanshee/labels/schema.py:175` explicitly pins the field as the **measured** post-preprocess peak, deliberately distinct from `GenerationMetadata.loudness_target_peak_dbfs` (the configured target). The hardcode meant every clip's JSON disagreed with the schema's own contract — and post-#78 (which lowered the default target to −2.0 dBFS) the lie became audible: clips actually peaked near −2.0 dBFS but reported −1.0.

## Solution

Two changes:

1. **`cli.py`**: write `normalized_dbfs=result.peak_dbfs` (the field that `PreprocessingResult` already exposes for exactly this purpose).
2. **Extract `_build_preprocessing_metadata(result)`** at module scope. Six-line helper, but it makes the wiring unit-testable in 5 ms without spinning up `ScriptGenerator`+`TTSRenderer`+full pipeline. The senior-review on the closed PR #100 specifically called out the prior 700 ms heavyweight test as a symptom of poor extractability.

Also cleaned up the `cli.py` import block (stdlib → third-party → first-party, one TYPE_CHECKING block). No functional change.

## Files changed

| File | Change |
|---|---|
| `synthbanshee/cli.py` | Helper extraction; `normalized_dbfs=result.peak_dbfs`; import re-ordering |
| `tests/unit/test_cli.py` | New `TestBuildPreprocessingMetadata` — 5-value parametrized peak pass-through + flag-truth check |
| `tests/integration/test_happy_path.py` | Mirror the same wiring (`result.peak_dbfs` for `-1.0`) |

## Downstream-reader audit

```
$ grep -rn "normalized_dbfs" --include="*.py" --include="*.md" .
synthbanshee/cli.py            ← writer (this PR)
synthbanshee/labels/schema.py  ← field + docstring (no logic)
docs/spec.md                   ← example JSON (PR #103 updates)
tests/...                      ← assertions
```

No production code branches on this value. **Behavioural change for consumers:** clips generated post-merge will report the actual measured peak (≈ −2.0 dBFS ± preprocessing slop) instead of the constant `−1.0`. Existing on-disk clips are unchanged until regenerated.

## Test plan

- [x] `pytest tests/unit/` — **1694 passed** (5 new parametrized helper tests + 1 step-flags check)
- [x] `pytest tests/integration/` — **54 passed**, 1 skipped
- [x] `ruff check synthbanshee/ tests/` — clean
- [x] `ruff format --check synthbanshee/cli.py` — formatted

### Tier-3 ASR sanity (local)

Not applicable: CLI metadata wiring only; no `tts/`, `script/`, `augment/`, or speaker / scene / acoustic YAML changes.

## v1 → v2 corrections (from self-review)

v1 of this PR wrote `preproc_config.target_peak_dbfs`. That was wrong — the schema docstring on `labels/schema.py:175` already documents `normalized_dbfs` as the **measured** value (kept separate from `loudness_target_peak_dbfs`, which is the target). v1 also shipped a weak test that would have passed against `−2.0` re-hardcoded, and inlined `PreprocessingConfig()` import inside the test function. All addressed in v2:

| v1 issue | v2 fix |
|---|---|
| Wrote target instead of measured peak | `result.peak_dbfs` (matches schema docstring intent) |
| Test would pass for hardcoded `-2.0` literal | Parametrized over 5 non-default values; helper is the unit under test |
| Heavyweight CLI-runner test for one field | Focused 5 ms helper test; no scene YAML coupling |
| Inline `from … import PreprocessingConfig` in test | Helper test imports only `PreprocessingResult`, at module top |
| Implicit `preproc_config` non-None invariant across try/except | Helper takes typed `PreprocessingResult` only — no cross-scope variable |

Refs #101 (1/2). Pairs with #103 (`docs(spec)`); after both merge, `cli.py`, the schema docstring, and `docs/spec.md` all agree that `normalized_dbfs` is the measured peak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)