### PR TITLE
docs(spec): #101 — corpus-handoff schema drift (casing table, has_violence rule, measured-peak note)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -46,6 +46,8 @@ assets/                     ← source assets (TTS outputs, SFX, IR files)
   noise/
 ```
 
+Path components are lowercase per §2.5; the `{speaker_id}` directory is `speaker_id.lower()` of the first speaker listed in the scene config — see §2.3.
+
 ### 2.2 Language Codes
 
 | Code | Language | Notes |
@@ -67,16 +69,18 @@ Examples:
 
 Role codes: `AGG` (aggressor) · `VIC` (victim) · `BYS` (bystander) · `NEU` (neutral/non-violent speaker)
 
+`speaker_id` values are uppercase wherever they appear — YAML configs, JSON / JSONL / TXT outputs, the manifest's `speaker_ids` column, runtime identifiers. The on-disk **directory name** under `data/{language}/` is the lowercase form of `scene.speakers[0].speaker_id` (the first listed speaker — for SV/IT scenes typically the aggressor; for NEU/NEG scenes whatever the YAML puts first). Concretely: a scene whose first listed speaker is `AGG_M_30-45_001` writes to `data/he/agg_m_30-45_001/`, but every metadata *value* still reads `AGG_M_30-45_001`. Code: `synthbanshee/cli.py` `_run_generate_pipeline` (`first_speaker_ref.speaker_id.lower()`).
+
 ### 2.4 Clip ID Format
 
 ```
 {project_code}_{violence_type_code}_{tier}_{scene_id:04d}_{segment:02d}
 ```
 
-Examples:
-- `SP_IT_B_0023_00` — She-Proves, Intimate Terrorism, Tier B, scene 23, full scene
-- `EL_SV_A_0105_03` — Elephant in the Room, Situational Violence, Tier A, scene 105, segment 3
-- `SP_NEG_C_0412_00` — She-Proves, Negative/Confusor, Tier C, scene 412
+Examples (on-disk form — lowercased by the CLI per §2.5; the same id appears uppercase as `scene_id:` in YAML scene configs):
+- `sp_it_b_0023_00` — She-Proves, Intimate Terrorism, Tier B, scene 23, full scene
+- `el_sv_a_0105_03` — Elephant in the Room, Situational Violence, Tier A, scene 105, segment 3
+- `sp_neg_c_0412_00` — She-Proves, Negative/Confusor, Tier C, scene 412
 
 Project codes: `SP` (She-Proves) · `EL` (Elephant in the Room)
 
@@ -247,7 +251,7 @@ Every clip has a companion `{clip_id}.json` file with this schema:
 
 ```json
 {
-  "clip_id": "SP_IT_B_0023_00",
+  "clip_id": "sp_it_b_0023_00",
   "project": "she_proves",
   "language": "he",
   "violence_typology": "IT",
@@ -256,10 +260,10 @@ Every clip has a companion `{clip_id}.json` file with this schema:
   "sample_rate": 16000,
   "channels": 1,
   "snr_db_estimated": 19.4,
-  "scene_config": "configs/scenes/SP_IT_B_0023.yaml",
+  "scene_config": "configs/scenes/she_proves/sp_it_b_0023.yaml",
   "random_seed": 42,
   "generation_date": "2026-04-10",
-  "generator_version": "avdp-synth-0.1.0",
+  "generator_version": "0.1.0",
   "is_synthetic": true,
   "tts_engine": "azure_he_IL",
   "acoustic_scene": {
@@ -276,14 +280,16 @@ Every clip has a companion `{clip_id}.json` file with this schema:
       "role": "AGG",
       "gender": "male",
       "age_range": "30-45",
-      "tts_voice_id": "he-IL-AvriNeural"
+      "tts_voice_id": "he-IL-AvriNeural",
+      "voice_family": "he-IL-AvriNeural"
     },
     {
       "speaker_id": "VIC_F_25-40_002",
       "role": "VIC",
       "gender": "female",
       "age_range": "25-40",
-      "tts_voice_id": "he-IL-HilaNeural"
+      "tts_voice_id": "he-IL-HilaNeural",
+      "voice_family": "he-IL-HilaNeural"
     }
   ],
   "weak_label": {
@@ -297,16 +303,42 @@ Every clip has a companion `{clip_id}.json` file with this schema:
     "downmixed_to_mono": true,
     "spectral_filtered": true,
     "denoised": true,
-    "normalized_dbfs": -1.0,
+    "normalized_dbfs": -2.0,
     "silence_padded": true
   },
