### PR TITLE
fix(tts): #72 — phrase prosody volume must be %, not dB (root cause)

### DIFF
--- a/synthbanshee/tts/ssml_types.py
+++ b/synthbanshee/tts/ssml_types.py
@@ -65,8 +65,14 @@ class PhraseProsody:
         char_end: Exclusive end offset.
         rate: SSML rate value (e.g. ``"+15%"``, ``"slow"``).
             ``None`` means no rate change.
-        pitch: SSML pitch value (e.g. ``"+2st"``). ``None`` means no change.
-        volume: SSML volume value (e.g. ``"+3dB"``). ``None`` means no change.
+        pitch: SSML pitch value (e.g. ``"+2st"`` or ``"+6%"``). ``None``
+            means no change. Mixing ``st`` (inner) with ``%`` (outer) is
+            tolerated by Azure.
+        volume: SSML volume value (e.g. ``"+3%"``). ``None`` means no
+            change. **Must be expressed in ``%``** to match the outer
+            ``<prosody volume="...">`` emitted by ``_volume_to_string``;
+            nesting ``volume="+NdB"`` inside ``volume="+N%"`` triggers
+            Azure SSML parser error 0x80045003 (#72).
         break_before_ms: Milliseconds of silence inserted before the span.
         break_after_ms: Milliseconds of silence inserted after the span.
     """
@@ -86,8 +92,10 @@ class PhraseProsody:
 # ---------------------------------------------------------------------------
 
 _HINT_DEFAULTS: dict[str, dict[str, str | int]] = {
-    # Stressed accusatory phrase — faster, louder, higher pitch
-    "stress": {"rate": "+15%", "volume": "+3dB", "pitch": "+1st", "break_before_ms": 0},
+    # Stressed accusatory phrase — faster, louder, higher pitch.
+    # `volume` must be in `%` (#72): Azure SSML rejects `volume="+NdB"`
+    # nested inside the outer `volume="+N%"` emitted by `_volume_to_string`.
+    "stress": {"rate": "+15%", "volume": "+3%", "pitch": "+1st", "break_before_ms": 0},
     # Deliberate command slowing — measured menace
     "slow": {"rate": "-20%", "break_before_ms": 150},
     # Pause before the phrase for dramatic weight

--- a/tests/unit/test_phrase_prosody.py
+++ b/tests/unit/test_phrase_prosody.py
@@ -15,6 +15,7 @@ import xml.etree.ElementTree as ET
 
 from synthbanshee.tts.ssml_builder import SSMLBuilder, UtteranceSpec, _apply_phrase_prosody
 from synthbanshee.tts.ssml_types import (
+    _HINT_DEFAULTS,
     PhraseHint,
     PhraseProsody,
     _build_offset_map,
@@ -106,7 +107,10 @@ class TestResolvePhraseHints:
         )
         result = resolve_phrase_hints([hint], text, text)
         assert result[0].rate == "+15%"
-        assert result[0].volume == "+3dB"
+        # `volume` must be in `%` (#72): Azure SSML rejects `volume="+NdB"`
+        # nested inside the outer `volume="+N%"` emitted by `_volume_to_string`.
+        # Don't reintroduce `+3dB` here without also changing the outer emitter.
+        assert result[0].volume == "+3%"
         assert result[0].pitch == "+1st"
 
     def test_hint_defaults_applied_menace(self) -> None:
@@ -188,6 +192,44 @@ class TestResolvePhraseHints:
         # After clamping start=0, end=5 → valid 5-char span.
         assert len(result) == 1
         assert result[0].char_start == 0
+
+
+# ---------------------------------------------------------------------------
+# Hint defaults — Azure SSML unit invariant
+# ---------------------------------------------------------------------------
+
+
+class TestHintDefaultUnits:
+    """Azure rejects SSML when an inner `<prosody volume="+NdB">` is nested
+    inside an outer `<prosody volume="+N%">` (#72: `0x80045003 / Connection
+    was closed by the remote host`).  Since `_volume_to_string` always emits
+    the outer prosody volume in `%`, every nested phrase prosody value must
+    also be in `%`.  Reintroducing `dB` here re-breaks the corpus generation
+    for any scene that emits a `stress` hint (most violent / agitated scenes)."""
+
+    def test_no_hint_default_uses_db_for_volume(self) -> None:
+        for hint_name, defaults in _HINT_DEFAULTS.items():
+            volume = defaults.get("volume")
+            if volume is None:
+                continue
+            assert isinstance(volume, str)
+            assert not volume.endswith("dB"), (
+                f"Hint {hint_name!r} default volume {volume!r} uses dB; "
+                "must be % to match the outer prosody emitter and avoid #72 "
+                "(Azure SSML parse error 0x80045003)"
+            )
+
+    def test_hint_default_volumes_parse_as_percent(self) -> None:
+        for hint_name, defaults in _HINT_DEFAULTS.items():
+            volume = defaults.get("volume")
+            if volume is None:
+                continue
+            assert isinstance(volume, str)
+            assert volume.endswith("%"), (
+                f"Hint {hint_name!r} default volume {volume!r} must end in '%'"
+            )
+            n = volume.rstrip("%").lstrip("+")
+            int(n.lstrip("-"))  # numeric (no exception => fine)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Reliable root cause for the long-standing intermittent #72: `Azure SSML parsing error 0x80045003 / Connection was closed by the remote host`.

Reproduced during the delivery-003 corpus regen (`avdp-synth-corpus`, on top of recent PRs #102/#103/#105): 6 of 8 elephant Tier B scenes fail every time on the first uncached turn. Bisected with 9 hand-crafted A/B SSML round-trips against live Azure.

## What triggers it

When the M2b phrase-prosody system fires a `stress` hint, the renderer produces nested `<prosody>` with the inner volume in `dB` and the outer in `%`:

```xml
<prosody rate="+9%" pitch="+7%" volume="+5%">     <!-- outer: _volume_to_string emits % -->
  text...
  <prosody rate="+15%" pitch="+1st" volume="+3dB">stress span</prosody>  <!-- _HINT_DEFAULTS["stress"] -->
  text...
</prosody>
```

Azure rejects volume unit mismatch (`dB` inner under `%` outer). Pitch unit mismatch (`st` under `%`) is tolerated. Mid-word `<break />` is tolerated. Both confirmed against live Azure.

## Fix

`_HINT_DEFAULTS["stress"]["volume"]: "+3dB"` → `"+3%"`. Matches the lossy 1:1 dB→% mapping that `_volume_to_string` already uses for the outer prosody. No SSML-builder code changes — just the hint default + docstring update.

## A/B isolation results (live Azure)

| Test | Outer | Inner | Result |
|---|---|---|---|
| Original (the bug) | `vol="+5%"` | `vol="+3dB"`, mid-word | **FAIL** |
| No nested prosody | `vol="+5%"` | — | OK |
| Mid-word `<break />` (no nested prosody) | `vol="+5%"` | break only | OK |
| Word-aligned nest, mixed units | `vol="+5%"` | `vol="+3dB"` | **FAIL** |
| Word-aligned nest, all-% units | `vol="+5%"` | `vol="+3%"` | OK |
| Word-aligned nest, `pitch="+1st"`, no inner volume | `vol="+5%"` | `pitch="+1st"` | OK |
| Word-aligned nest, `pitch="+6%"`, `volume="+3dB"` | `vol="+5%"` | `vol="+3dB"` | **FAIL** |
| Word-aligned nest, `pitch="+1st"`, `volume="+3%"` | `vol="+5%"` | `vol="+3%"` | OK |

Volume `dB` inside volume `%` is the trigger; nothing else.

## Files changed

| File | Change |
|---|---|
| `synthbanshee/tts/ssml_types.py` | `_HINT_DEFAULTS["stress"]["volume"]: "+3dB"` → `"+3%"`; `PhraseProsody.volume` docstring updated to pin the `%`-only constraint and reference #72 |
| `tests/unit/test_phrase_prosody.py` | `test_hint_defaults_applied_stress` updated to assert `"+3%"`; new class `TestHintDefaultUnits` — two structural tests pinning the "no `dB` for volume" / "must end in `%`" invariant across `_HINT_DEFAULTS` |

## Test plan

- [x] `pytest tests/unit/` — **1696 passed** (1694 prior + 2 new structural tests)
- [x] `ruff check synthbanshee/ tests/` — clean
- [x] Live Azure: TEST H (nested word-aligned, all-% units) returns 307,630 audio bytes; TEST A (original failing SSML) reproduces #72 100% of the time.

### Tier-3 ASR sanity (local)

This change *will* alter audio output for any scene that emits a `stress` phrase hint — the inner prosody volume drops from a real +3 dB (~+41% linear) to the lossy synthbanshee convention of +3% (matching how the outer prosody has always been emitted). Per `CLAUDE.md`'s ASR sanity policy, this is in-scope; will run `qa-report --asr` on the delivery-003 corpus once those scenes regenerate and paste the result into the upcoming corpus PR.

## Unblocks

`avdp-synth-corpus` delivery-003 (in-flight) — the 6 elephant Tier B scenes that hit this can now regenerate cleanly.

Refs #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)