### PR TITLE
feat(scenes): add sp_sv_a_0003 + sp_it_a_0003 — Google-pair shadows for delivery-003

### DIFF
--- a/configs/scenes/she_proves/sp_it_a_0003.yaml
+++ b/configs/scenes/she_proves/sp_it_a_0003.yaml
@@ -1,0 +1,28 @@
+scene_id: SP_IT_A_0003
+project: she_proves
+language: he
+violence_typology: IT
+tier: A
+random_seed: 1103
+# Sister scene to sp_it_a_0001: same template, slots, and intensity arc;
+# swapped to the Google Chirp HD speaker pair so the toy corpus carries
+# voice + backend diversity (closes the qa-report low_voice_diversity_*
+# and single_backend warnings from delivery 002).
+speakers:
+  - speaker_id: AGG_M_30-45_002
+    role: AGG
+  - speaker_id: VIC_F_25-40_003
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/intimate_terror_coercive_control.j2
+script_slots:
+  relationship: spouse
+  setting: small_bedroom
+  grievance: coming_home_late
+intensity_arc: [1, 2, 3, 4, 5, 4, 3]
+she_proves:
+  incident_window_start_fraction: 0.35
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation, peak]
+  post_incident_phases: [aftermath, de-escalation]
+target_duration_minutes: 4.0
+min_pre_incident_seconds: 80

--- a/configs/scenes/she_proves/sp_sv_a_0003.yaml
+++ b/configs/scenes/she_proves/sp_sv_a_0003.yaml
@@ -1,0 +1,28 @@
+scene_id: SP_SV_A_0003
+project: she_proves
+language: he
+violence_typology: SV
+tier: A
+random_seed: 1203
+# Sister scene to sp_sv_a_0001: same template, slots, and intensity arc;
+# swapped to the Google Chirp HD speaker pair so the toy corpus carries
+# voice + backend diversity (closes the qa-report low_voice_diversity_*
+# and single_backend warnings from delivery 002).
+speakers:
+  - speaker_id: AGG_M_30-45_002
+    role: AGG
+  - speaker_id: VIC_F_25-40_003
+    role: VIC
+script_template: synthbanshee/script/templates/she_proves/physical_assault_escalation.j2
+script_slots:
+  relationship: spouse
+  setting: living_room
+  grievance: money_dispute
+intensity_arc: [2, 3, 4, 5, 4, 2]
+she_proves:
+  incident_window_start_fraction: 0.30
+  pre_incident_phases: [baseline, tension]
+  incident_phases: [escalation, peak]
+  post_incident_phases: [aftermath]
+target_duration_minutes: 3.5
+min_pre_incident_seconds: 60


### PR DESCRIPTION
## Summary

Adds two new she_proves Tier A scene configs:

- `configs/scenes/she_proves/sp_sv_a_0003.yaml`
- `configs/scenes/she_proves/sp_it_a_0003.yaml`

Each is a **sister scene** to the corresponding `sp_*_a_0001` — same script template, same slots, same intensity arc, same duration target. The only deliberate variable: the `speakers:` block points to the **Google Chirp HD pair** (`AGG_M_30-45_002` + `VIC_F_25-40_003`), so the upcoming delivery-003 toy corpus carries voice + TTS-backend diversity without authoring new scripts.

## Motivation

The corpus delivery-002 wet test fired three run-level qa-report warnings: `low_voice_diversity_male`, `low_voice_diversity_female`, `single_backend`. All four personas in that delivery (`AGG_001`, `VIC_002`, `BEN_003`, `SW_001`) map to only two Azure voices (`he-IL-AvriNeural`, `he-IL-HilaNeural`). These two new scenes provide a controlled axis for closing those findings in delivery-003.

## Files changed

| File | Change |
|---|---|
| `configs/scenes/she_proves/sp_sv_a_0003.yaml` | NEW — sister to `sp_sv_a_0001` with Google speakers |
| `configs/scenes/she_proves/sp_it_a_0003.yaml` | NEW — sister to `sp_it_a_0001` with Google speakers |

## Test plan

- [x] `SceneConfig.from_yaml(...)` parses both files cleanly:
  ```
  SP_SV_A_0003: tier=A, typology=SV, speakers=[AGG_M_30-45_002, VIC_F_25-40_003], duration=3.5m
  SP_IT_A_0003: tier=A, typology=IT, speakers=[AGG_M_30-45_002, VIC_F_25-40_003], duration=4.0m
  ```
- [x] Random seeds (`1203`, `1103`) follow the established `1{typology_digit}{NN}` scheme, no collision with existing scenes.
- [ ] No code touched, no template touched — CI just sanity-checking the YAMLs parse and pre-commit passes.

### Tier-3 ASR sanity (local)

Not applicable: scene config YAMLs only; no code change to `tts/`, `script/`, `augment/`, or speaker configs.

Refs the upcoming `avdp-synth-corpus` delivery-003 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)