-  "dirty_file_path": "assets/speech/he/AGG_M_30-45_001/SP_IT_B_0023_00_dirty.wav",
-  "transcript_path": "data/he/AGG_M_30-45_001/SP_IT_B_0023_00.txt",
+  "generation_metadata": {
+    "pipeline_version": "0.1.0",
+    "tts_backend": {"AGG_M_30-45_001": "azure", "VIC_F_25-40_002": "azure"},
+    "voice_family": {"AGG_M_30-45_001": "he-IL-AvriNeural", "VIC_F_25-40_002": "he-IL-HilaNeural"},
+    "mix_mode_used": "sequential",
+    "normalization_strategy": "per_turn_rms_v2_target_peak",
+    "loudness_target_peak_dbfs": -2.0,
+    "breathiness_applied": false,
+    "effective_prosody_caps": []
+  },
+  "dirty_file_path": "assets/speech/dirty/sp_it_b_0023_00_dirty.wav",
+  "transcript_path": "data/he/agg_m_30-45_001/sp_it_b_0023_00.txt",
   "quality_flags": [],
   "annotator_confidence": 1.0,
   "iaa_reviewed": false
 }
 ```
+
+**Field notes**
+
+- `preprocessing_applied.normalized_dbfs` is the configured target of step 5a (§3.1), i.e. `PreprocessingConfig.target_peak_dbfs` — same value also surfaces structurally in `generation_metadata.loudness_target_peak_dbfs`. Default `-2.0`, valid range `[-12.0, -1.5]`.
+- `generation_metadata` was wired in M11 (CLI build step). Clips produced before that commit have it as `null`; `generator_version` alone is not a reliable presence signal (the version was bumped before the field was wired). Treat absence as "unknown", not failure.
+- `speakers[].voice_family` defaults to `tts_voice_id` when the speaker YAML omits it; consumers should read whichever is non-empty.
+
+#### `weak_label.has_violence` — derivation rule
+
+Authoritative source: `LabelGenerator.build_clip_metadata` in `synthbanshee/labels/generator.py`:
+
+```python
+has_violence = any(e.tier1_category != "NONE" for e in events)
+```
+
+`NEG` (Negative / Confusor) clips are correctly `has_violence: false` even when `max_intensity ≥ 3` — by §4.1 NEG is "acoustically intense but non-violent", so every event ends up `tier1_category: "NONE"`. **External docs and downstream code must mirror this rule** — re-deriving from typology or intensity alone produces disagreement on every NEG row.
 
 **`quality_flags`** valid values: `low_snr` · `clipping` · `short_silence_pad` · `label_uncertainty` · `iaa_disagreement` · `synthetic_artifact`
 
@@ -316,8 +348,8 @@ One record per labeled event, stored **per-clip** as `{clip_id}.jsonl` in the sa
 
 ```json
 {
-  "event_id": "SP_IT_B_0023_00_EVT_007",
-  "clip_id": "SP_IT_B_0023_00",
+  "event_id": "sp_it_b_0023_00_EVT_007",
+  "clip_id": "sp_it_b_0023_00",
   "onset": 143.82,
   "offset": 146.05,
   "tier1_category": "PHYS",
@@ -540,7 +572,7 @@ The confusor set is **critical** for both projects. A model that cannot distingu
 Each `.txt` transcript file follows this format (UTF-8):
 
 ```
-[CLIP_ID: SP_IT_B_0023_00]
+[CLIP_ID: sp_it_b_0023_00]
 [SPEAKER: AGG_M_30-45_001 | ROLE: AGG | ONSET: 0.0 | OFFSET: 4.2]
 אמרתי לך לא ללכת לשם!
 [ACTION: VERB_SHOUT | INTENSITY: 4]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -46,7 +46,7 @@ assets/                     ← source assets (TTS outputs, SFX, IR files)
   noise/
 ```
 
-Path components are lowercase per §2.5; the `{speaker_id}` directory is `speaker_id.lower()` of the first speaker listed in the scene config — see §2.3.
+The `{speaker_id}` path component is derived (not literal); see §2.5 for the per-surface casing rules.
 
 ### 2.2 Language Codes
 
@@ -69,7 +69,7 @@ Examples:
 
 Role codes: `AGG` (aggressor) · `VIC` (victim) · `BYS` (bystander) · `NEU` (neutral/non-violent speaker)
 
-`speaker_id` values are uppercase wherever they appear — YAML configs, JSON / JSONL / TXT outputs, the manifest's `speaker_ids` column, runtime identifiers. The on-disk **directory name** under `data/{language}/` is the lowercase form of `scene.speakers[0].speaker_id` (the first listed speaker — for SV/IT scenes typically the aggressor; for NEU/NEG scenes whatever the YAML puts first). Concretely: a scene whose first listed speaker is `AGG_M_30-45_001` writes to `data/he/agg_m_30-45_001/`, but every metadata *value* still reads `AGG_M_30-45_001`. Code: `synthbanshee/cli.py` `_run_generate_pipeline` (`first_speaker_ref.speaker_id.lower()`).
+`speaker_id` is uppercase as a value (configs, JSON, manifest, runtime). The matching directory name is `speaker_id.lower()` — see the casing table in §2.5.
 
 ### 2.4 Clip ID Format
 
@@ -77,10 +77,11 @@ Role codes: `AGG` (aggressor) · `VIC` (victim) · `BYS` (bystander) · `NEU` (n
 {project_code}_{violence_type_code}_{tier}_{scene_id:04d}_{segment:02d}
 ```
 
-Examples (on-disk form — lowercased by the CLI per §2.5; the same id appears uppercase as `scene_id:` in YAML scene configs):
-- `sp_it_b_0023_00` — She-Proves, Intimate Terrorism, Tier B, scene 23, full scene
+`clip_id` is derived at write time from the scene's uppercase `scene_id` YAML field via `scene_id.lower()` (hyphens → underscores) plus the `_NN` segment suffix; it does **not** appear verbatim in any YAML. Examples (on-disk form):
+
+- `sp_it_b_0023_00` — She-Proves, Intimate Terrorism, Tier B, scene 23, segment 0
 - `el_sv_a_0105_03` — Elephant in the Room, Situational Violence, Tier A, scene 105, segment 3
-- `sp_neg_c_0412_00` — She-Proves, Negative/Confusor, Tier C, scene 412
+- `sp_neg_c_0412_00` — She-Proves, Negative / Confusor, Tier C, scene 412
 
 Project codes: `SP` (She-Proves) · `EL` (Elephant in the Room)
 
@@ -88,8 +89,26 @@ Project codes: `SP` (She-Proves) · `EL` (Elephant in the Room)
 
 - ASCII characters only. No spaces, no UTF-8 characters above U+00A1.
 - Maximum filename length: 128 characters.
-- All filenames are lowercase.
-- Every `.wav` file **must** have a corresponding `.txt` and `.json` file with the identical stem in the same directory.
+- All filenames (and filesystem path components) are lowercase.
+- Every `.wav` file **must** have a corresponding `.txt`, `.json`, and `.jsonl` file with the identical stem in the same directory.
+
+#### Identifier casing (per surface)
+
+The same logical id appears in multiple places with different casing rules. This is the contract:
+
+| Surface                                              | Case            | Example                                  |
+|------------------------------------------------------|-----------------|------------------------------------------|
+| YAML `scene_id` / `speaker_id` / `speakers[].speaker_id` | UPPERCASE       | `SP_IT_B_0023`, `AGG_M_30-45_001`        |
+| On-disk filename stem (`clip_id`)                    | lowercase       | `sp_it_b_0023_00`                        |
+| On-disk speaker directory (`{speaker_id}/`)          | lowercase       | `agg_m_30-45_001/`                       |
+| JSON `clip_id`                                       | lowercase       | `sp_it_b_0023_00`                        |
+| JSON `speakers[].speaker_id`                         | UPPERCASE       | `AGG_M_30-45_001`                        |
+| TXT `[CLIP_ID: …]`                                   | lowercase       | `sp_it_b_0023_00`                        |
+| TXT `[SPEAKER: …]`                                   | UPPERCASE       | `AGG_M_30-45_001`                        |
+| JSONL `event_id` / `clip_id`                         | mixed (see §5.2) | `sp_it_b_0023_00_EVT_007`               |
+| Manifest `speaker_ids` column (pipe-separated)       | UPPERCASE       | `AGG_M_30-45_001\|VIC_F_25-40_002`        |
+
+Consumers reconstructing paths from metadata must apply `.lower()` to `speakers[0].speaker_id` (or read `wav_path` from the manifest, which is already correct).
 
 ---
 
@@ -281,15 +300,14 @@ Every clip has a companion `{clip_id}.json` file with this schema:
       "gender": "male",
       "age_range": "30-45",
       "tts_voice_id": "he-IL-AvriNeural",
-      "voice_family": "he-IL-AvriNeural"
+      "voice_family": "Avri"
     },
     {
       "speaker_id": "VIC_F_25-40_002",
       "role": "VIC",
       "gender": "female",
       "age_range": "25-40",
-      "tts_voice_id": "he-IL-HilaNeural",
-      "voice_family": "he-IL-HilaNeural"
+      "tts_voice_id": "he-IL-HilaNeural"
     }
   ],
   "weak_label": {
@@ -303,13 +321,13 @@ Every clip has a companion `{clip_id}.json` file with this schema:
     "downmixed_to_mono": true,
     "spectral_filtered": true,
     "denoised": true,
-    "normalized_dbfs": -2.0,
+    "normalized_dbfs": -2.013,
     "silence_padded": true
   },
   "generation_metadata": {
     "pipeline_version": "0.1.0",
     "tts_backend": {"AGG_M_30-45_001": "azure", "VIC_F_25-40_002": "azure"},
-    "voice_family": {"AGG_M_30-45_001": "he-IL-AvriNeural", "VIC_F_25-40_002": "he-IL-HilaNeural"},
+    "voice_family": {"AGG_M_30-45_001": "Avri", "VIC_F_25-40_002": "he-IL-HilaNeural"},
     "mix_mode_used": "sequential",
     "normalization_strategy": "per_turn_rms_v2_target_peak",
     "loudness_target_peak_dbfs": -2.0,
@@ -326,19 +344,10 @@ Every clip has a companion `{clip_id}.json` file with this schema:
 
 **Field notes**
 
-- `preprocessing_applied.normalized_dbfs` is the configured target of step 5a (§3.1), i.e. `PreprocessingConfig.target_peak_dbfs` — same value also surfaces structurally in `generation_metadata.loudness_target_peak_dbfs`. Default `-2.0`, valid range `[-12.0, -1.5]`.
-- `generation_metadata` was wired in M11 (CLI build step). Clips produced before that commit have it as `null`; `generator_version` alone is not a reliable presence signal (the version was bumped before the field was wired). Treat absence as "unknown", not failure.
-- `speakers[].voice_family` defaults to `tts_voice_id` when the speaker YAML omits it; consumers should read whichever is non-empty.
-
-#### `weak_label.has_violence` — derivation rule
-
-Authoritative source: `LabelGenerator.build_clip_metadata` in `synthbanshee/labels/generator.py`:
-
-```python
-has_violence = any(e.tier1_category != "NONE" for e in events)
-```
-
-`NEG` (Negative / Confusor) clips are correctly `has_violence: false` even when `max_intensity ≥ 3` — by §4.1 NEG is "acoustically intense but non-violent", so every event ends up `tier1_category: "NONE"`. **External docs and downstream code must mirror this rule** — re-deriving from typology or intensity alone produces disagreement on every NEG row.
+- `preprocessing_applied.normalized_dbfs` is the **measured** post-preprocess peak (pair with `generation_metadata.loudness_target_peak_dbfs` to compute drift from target — see `labels/schema.py` for the docstring that pins this split).
+- `generation_metadata` is **optional**: a JSON object when the generator recorded pipeline provenance, `null` otherwise. Treat absence as "unknown", not as failure. `generator_version` alone is not a reliable presence signal.
+- `speakers[].voice_family` is **optional**: a stable family handle (e.g. `"Avri"`) when the speaker YAML overrides it, omitted otherwise. Consumers should fall back to `tts_voice_id`.
+- `weak_label.has_violence` is **derived**, not asserted: `any(e.tier1_category != "NONE" for e in events)` — see `synthbanshee/labels/generator.py`. Corollaries: empty `events` → `False`; `NEG` typology clips are `False` (every event lands `tier1_category: "NONE"` by §4.1); `violence_typology` and `has_violence` may disagree (e.g. `SV` with `False` if no violent tier1 fired). The events are the ground truth; the flag is convenience. **External docs and downstream code must mirror this rule** — re-deriving from typology or intensity alone produces disagreement on every NEG row.
 
 **`quality_flags`** valid values: `low_snr` · `clipping` · `short_silence_pad` · `label_uncertainty` · `iaa_disagreement` · `synthetic_artifact`
 
@@ -364,6 +373,8 @@ One record per labeled event, stored **per-clip** as `{clip_id}.jsonl` in the sa
   "notes": "punch impact followed by object fall"
 }
 ```
+
+`event_id` is generated as `{clip_id}_EVT_{idx:03d}` — the `clip_id` prefix is lowercase per §2.5 and `EVT` is a literal uppercase token (it is not a casing inconsistency). `speaker_id` and `speaker_role` are values, not filenames, so they remain uppercase per §2.5's casing table.
 
 **`label_source`** values: `auto` (derived from scene config/script) · `human` (manual annotation) · `auto_reviewed` (auto + human validation pass)
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -279,7 +279,7 @@ Every clip has a companion `{clip_id}.json` file with this schema:
   "sample_rate": 16000,
   "channels": 1,
   "snr_db_estimated": 19.4,
-  "scene_config": "configs/scenes/she_proves/sp_it_b_0023.yaml",
+  "scene_config": "configs/scenes/she_proves_tier_b/sp_it_b_0023.yaml",
   "random_seed": 42,
   "generation_date": "2026-04-10",
   "generator_version": "0.1.0",


### PR DESCRIPTION
## Problem

Surfaced in a pre-handoff review of `DataHackIL/avdp-synth-corpus` PR #2 (8-clip M2a wet test):

1. **Uppercase paths in spec examples** contradict §2.5 ("all filenames are lowercase") and the on-disk reality from `cli.py:365–367` (`scene_id.lower()`, `speaker_id.lower()`). Consumer teams reconstructing paths from `speakers[].speaker_id` (canonical uppercase) hit directories that don't exist.
2. **§5.1 example JSON lacks `generation_metadata` and `speakers[].voice_family`** — both part of the current `ClipMetadata` schema; consumers reading the spec didn't know to expect them.
3. **`weak_label.has_violence` derivation rule was never pinned in the spec.** The corpus README invented `typology in {SV,IT,NEG} and max_intensity >= 3`, which disagrees with the actual code (`any(e.tier1_category != "NONE" for e in events)` in `synthbanshee/labels/generator.py`) on every NEG row.
4. **`preprocessing_applied.normalized_dbfs` was documented inconsistently** — the §5.1 example showed `-1.0` (the pre-#78 hardcode); the schema docstring at `labels/schema.py:175` already pins the field as the **measured** peak (distinct from `generation_metadata.loudness_target_peak_dbfs`, the target). The spec example didn't reflect this contract.

## Solution

| Section | Change |
|---|---|
| §2.1 | Single-line footnote pointing at §2.5 (no inline rule restatement) |
| §2.3 | Single sentence: `speaker_id` is uppercase; directory is its lowercase form — see §2.5 |
| §2.4 | Clarify that `clip_id` is *derived* from `scene_id` (lowercase + `_NN` suffix); does **not** appear verbatim in any YAML |
| §2.5 | New "Identifier casing (per surface)" **table** — one row per surface, single source of truth |
| §5.1 example | `normalized_dbfs: -2.013` (realistic measured); `voice_family` shows BOTH cases — distinct value `"Avri"` for AGG, omitted for VIC to demonstrate the optional fallback |
| §5.1 notes | Four dense bullets — `normalized_dbfs` as **measured**; `generation_metadata` as **optional**; `voice_family` as **optional**; `has_violence` as **derived** with explicit boundary cases (empty events, typology/flag disagreement) |
| §5.2 | One sentence on `event_id` format — literal `EVT` token with lowercase `clip_id` prefix is intentional |

## Files changed

- `docs/spec.md` (only) — 36 insertions, 25 deletions

## Test plan

- [x] `pytest tests/unit/` — **1688 passed**
- [x] `ruff check synthbanshee/ tests/ docs/` — clean
- [x] Cross-checked spec example JSON against an actual corpus clip JSON (`sp_it_a_0001_00.json`) for shape parity

## Merge order with #102

`labels/schema.py:175` is the existing source of truth: `normalized_dbfs` is the **measured** peak. Both this PR and #102 converge on that contract — #102 fixes the CLI to write the measured value; this PR documents the same. **Either order is safe.** If this PR merges first, the spec already matches the schema docstring (which was always right) — only the CLI lags briefly. If #102 merges first, the example in this PR is what newly generated clips will look like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)